### PR TITLE
Update facet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a219b97d2f75648ed5470f9efaed7fac98b0f5218d701e305444578cfbb33d3b"
+checksum = "0be4cf803e7c34ab73217e3c05b6c382b8a70a5948a9282ed9d64f62c2a03a90"
 dependencies = [
  "facet-core",
  "facet-macros",
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8f4f44d3904eb16187e3c0d93c1f6eed2d5f5e5532fb3cbf60a0849fdae726"
+checksum = "bc0dfc311334e2fad887baaebdc3773c05bbbddc286bef7c9c87cfb3fb4235fb"
 dependencies = [
  "bitflags",
  "impls",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41934d083cf0dab2dc480d9c69240448478f06455c69a738833dbe8ef244efbe"
+checksum = "c10707410fd2c4f6b779fa04eac1a25d2907322dfb31039f16829c7996236768"
 dependencies = [
  "facet-core",
  "facet-macros-emit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d134f3ac4926124eaf521a1031d11ea98816df3d39fc446fcfd6b36884603f"
+checksum = "749b8449e4daf7359bdf1dabdba6ce424ff8b1bdc23bdb795661b2e991a08d87"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f26c17270c2ac1bd555c4304fe067639f0ddafdd3c8d07a200b2bb5a326e03"
+checksum = "0ea08bc854235d4dff08fd57df8033285c11b8d7548b20c6da218194e7e6035f"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -1067,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-emit"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e390d85bbdd57eb8ef7f7b10254feaf9727f77cf4312722cd8f030a8c182491e"
+checksum = "c496a4d3bd731444d278cf1178302d854c46dd04661e79a67d926b63d60a4cbb"
 dependencies = [
  "facet-macros-parse",
  "quote",
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-parse"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76290ce9f9701d81b4c2d4b819a64caea9334056d2fb5c5f8c88b24afd9b6dc1"
+checksum = "e5e81c2f638023b13c3ab6e73b29be6fec44bdced5e418839c215a4b81afc6e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2018,9 +2018,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "revm"
-version = "27.0.1"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff49cb058b1100aba529a048655594d89f6b86cefd1b50b63facd2465b6a0e"
+checksum = "24188978ab59b8fd508d0193f8a08848bdcd19ae0f73f2ad1d6ee3b2cd6c0903"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2037,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a7d034cdf74c5f952ffc26e9667dd4285c86379ce1b1190b5d597c398a7565"
+checksum = "7a685758a4f375ae9392b571014b9779cfa63f0d8eb91afb4626ddd958b23615"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199000545a2516f3fef7241e33df677275f930f56203ec4a586f7815e7fb5598"
+checksum = "2c949e6b9d996ae5c7606cd4f82d997dabad30909f85601b5876b704d95b505b"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -2066,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47db30cb6579fddb974462ea385d297ea57d0d13750fc1086d65166c4fb281eb"
+checksum = "a303a93102fceccec628265efd550ce49f2817b38ac3a492c53f7d524f18a1ca"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2082,9 +2082,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe1906ae0f5f83153a6d46da8791405eb30385b9deb4845c27b4a6802e342e8"
+checksum = "7db360729b61cc347f9c2f12adb9b5e14413aea58778cf9a3b7676c6a4afa115"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -2096,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faffdc496bad90183f31a144ed122caefa4e74ffb02f57137dc8a94d20611550"
+checksum = "b8500194cad0b9b1f0567d72370795fd1a5e0de9ec719b1607fa1566a23f039a"
 dependencies = [
  "auto_impl",
  "either",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844ecdeb61f8067a7ccb61e32c69d303fe9081b5f1e21e09a337c883f4dda1ad"
+checksum = "35b3a613d012189571b28fb13befc8c8af54e54f4f76997a0c02828cea0584a3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee95fd546963e456ab9b615adc3564f64a801a49d9ebcdc31ff63ce3a601069c"
+checksum = "64aee1f5f5b07cfa73250f530edf4c8c3bb8da693d5d00fe9f94f70499978f00"
 dependencies = [
  "auto_impl",
  "either",
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "23.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1776f996bb79805b361badd8b6326ac04a8580764aebf72b145620a6e21cf1c3"
+checksum = "8d2a89c40b7c72220f3d4b753ca0ce9ae912cf5dad7d3517182e4e1473b9b55e"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "7.0.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7bc9492e94ad3280c4540879d28d3fdbfbc432ebff60f17711740ebb4309ff"
+checksum = "106fec5c634420118c7d07a6c37110186ae7f23025ceac3a5dbe182eea548363"
 dependencies = [
  "bitflags",
  "revm-bytecode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.87"
 [dependencies]
 anyhow = "1.0.98"
 erased-discriminant = "1"
-facet = "=0.27.15"
+facet = "0.27.16"
 heck = "0.5.0"
 include_dir = { version = "0.7.4", optional = true }
 once_cell = "1.21.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.87"
 [dependencies]
 anyhow = "1.0.98"
 erased-discriminant = "1"
-facet = "0.27.15"
+facet = "=0.27.15"
 heck = "0.5.0"
 include_dir = { version = "0.7.4", optional = true }
 once_cell = "1.21.3"
@@ -30,7 +30,7 @@ bincode = "=1"
 hex = "0.4.3"
 maplit = "1.0.2"
 regex = "1.11.1"
-revm = "27.0.1"
+revm = "27.0.2"
 tempfile = "3.20.0"
 which = "8.0.0"
 

--- a/src/generation/common.rs
+++ b/src/generation/common.rs
@@ -5,12 +5,11 @@ use crate::reflection::format::Format;
 
 pub(crate) fn mangle_type(format: &Format) -> String {
     use Format::{
-        Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, QualifiedTypeName, Seq,
-        Str, Tuple, TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
+        Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, Seq, Str, Tuple,
+        TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
     };
     match format {
-        TypeName(x) => x.to_string(),
-        QualifiedTypeName(qualified_name) => qualified_name.to_legacy_string(),
+        TypeName(qualified_name) => qualified_name.to_legacy_string(),
         Unit => "unit".into(),
         Bool => "bool".into(),
         I8 => "i8".into(),

--- a/src/generation/java.rs
+++ b/src/generation/java.rs
@@ -199,12 +199,11 @@ where
 
     fn quote_type(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, QualifiedTypeName,
-            Seq, Str, Tuple, TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, Seq, Str, Tuple,
+            TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
         };
         match format {
-            TypeName(x) => self.quote_qualified_name(x),
-            QualifiedTypeName(qualified_name) => {
+            TypeName(qualified_name) => {
                 self.quote_qualified_name(&qualified_name.to_legacy_string())
             }
             Unit => "com.novi.serde.Unit".into(),
@@ -311,11 +310,11 @@ where
 
     fn quote_serialize_value(&self, value: &str, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         match format {
-            TypeName(_) | QualifiedTypeName(_) => format!("{value}.serialize(serializer);"),
+            TypeName(_) => format!("{value}.serialize(serializer);"),
             Unit => format!("serializer.serialize_unit({value});"),
             Bool => format!("serializer.serialize_bool({value});"),
             I8 => format!("serializer.serialize_i8({value});"),
@@ -344,15 +343,11 @@ where
 
     fn quote_deserialize(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         match format {
-            TypeName(name) => format!(
-                "{}.deserialize(deserializer)",
-                self.quote_qualified_name(name)
-            ),
-            QualifiedTypeName(qualified_name) => {
+            TypeName(qualified_name) => {
                 format!(
                     "{}.deserialize(deserializer)",
                     self.quote_qualified_name(&qualified_name.to_legacy_string())

--- a/src/generation/swift.rs
+++ b/src/generation/swift.rs
@@ -159,12 +159,11 @@ where
 
     fn quote_type(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, QualifiedTypeName,
-            Seq, Str, Tuple, TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, Seq, Str, Tuple,
+            TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
         };
         match format {
-            TypeName(x) => self.quote_qualified_name(x),
-            QualifiedTypeName(qualified_name) => qualified_name.to_legacy_string(),
+            TypeName(qualified_name) => qualified_name.to_legacy_string(),
             Unit => "Unit".into(),
             Bool => "Bool".into(),
             I8 => "Int8".into(),
@@ -250,11 +249,11 @@ where
     #[allow(clippy::unused_self)]
     fn quote_serialize_value(&self, value: &str, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         match format {
-            TypeName(_) | QualifiedTypeName(_) => {
+            TypeName(_) => {
                 format!("try {value}.serialize(serializer: serializer)")
             }
             Unit => format!("try serializer.serialize_unit(value: {value})"),
@@ -284,15 +283,11 @@ where
 
     fn quote_deserialize(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         match format {
             TypeName(name) => format!(
-                "try {}.deserialize(deserializer: deserializer)",
-                self.quote_qualified_name(name)
-            ),
-            QualifiedTypeName(name) => format!(
                 "try {}.deserialize(deserializer: deserializer)",
                 self.quote_qualified_name(&name.to_legacy_string())
             ),

--- a/src/generation/tests/test_utils.rs
+++ b/src/generation/tests/test_utils.rs
@@ -643,7 +643,7 @@ fn test_get_simple_registry() {
               - I64
               - U64
         - c:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Choice
     ");
@@ -673,10 +673,10 @@ fn test_get_registry() {
         1:
           Node:
             TUPLE:
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: SerdeData
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: List
     NewTypeStruct:
@@ -687,13 +687,13 @@ fn test_get_registry() {
         - f_bytes: BYTES
         - f_option:
             OPTION:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Struct
         - f_unit: UNIT
         - f_seq:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Struct
         - f_opt_seq:
@@ -714,7 +714,7 @@ fn test_get_registry() {
         - f_nested_seq:
             SEQ:
               SEQ:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: Struct
     PrimitiveTypes:
@@ -741,13 +741,13 @@ fn test_get_registry() {
         0:
           PrimitiveTypes:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: PrimitiveTypes
         1:
           OtherTypes:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: OtherTypes
         2:
@@ -764,31 +764,31 @@ fn test_get_registry() {
           StructVariant:
             STRUCT:
               - f0:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: UnitStruct
               - f1:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: NewTypeStruct
               - f2:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: TupleStruct
               - f3:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: Struct
         6:
           ListWithMutualRecursion:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: List
         7:
           TreeWithMutualRecursion:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Tree
         8:
@@ -804,13 +804,13 @@ fn test_get_registry() {
         10:
           SimpleList:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: SimpleList
         11:
           CStyleEnum:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: CStyleEnum
         12:
@@ -831,7 +831,7 @@ fn test_get_registry() {
     SimpleList:
       NEWTYPESTRUCT:
         OPTION:
-          QUALIFIEDTYPENAME:
+          TYPENAME:
             namespace: ROOT
             name: SimpleList
     Struct:
@@ -841,12 +841,12 @@ fn test_get_registry() {
     Tree:
       STRUCT:
         - value:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: SerdeData
         - children:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Tree
     TupleStruct:

--- a/src/generation/typescript.rs
+++ b/src/generation/typescript.rs
@@ -131,12 +131,11 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
 
     fn quote_type(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, QualifiedTypeName,
-            Seq, Str, Tuple, TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Map, Option, Seq, Str, Tuple,
+            TupleArray, TypeName, U8, U16, U32, U64, U128, Unit, Variable,
         };
         match format {
-            TypeName(x) => self.quote_qualified_name(x),
-            QualifiedTypeName(qualified_name) => {
+            TypeName(qualified_name) => {
                 self.quote_qualified_name(&qualified_name.to_legacy_string())
             }
             Unit => "unit".into(),
@@ -214,13 +213,13 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
     #[allow(clippy::unused_self)]
     fn quote_serialize_value(&self, value: &str, format: &Format, use_this: bool) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         let this_str = if use_this { "this." } else { "" };
 
         match format {
-            TypeName(_) | QualifiedTypeName(_) => {
+            TypeName(_) => {
                 format!("{this_str}{value}.serialize(serializer);")
             }
             Unit => format!("serializer.serializeUnit({this_str}{value});"),
@@ -251,15 +250,11 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
 
     fn quote_deserialize(&self, format: &Format) -> String {
         use Format::{
-            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, QualifiedTypeName, Str, TypeName,
-            U8, U16, U32, U64, U128, Unit,
+            Bool, Bytes, Char, F32, F64, I8, I16, I32, I64, I128, Str, TypeName, U8, U16, U32, U64,
+            U128, Unit,
         };
         match format {
             TypeName(name) => format!(
-                "{}.deserialize(deserializer)",
-                self.quote_qualified_name(name)
-            ),
-            QualifiedTypeName(name) => format!(
                 "{}.deserialize(deserializer)",
                 self.quote_qualified_name(&name.to_legacy_string())
             ),

--- a/src/reflection/format/mod.rs
+++ b/src/reflection/format/mod.rs
@@ -46,6 +46,12 @@ pub struct QualifiedTypeName {
     pub name: String,
 }
 
+impl From<&str> for QualifiedTypeName {
+    fn from(value: &str) -> Self {
+        Self::from_legacy_string(value)
+    }
+}
+
 impl QualifiedTypeName {
     /// Create a new qualified type name in the root namespace.
     #[must_use]
@@ -91,10 +97,9 @@ impl QualifiedTypeName {
 pub enum Format {
     /// A format whose value is initially unknown. Used internally for tracing. Not (de)serializable.
     Variable(#[serde(with = "not_implemented")] Variable<Format>),
+
     /// The name of a container.
-    TypeName(String),
-    /// A qualified type name with namespace information.
-    QualifiedTypeName(QualifiedTypeName),
+    TypeName(QualifiedTypeName),
 
     // The formats of primitive types
     Unit,
@@ -570,7 +575,6 @@ impl FormatHolder for Format {
         match self {
             Self::Variable(variable) => variable.visit(f)?,
             Self::TypeName(_)
-            | Self::QualifiedTypeName(_)
             | Self::Unit
             | Self::Bool
             | Self::I8
@@ -622,7 +626,6 @@ impl FormatHolder for Format {
                     .expect("variable is known");
             }
             Self::TypeName(_)
-            | Self::QualifiedTypeName(_)
             | Self::Unit
             | Self::Bool
             | Self::I8
@@ -712,8 +715,6 @@ impl FormatHolder for Format {
             | (Self::Bytes, Self::Bytes) => (),
 
             (Self::TypeName(name1), Self::TypeName(name2)) if *name1 == name2 => (),
-            (Self::QualifiedTypeName(name1), Self::QualifiedTypeName(name2)) if *name1 == name2 => {
-            }
 
             (Self::Option(format1), Self::Option(format2))
             | (Self::Seq(format1), Self::Seq(format2)) => {

--- a/src/reflection/format/tests.rs
+++ b/src/reflection/format/tests.rs
@@ -32,7 +32,7 @@ fn test_format_visiting() {
         .visit(&mut |f| {
             if let TypeName(x) = f {
                 // Insert a &str borrowed from `format`.
-                names.insert(x.as_str());
+                names.insert(x.to_legacy_string());
             }
             Ok(())
         })

--- a/src/reflection/namespace/mod.rs
+++ b/src/reflection/namespace/mod.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 use crate::{
     generation::CodeGeneratorConfig,
-    reflection::{ContainerFormat, Format, FormatHolder, Registry},
+    reflection::{ContainerFormat, Format, FormatHolder, Registry, format},
 };
 
 #[derive(Debug, Clone, Serialize)]
@@ -77,33 +77,13 @@ pub fn split(root: &str, registry: Registry) -> BTreeMap<Namespace, Registry> {
 fn make_namespace(format: &mut ContainerFormat, namespace: &str) -> super::Result<Namespace> {
     let mut external_definitions: BTreeMap<String, Vec<String>> = BTreeMap::new();
     format.visit_mut(&mut |format| {
-        match format {
-            Format::TypeName(name) => {
-                if let Some((namespace, name)) = name.split_once('.') {
-                    external_definitions
-                        .entry(namespace.to_string())
-                        .or_default()
-                        .push(name.to_string());
-                    *format = Format::TypeName(name.to_string());
-                }
+        if let Format::TypeName(qualified_name) = format {
+            if let format::Namespace::Named(ns) = &qualified_name.namespace {
+                external_definitions
+                    .entry(ns.to_string())
+                    .or_default()
+                    .push(qualified_name.name.clone());
             }
-            Format::QualifiedTypeName(qualified_name) => {
-                match &qualified_name.namespace {
-                    crate::reflection::format::Namespace::Named(ns) => {
-                        external_definitions
-                            .entry(ns.to_string())
-                            .or_default()
-                            .push(qualified_name.name.clone());
-                        // Convert to simple TypeName for this namespace
-                        *format = Format::TypeName(qualified_name.name.clone());
-                    }
-                    crate::reflection::format::Namespace::Root => {
-                        // Already in root namespace, just convert to TypeName
-                        *format = Format::TypeName(qualified_name.name.clone());
-                    }
-                }
-            }
-            _ => {}
         }
         Ok(())
     })?;

--- a/src/reflection/namespace/tests.rs
+++ b/src/reflection/namespace/tests.rs
@@ -41,7 +41,9 @@ fn single_namespace() {
     : ChildOne:
         STRUCT:
           - child:
-              TYPENAME: GrandChild
+              TYPENAME:
+                namespace: ROOT
+                name: GrandChild
       ChildTwo:
         STRUCT:
           - field: STR
@@ -51,9 +53,13 @@ fn single_namespace() {
       Parent:
         STRUCT:
           - one:
-              TYPENAME: ChildOne
+              TYPENAME:
+                namespace: ROOT
+                name: ChildOne
           - two:
-              TYPENAME: ChildTwo
+              TYPENAME:
+                namespace: ROOT
+                name: ChildTwo
     ");
 }
 
@@ -101,9 +107,15 @@ fn root_namespace_with_two_child_namespaces() {
     : Parent:
         STRUCT:
           - one:
-              TYPENAME: ChildOne
+              TYPENAME:
+                namespace:
+                  NAMED: one
+                name: ChildOne
           - two:
-              TYPENAME: ChildTwo
+              TYPENAME:
+                namespace:
+                  NAMED: two
+                name: ChildTwo
     ? module_name: one
       serialization: true
       encodings: []
@@ -117,7 +129,10 @@ fn root_namespace_with_two_child_namespaces() {
     : ChildOne:
         STRUCT:
           - child:
-              TYPENAME: GrandChild
+              TYPENAME:
+                namespace:
+                  NAMED: one
+                name: GrandChild
       GrandChild:
         STRUCT:
           - field: STR

--- a/src/reflection/namespace_tests.rs
+++ b/src/reflection/namespace_tests.rs
@@ -38,19 +38,19 @@ fn nested_namespaced_structs() {
     Parent:
       STRUCT:
         - one:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: one
               name: Child
         - two:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: two
               name: Child
     one.Child:
       STRUCT:
         - child:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: GrandChild
     two.Child:
@@ -106,14 +106,14 @@ fn nested_namespaced_enums() {
         0:
           One:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: one
                 name: Child
         1:
           Two:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: two
                 name: Child
@@ -122,7 +122,7 @@ fn nested_namespaced_enums() {
         0:
           Data:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: GrandChild
     two.Child:
@@ -172,19 +172,19 @@ fn nested_namespaced_renamed_structs() {
     Parent:
       STRUCT:
         - one:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: one
               name: Kid
         - two:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: two
               name: Kid
     one.Kid:
       STRUCT:
         - child:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: GrandKid
     two.Kid:
@@ -222,27 +222,27 @@ fn namespaced_collections() {
       STRUCT:
         - users:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
         - user_arrays:
             TUPLEARRAY:
               CONTENT:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace:
                     NAMED: api
                   name: User
               SIZE: 5
         - optional_user:
             OPTION:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
         - groups:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: api
                 name: Group
@@ -250,7 +250,7 @@ fn namespaced_collections() {
       STRUCT:
         - users:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
@@ -289,12 +289,12 @@ fn namespaced_maps() {
         - user_profiles:
             MAP:
               KEY:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace:
                     NAMED: models
                   name: UserId
               VALUE:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace:
                     NAMED: models
                   name: UserProfile
@@ -351,7 +351,7 @@ fn complex_namespaced_enums() {
       STRUCT:
         - events:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: events
                 name: Event
@@ -360,7 +360,7 @@ fn complex_namespaced_enums() {
         0:
           UserCreated:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: events
                 name: UserData
@@ -368,19 +368,19 @@ fn complex_namespaced_enums() {
           UserUpdated:
             STRUCT:
               - old:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace:
                       NAMED: events
                     name: UserData
               - new:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace:
                       NAMED: events
                     name: UserData
         2:
           SystemEvent:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: events
                 name: SystemData
@@ -420,12 +420,12 @@ fn namespaced_transparent_structs() {
     Container:
       STRUCT:
         - direct_id:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: wrappers
               name: UserId
         - wrapped_id:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: wrappers
               name: UserId
@@ -467,14 +467,14 @@ fn cross_namespace_references() {
       STRUCT:
         - records:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: storage
                 name: Record
     api.Request:
       STRUCT:
         - entity:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: entities
               name: Entity
@@ -485,12 +485,12 @@ fn cross_namespace_references() {
     storage.Record:
       STRUCT:
         - entity:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: entities
               name: Entity
         - request:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: api
               name: Request
@@ -521,7 +521,7 @@ fn namespace_with_byte_attributes() {
     Document:
       STRUCT:
         - binary:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: data
               name: BinaryData
@@ -562,19 +562,19 @@ fn deeply_nested_namespaces() {
     RootStruct:
       STRUCT:
         - middle:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: level1
               name: MiddleStruct
         - deep_direct:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: level1.level2
               name: DeepStruct
     level1.MiddleStruct:
       STRUCT:
         - deep:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: level1.level2
               name: DeepStruct
@@ -607,7 +607,7 @@ fn transparent_struct_explicit_namespace() {
     Container:
       STRUCT:
         - wrapped_id:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: UserId
     UserId:
@@ -686,35 +686,35 @@ fn explicit_namespace_declarations() {
     ApiContainer:
       STRUCT:
         - user:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: api
               name: User
         - group:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: api
               name: Group
     RootContainer:
       STRUCT:
         - api_data:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: ApiContainer
         - event:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: events
               name: Event
         - efficient:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: RootGroup
     RootGroup:
       STRUCT:
         - users:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: RootUser
     RootUser:
@@ -725,7 +725,7 @@ fn explicit_namespace_declarations() {
       STRUCT:
         - users:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
@@ -738,14 +738,14 @@ fn explicit_namespace_declarations() {
         0:
           UserCreated:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: events
                 name: UserData
         1:
           SystemEvent:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace:
                   NAMED: events
                 name: SystemData
@@ -795,32 +795,32 @@ fn collections_with_explicit_namespace() {
       STRUCT:
         - users:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: UnnamedUser
         - admins:
             TUPLEARRAY:
               CONTENT:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: UnnamedUser
               SIZE: 2
         - optional_user:
             OPTION:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: UnnamedUser
         - role_map:
             MAP:
               KEY: STR
               VALUE:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: UnnamedRole
         - nested_lists:
             SEQ:
               SEQ:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: UnnamedUser
     ");
@@ -872,7 +872,7 @@ fn enums_with_explicit_namespace() {
       STRUCT:
         - progress: F32
         - estimate:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: ErrorData
     SuccessData:
@@ -883,33 +883,33 @@ fn enums_with_explicit_namespace() {
         0:
           Success:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: SuccessData
         1:
           Error:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: ErrorData
         2:
           Processing:
             STRUCT:
               - data:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: ProcessingData
               - extra:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: SuccessData
         3:
           Multipart:
             TUPLE:
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: ErrorData
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: SuccessData
         4:
@@ -954,36 +954,36 @@ fn nested_structs_with_explicit_namespace() {
     MiddleLayer:
       STRUCT:
         - inner:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: DeepInner
         - inner_list:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: DeepInner
     TopLayer:
       STRUCT:
         - middle:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: MiddleLayer
         - direct_inner:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: DeepInner
     nested.Container:
       STRUCT:
         - top:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: TopLayer
         - middle_direct:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: MiddleLayer
         - inner_direct:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: DeepInner
     ");
@@ -1020,13 +1020,13 @@ fn transparent_struct_chains() {
     IdContainer:
       STRUCT:
         - id:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: identity
               name: NamespacedWrapper
     identity.NamespacedWrapper:
       NEWTYPESTRUCT:
-        QUALIFIEDTYPENAME:
+        TYPENAME:
           namespace: ROOT
           name: DoubleWrapperId
     ");
@@ -1060,36 +1060,36 @@ fn mixed_containers_with_explicit_namespace() {
     storage.MixedContainer:
       STRUCT:
         - single:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Item
         - vector:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Item
         - array:
             TUPLEARRAY:
               CONTENT:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: Item
               SIZE: 3
         - option:
             OPTION:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Item
         - tuple:
             TUPLE:
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: Item
               - STR
         - nested_option:
             OPTION:
               SEQ:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: Item
         - complex_map:
@@ -1098,7 +1098,7 @@ fn mixed_containers_with_explicit_namespace() {
               VALUE:
                 SEQ:
                   OPTION:
-                    QUALIFIEDTYPENAME:
+                    TYPENAME:
                       namespace: ROOT
                       name: Item
     ");
@@ -1136,17 +1136,17 @@ fn no_namespace_pollution() {
     RootContainer:
       STRUCT:
         - alpha:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: alpha
               name: AlphaContainer
         - beta:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: beta
               name: BetaContainer
         - unnamespaced:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: SharedType
     SharedType:
@@ -1155,13 +1155,13 @@ fn no_namespace_pollution() {
     alpha.AlphaContainer:
       STRUCT:
         - shared:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: SharedType
     beta.BetaContainer:
       STRUCT:
         - shared:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: SharedType
     ");
@@ -1202,29 +1202,29 @@ fn explicit_namespace_behavior_summary() {
     Root:
       STRUCT:
         - first:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: first
               name: FirstContainer
         - second:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace:
                 NAMED: second
               name: SecondContainer
         - direct:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: BaseType
     first.FirstContainer:
       STRUCT:
         - item:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: BaseType
     second.SecondContainer:
       STRUCT:
         - item:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: BaseType
     ");

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -205,7 +205,7 @@ fn nested_newtype() {
       NEWTYPESTRUCT: I32
     MyNewType:
       NEWTYPESTRUCT:
-        QUALIFIEDTYPENAME:
+        TYPENAME:
           namespace: ROOT
           name: Inner
     ");
@@ -239,7 +239,7 @@ fn newtype_with_list_of_named_type() {
     MyNewType:
       NEWTYPESTRUCT:
         SEQ:
-          QUALIFIEDTYPENAME:
+          TYPENAME:
             namespace: ROOT
             name: Inner
     ");
@@ -275,7 +275,7 @@ fn newtype_with_nested_list_of_named_type() {
       NEWTYPESTRUCT:
         SEQ:
           SEQ:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Inner
     ");
@@ -298,7 +298,7 @@ fn newtype_with_triple_nested_list_of_named_type() {
         SEQ:
           SEQ:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Inner
     ");
@@ -419,7 +419,7 @@ fn option_of_list_of_named_type() {
         - a:
             OPTION:
               SEQ:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: Inner
     ");
@@ -461,7 +461,7 @@ fn list_of_options_of_named_type() {
         - a:
             SEQ:
               OPTION:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: Inner
     ");
@@ -499,7 +499,7 @@ fn nested_tuple_struct_1() {
       NEWTYPESTRUCT: I32
     MyTupleStruct:
       TUPLESTRUCT:
-        - QUALIFIEDTYPENAME:
+        - TYPENAME:
             namespace: ROOT
             name: Inner
         - U8
@@ -524,7 +524,7 @@ fn nested_tuple_struct_2() {
     MyTupleStruct:
       TUPLESTRUCT:
         - I32
-        - QUALIFIEDTYPENAME:
+        - TYPENAME:
             namespace: ROOT
             name: Inner
         - U8
@@ -628,7 +628,7 @@ fn struct_with_option_fields() {
       STRUCT:
         - a:
             OPTION:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Inner
         - b:
@@ -661,11 +661,11 @@ fn struct_with_fields_of_newtypes_and_tuple_structs() {
     MyStruct:
       STRUCT:
         - a:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Inner1
         - b:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Inner2
     ");
@@ -757,7 +757,7 @@ fn enum_with_newtype_variants_containing_user_defined_types() {
         0:
           Variant1:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Inner
         1:
@@ -820,7 +820,7 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
         0:
           Variant1:
             TUPLE:
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: Inner
               - U8
@@ -828,7 +828,7 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
           Variant2:
             TUPLE:
               - I8
-              - QUALIFIEDTYPENAME:
+              - TYPENAME:
                   namespace: ROOT
                   name: Inner
     ");
@@ -859,7 +859,7 @@ fn enum_with_inline_struct_variants() {
           Variant1:
             STRUCT:
               - a:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: Inner
               - b: U8
@@ -867,7 +867,7 @@ fn enum_with_inline_struct_variants() {
         1:
           Variant2:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: Inner
     ");
@@ -907,7 +907,7 @@ fn enum_with_struct_variants_mixed_types() {
           Variant1:
             STRUCT:
               - a:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: Inner
               - b: U8
@@ -921,7 +921,7 @@ fn enum_with_struct_variants_mixed_types() {
             STRUCT:
               - x: I32
               - y:
-                  QUALIFIEDTYPENAME:
+                  TYPENAME:
                     namespace: ROOT
                     name: Inner
     ");
@@ -1043,11 +1043,11 @@ fn map_with_user_defined_types() {
         - user_map:
             MAP:
               KEY:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: UserId
               VALUE:
-                QUALIFIEDTYPENAME:
+                TYPENAME:
                   namespace: ROOT
                   name: UserProfile
         - id_to_count:
@@ -1117,7 +1117,7 @@ fn struct_with_box_of_t() {
     MyStruct:
       STRUCT:
         - boxed:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: UserProfile
     UserProfile:
@@ -1145,7 +1145,7 @@ fn struct_with_arc_of_t() {
     MyStruct:
       STRUCT:
         - boxed:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: UserProfile
     UserProfile:
@@ -1217,7 +1217,7 @@ fn own_result_enum() {
         - status: U16
         - headers:
             SEQ:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: HttpHeader
         - body: BYTES
@@ -1226,13 +1226,13 @@ fn own_result_enum() {
         0:
           Ok:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: HttpResponse
         1:
           Err:
             NEWTYPE:
-              QUALIFIEDTYPENAME:
+              TYPENAME:
                 namespace: ROOT
                 name: HttpError
     ");
@@ -1301,7 +1301,7 @@ fn struct_rename_with_named_type() {
       STRUCT:
         - id: U32
         - effect:
-            QUALIFIEDTYPENAME:
+            TYPENAME:
               namespace: ROOT
               name: Effect
     ");
@@ -1318,7 +1318,7 @@ fn self_referencing_type() {
     {
         "SimpleList": NewTypeStruct(
             Option(
-                QualifiedTypeName(
+                TypeName(
                     QualifiedTypeName {
                         namespace: Root,
                         name: "SimpleList",
@@ -1353,7 +1353,7 @@ fn complex_self_referencing_type() {
                     name: "children",
                     value: Option(
                         Seq(
-                            QualifiedTypeName(
+                            TypeName(
                                 QualifiedTypeName {
                                     namespace: Root,
                                     name: "Node",
@@ -1392,7 +1392,7 @@ fn tree_struct_with_mutual_recursion() {
                 0: Named {
                     name: "TreeWithMutualRecursion",
                     value: NewType(
-                        QualifiedTypeName(
+                        TypeName(
                             QualifiedTypeName {
                                 namespace: Root,
                                 name: "Tree",
@@ -1406,7 +1406,7 @@ fn tree_struct_with_mutual_recursion() {
             [
                 Named {
                     name: "value",
-                    value: QualifiedTypeName(
+                    value: TypeName(
                         QualifiedTypeName {
                             namespace: Root,
                             name: "Test",
@@ -1416,7 +1416,7 @@ fn tree_struct_with_mutual_recursion() {
                 Named {
                     name: "children",
                     value: Seq(
-                        QualifiedTypeName(
+                        TypeName(
                             QualifiedTypeName {
                                 namespace: Root,
                                 name: "Tree",
@@ -1452,7 +1452,7 @@ fn tree_enum_with_mutual_recursion() {
             [
                 Named {
                     name: "tree_with_mutual_recursion",
-                    value: QualifiedTypeName(
+                    value: TypeName(
                         QualifiedTypeName {
                             namespace: Root,
                             name: "Tree",
@@ -1466,7 +1466,7 @@ fn tree_enum_with_mutual_recursion() {
                 0: Named {
                     name: "Value",
                     value: NewType(
-                        QualifiedTypeName(
+                        TypeName(
                             QualifiedTypeName {
                                 namespace: Root,
                                 name: "Test",

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -532,6 +532,22 @@ fn nested_tuple_struct_2() {
 }
 
 #[test]
+fn struct_with_vec_of_u8() {
+    #[derive(Facet)]
+    struct MyStruct {
+        a: Vec<u8>,
+    }
+
+    let registry = reflect::<MyStruct>();
+    insta::assert_yaml_snapshot!(registry, @r"
+    MyStruct:
+      STRUCT:
+        - a:
+            SEQ: U8
+    ");
+}
+
+#[test]
 fn struct_with_vec_of_u8_to_bytes() {
     #[derive(Facet)]
     struct MyStruct {
@@ -544,6 +560,22 @@ fn struct_with_vec_of_u8_to_bytes() {
     MyStruct:
       STRUCT:
         - a: BYTES
+    ");
+}
+
+#[test]
+fn struct_with_slice_of_u8() {
+    #[derive(Facet)]
+    struct MyStruct<'a> {
+        a: &'a [u8],
+    }
+
+    let registry = reflect::<MyStruct>();
+    insta::assert_yaml_snapshot!(registry, @r"
+    MyStruct:
+      STRUCT:
+        - a:
+            SEQ: U8
     ");
 }
 


### PR DESCRIPTION
Two updates:

1. Removes `Format::TypeName`, and renames `Format:QualifiedTypeName` to `Format::TypeName`
2. Updates to Facet v0.27.16, which renames `SmartPointer` to `Pointer` and changes the way slices are handled. Updated the code and tests to match