### PR TITLE
feat: registry key is a QualifiedTypeName

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Reflect types annotated with [`#[Facet]`](https://crates.io/crates/facet) into J
 
 ### Notes:
 1. Currently, struct and enum renaming is not fully implemented and probably requires an upstream PR to facet.
-2. Vendors [`serde-reflect`](https://crates.io/crates/serde-reflect) and [`serde-generate`](https://crates.io/crates/serde-generate), which we are evolving to support additional features and more idiomatic foreign type generation with additional extension points.
-3. One way to generate code is to install `serde-generate-bin` (`cargo install serde-generate-bin`), and run that on the yaml generated (e.g. `serdegen --language swift --with-runtimes serde bincode --module-name Test test.yaml`).
 
 ### Usage
 
@@ -55,8 +53,9 @@ enum HttpError {
 
 let registry = reflect::<HttpResult>();
 insta::assert_yaml_snapshot!(registry, @r"
-HttpError:
-  ENUM:
+? namespace: ROOT
+  name: HttpError
+: ENUM:
     0:
       Url:
         NEWTYPE: STR
@@ -65,12 +64,14 @@ HttpError:
         NEWTYPE: STR
     2:
       Timeout: UNIT
-HttpHeader:
-  STRUCT:
+? namespace: ROOT
+  name: HttpHeader
+: STRUCT:
     - name: STR
     - value: STR
-HttpResponse:
-  STRUCT:
+? namespace: ROOT
+  name: HttpResponse
+: STRUCT:
     - status: U16
     - headers:
         SEQ:
@@ -78,8 +79,9 @@ HttpResponse:
             namespace: ROOT
             name: HttpHeader
     - body: BYTES
-HttpResult:
-  ENUM:
+? namespace: ROOT
+  name: HttpResult
+: ENUM:
     0:
       Ok:
         NEWTYPE:

--- a/src/generation/java.rs
+++ b/src/generation/java.rs
@@ -89,7 +89,7 @@ impl<'a> CodeGenerator<'a> {
         std::fs::create_dir_all(&dir_path)?;
 
         for (name, format) in registry {
-            self.write_container_class(&dir_path, current_namespace.clone(), name, format)?;
+            self.write_container_class(&dir_path, current_namespace.clone(), &name.name, format)?;
         }
         if self.config.serialization {
             self.write_helper_class(&dir_path, current_namespace, registry)?;

--- a/src/generation/swift.rs
+++ b/src/generation/swift.rs
@@ -96,7 +96,7 @@ impl<'a> CodeGenerator<'a> {
         emitter.output_preamble()?;
 
         for (name, format) in registry {
-            emitter.output_container(name, format)?;
+            emitter.output_container(&name.name, format)?;
         }
 
         if self.config.serialization {
@@ -939,6 +939,7 @@ impl super::SourceInstaller for Installer {
         config: &CodeGeneratorConfig,
         registry: &Registry,
     ) -> std::result::Result<(), Self::Error> {
+        println!("registry {registry:?}");
         let module_name = config.module_name().to_upper_camel_case();
         let targets = self.targets.entry(module_name.clone()).or_default();
         targets.insert("Serde".to_string());

--- a/src/generation/tests/test_utils.rs
+++ b/src/generation/tests/test_utils.rs
@@ -623,8 +623,9 @@ fn test_get_sample_values() {
 fn test_get_simple_registry() {
     let registry = get_simple_registry();
     insta::assert_yaml_snapshot!(&registry, @r"
-    Choice:
-      ENUM:
+    ? namespace: ROOT
+      name: Choice
+    : ENUM:
         0:
           A: UNIT
         1:
@@ -634,8 +635,9 @@ fn test_get_simple_registry() {
           C:
             STRUCT:
               - x: U8
-    Test:
-      STRUCT:
+    ? namespace: ROOT
+      name: Test
+    : STRUCT:
         - a:
             SEQ: U32
         - b:
@@ -654,8 +656,9 @@ fn test_get_simple_registry() {
 fn test_get_registry() {
     let registry = get_registry();
     insta::assert_yaml_snapshot!(&registry, @r"
-    CStyleEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: CStyleEnum
+    : ENUM:
         0:
           A: UNIT
         1:
@@ -666,8 +669,9 @@ fn test_get_registry() {
           D: UNIT
         4:
           E: UNIT
-    List:
-      ENUM:
+    ? namespace: ROOT
+      name: List
+    : ENUM:
         0:
           Empty: UNIT
         1:
@@ -679,10 +683,12 @@ fn test_get_registry() {
               - TYPENAME:
                   namespace: ROOT
                   name: List
-    NewTypeStruct:
-      NEWTYPESTRUCT: U64
-    OtherTypes:
-      STRUCT:
+    ? namespace: ROOT
+      name: NewTypeStruct
+    : NEWTYPESTRUCT: U64
+    ? namespace: ROOT
+      name: OtherTypes
+    : STRUCT:
         - f_string: STR
         - f_bytes: BYTES
         - f_option:
@@ -717,8 +723,9 @@ fn test_get_registry() {
                 TYPENAME:
                   namespace: ROOT
                   name: Struct
-    PrimitiveTypes:
-      STRUCT:
+    ? namespace: ROOT
+      name: PrimitiveTypes
+    : STRUCT:
         - f_bool: BOOL
         - f_u8: U8
         - f_u16: U16
@@ -736,8 +743,9 @@ fn test_get_registry() {
             OPTION: F64
         - f_char:
             OPTION: CHAR
-    SerdeData:
-      ENUM:
+    ? namespace: ROOT
+      name: SerdeData
+    : ENUM:
         0:
           PrimitiveTypes:
             NEWTYPE:
@@ -828,18 +836,21 @@ fn test_get_registry() {
                 VALUE: UNIT
         13:
           EmptyStructVariant: UNIT
-    SimpleList:
-      NEWTYPESTRUCT:
+    ? namespace: ROOT
+      name: SimpleList
+    : NEWTYPESTRUCT:
         OPTION:
           TYPENAME:
             namespace: ROOT
             name: SimpleList
-    Struct:
-      STRUCT:
+    ? namespace: ROOT
+      name: Struct
+    : STRUCT:
         - x: U32
         - y: U64
-    Tree:
-      STRUCT:
+    ? namespace: ROOT
+      name: Tree
+    : STRUCT:
         - value:
             TYPENAME:
               namespace: ROOT
@@ -849,11 +860,14 @@ fn test_get_registry() {
               TYPENAME:
                 namespace: ROOT
                 name: Tree
-    TupleStruct:
-      TUPLESTRUCT:
+    ? namespace: ROOT
+      name: TupleStruct
+    : TUPLESTRUCT:
         - U32
         - U64
-    UnitStruct: UNITSTRUCT
+    ? namespace: ROOT
+      name: UnitStruct
+    : UNITSTRUCT
     ");
 }
 

--- a/src/generation/typescript.rs
+++ b/src/generation/typescript.rs
@@ -76,7 +76,7 @@ impl<'a> CodeGenerator<'a> {
         emitter.output_preamble()?;
 
         for (name, format) in registry {
-            emitter.output_container(name, format)?;
+            emitter.output_container(&name.name, format)?;
         }
 
         if self.config.serialization {

--- a/src/reflection/namespace/tests.rs
+++ b/src/reflection/namespace/tests.rs
@@ -38,20 +38,24 @@ fn single_namespace() {
       custom_code: {}
       c_style_enums: false
       package_manifest: true
-    : ChildOne:
-        STRUCT:
+    : ? namespace: ROOT
+        name: ChildOne
+      : STRUCT:
           - child:
               TYPENAME:
                 namespace: ROOT
                 name: GrandChild
-      ChildTwo:
-        STRUCT:
+      ? namespace: ROOT
+        name: ChildTwo
+      : STRUCT:
           - field: STR
-      GrandChild:
-        STRUCT:
+      ? namespace: ROOT
+        name: GrandChild
+      : STRUCT:
           - field: STR
-      Parent:
-        STRUCT:
+      ? namespace: ROOT
+        name: Parent
+      : STRUCT:
           - one:
               TYPENAME:
                 namespace: ROOT
@@ -104,8 +108,9 @@ fn root_namespace_with_two_child_namespaces() {
       custom_code: {}
       c_style_enums: false
       package_manifest: true
-    : Parent:
-        STRUCT:
+    : ? namespace: ROOT
+        name: Parent
+      : STRUCT:
           - one:
               TYPENAME:
                 namespace:
@@ -126,15 +131,19 @@ fn root_namespace_with_two_child_namespaces() {
       custom_code: {}
       c_style_enums: false
       package_manifest: true
-    : ChildOne:
-        STRUCT:
+    : ? namespace:
+          NAMED: one
+        name: ChildOne
+      : STRUCT:
           - child:
               TYPENAME:
                 namespace:
                   NAMED: one
                 name: GrandChild
-      GrandChild:
-        STRUCT:
+      ? namespace:
+          NAMED: one
+        name: GrandChild
+      : STRUCT:
           - field: STR
     ? module_name: two
       serialization: true
@@ -144,8 +153,10 @@ fn root_namespace_with_two_child_namespaces() {
       custom_code: {}
       c_style_enums: false
       package_manifest: true
-    : ChildTwo:
-        STRUCT:
+    : ? namespace:
+          NAMED: two
+        name: ChildTwo
+      : STRUCT:
           - field: STR
     ");
 }

--- a/src/reflection/namespace_tests.rs
+++ b/src/reflection/namespace_tests.rs
@@ -32,11 +32,13 @@ fn nested_namespaced_structs() {
 
     let registry = reflect::<Parent>();
     insta::assert_yaml_snapshot!(registry, @r"
-    GrandChild:
-      STRUCT:
+    ? namespace: ROOT
+      name: GrandChild
+    : STRUCT:
         - field: STR
-    Parent:
-      STRUCT:
+    ? namespace: ROOT
+      name: Parent
+    : STRUCT:
         - one:
             TYPENAME:
               namespace:
@@ -47,14 +49,18 @@ fn nested_namespaced_structs() {
               namespace:
                 NAMED: two
               name: Child
-    one.Child:
-      STRUCT:
+    ? namespace:
+        NAMED: one
+      name: Child
+    : STRUCT:
         - child:
             TYPENAME:
               namespace: ROOT
               name: GrandChild
-    two.Child:
-      STRUCT:
+    ? namespace:
+        NAMED: two
+      name: Child
+    : STRUCT:
         - field: STR
     ");
 }
@@ -97,12 +103,14 @@ fn nested_namespaced_enums() {
 
     let registry = reflect::<Parent>();
     insta::assert_yaml_snapshot!(registry, @r"
-    GrandChild:
-      ENUM:
+    ? namespace: ROOT
+      name: GrandChild
+    : ENUM:
         0:
           None: UNIT
-    Parent:
-      ENUM:
+    ? namespace: ROOT
+      name: Parent
+    : ENUM:
         0:
           One:
             NEWTYPE:
@@ -117,16 +125,20 @@ fn nested_namespaced_enums() {
                 namespace:
                   NAMED: two
                 name: Child
-    one.Child:
-      ENUM:
+    ? namespace:
+        NAMED: one
+      name: Child
+    : ENUM:
         0:
           Data:
             NEWTYPE:
               TYPENAME:
                 namespace: ROOT
                 name: GrandChild
-    two.Child:
-      ENUM:
+    ? namespace:
+        NAMED: two
+      name: Child
+    : ENUM:
         0:
           Data:
             NEWTYPE: STR
@@ -166,11 +178,13 @@ fn nested_namespaced_renamed_structs() {
 
     let registry = reflect::<Parent>();
     insta::assert_yaml_snapshot!(registry, @r"
-    GrandKid:
-      STRUCT:
+    ? namespace: ROOT
+      name: GrandKid
+    : STRUCT:
         - field: STR
-    Parent:
-      STRUCT:
+    ? namespace: ROOT
+      name: Parent
+    : STRUCT:
         - one:
             TYPENAME:
               namespace:
@@ -181,14 +195,18 @@ fn nested_namespaced_renamed_structs() {
               namespace:
                 NAMED: two
               name: Kid
-    one.Kid:
-      STRUCT:
+    ? namespace:
+        NAMED: one
+      name: Kid
+    : STRUCT:
         - child:
             TYPENAME:
               namespace: ROOT
               name: GrandKid
-    two.Kid:
-      STRUCT:
+    ? namespace:
+        NAMED: two
+      name: Kid
+    : STRUCT:
         - field: STR
     ");
 }
@@ -218,8 +236,9 @@ fn namespaced_collections() {
 
     let registry = reflect::<Response>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Response:
-      STRUCT:
+    ? namespace: ROOT
+      name: Response
+    : STRUCT:
         - users:
             SEQ:
               TYPENAME:
@@ -246,16 +265,20 @@ fn namespaced_collections() {
                 namespace:
                   NAMED: api
                 name: Group
-    api.Group:
-      STRUCT:
+    ? namespace:
+        NAMED: api
+      name: Group
+    : STRUCT:
         - users:
             SEQ:
               TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
-    api.User:
-      STRUCT:
+    ? namespace:
+        NAMED: api
+      name: User
+    : STRUCT:
         - id: STR
         - name: STR
     ");
@@ -284,8 +307,9 @@ fn namespaced_maps() {
 
     let registry = reflect::<Database>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Database:
-      STRUCT:
+    ? namespace: ROOT
+      name: Database
+    : STRUCT:
         - user_profiles:
             MAP:
               KEY:
@@ -302,10 +326,14 @@ fn namespaced_maps() {
             MAP:
               KEY: STR
               VALUE: U32
-    models.UserId:
-      NEWTYPESTRUCT: STR
-    models.UserProfile:
-      STRUCT:
+    ? namespace:
+        NAMED: models
+      name: UserId
+    : NEWTYPESTRUCT: STR
+    ? namespace:
+        NAMED: models
+      name: UserProfile
+    : STRUCT:
         - name: STR
         - active: BOOL
     ");
@@ -347,16 +375,19 @@ fn complex_namespaced_enums() {
 
     let registry = reflect::<EventLog>();
     insta::assert_yaml_snapshot!(registry, @r"
-    EventLog:
-      STRUCT:
+    ? namespace: ROOT
+      name: EventLog
+    : STRUCT:
         - events:
             SEQ:
               TYPENAME:
                 namespace:
                   NAMED: events
                 name: Event
-    events.Event:
-      ENUM:
+    ? namespace:
+        NAMED: events
+      name: Event
+    : ENUM:
         0:
           UserCreated:
             NEWTYPE:
@@ -386,11 +417,15 @@ fn complex_namespaced_enums() {
                 name: SystemData
         3:
           Simple: UNIT
-    events.SystemData:
-      STRUCT:
+    ? namespace:
+        NAMED: events
+      name: SystemData
+    : STRUCT:
         - timestamp: U64
-    events.UserData:
-      STRUCT:
+    ? namespace:
+        NAMED: events
+      name: UserData
+    : STRUCT:
         - id: STR
         - email: STR
     ");
@@ -417,8 +452,9 @@ fn namespaced_transparent_structs() {
 
     let registry = reflect::<Container>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Container:
-      STRUCT:
+    ? namespace: ROOT
+      name: Container
+    : STRUCT:
         - direct_id:
             TYPENAME:
               namespace:
@@ -429,8 +465,10 @@ fn namespaced_transparent_structs() {
               namespace:
                 NAMED: wrappers
               name: UserId
-    wrappers.UserId:
-      NEWTYPESTRUCT: STR
+    ? namespace:
+        NAMED: wrappers
+      name: UserId
+    : NEWTYPESTRUCT: STR
     ");
 }
 
@@ -463,27 +501,34 @@ fn cross_namespace_references() {
 
     let registry = reflect::<System>();
     insta::assert_yaml_snapshot!(registry, @r"
-    System:
-      STRUCT:
+    ? namespace: ROOT
+      name: System
+    : STRUCT:
         - records:
             SEQ:
               TYPENAME:
                 namespace:
                   NAMED: storage
                 name: Record
-    api.Request:
-      STRUCT:
+    ? namespace:
+        NAMED: api
+      name: Request
+    : STRUCT:
         - entity:
             TYPENAME:
               namespace:
                 NAMED: entities
               name: Entity
         - metadata: STR
-    entities.Entity:
-      STRUCT:
+    ? namespace:
+        NAMED: entities
+      name: Entity
+    : STRUCT:
         - id: STR
-    storage.Record:
-      STRUCT:
+    ? namespace:
+        NAMED: storage
+      name: Record
+    : STRUCT:
         - entity:
             TYPENAME:
               namespace:
@@ -518,15 +563,18 @@ fn namespace_with_byte_attributes() {
 
     let registry = reflect::<Document>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Document:
-      STRUCT:
+    ? namespace: ROOT
+      name: Document
+    : STRUCT:
         - binary:
             TYPENAME:
               namespace:
                 NAMED: data
               name: BinaryData
-    data.BinaryData:
-      STRUCT:
+    ? namespace:
+        NAMED: data
+      name: BinaryData
+    : STRUCT:
         - content: BYTES
         - header: BYTES
         - metadata: STR
@@ -559,8 +607,9 @@ fn deeply_nested_namespaces() {
 
     let registry = reflect::<RootStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    RootStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: RootStruct
+    : STRUCT:
         - middle:
             TYPENAME:
               namespace:
@@ -571,15 +620,19 @@ fn deeply_nested_namespaces() {
               namespace:
                 NAMED: level1.level2
               name: DeepStruct
-    level1.MiddleStruct:
-      STRUCT:
+    ? namespace:
+        NAMED: level1
+      name: MiddleStruct
+    : STRUCT:
         - deep:
             TYPENAME:
               namespace:
                 NAMED: level1.level2
               name: DeepStruct
-    level1.level2.DeepStruct:
-      STRUCT:
+    ? namespace:
+        NAMED: level1.level2
+      name: DeepStruct
+    : STRUCT:
         - value: STR
     ");
 }
@@ -604,14 +657,16 @@ fn transparent_struct_explicit_namespace() {
 
     let registry = reflect::<Container>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Container:
-      STRUCT:
+    ? namespace: ROOT
+      name: Container
+    : STRUCT:
         - wrapped_id:
             TYPENAME:
               namespace: ROOT
               name: UserId
-    UserId:
-      NEWTYPESTRUCT: STR
+    ? namespace: ROOT
+      name: UserId
+    : NEWTYPESTRUCT: STR
     ");
 }
 
@@ -683,8 +738,9 @@ fn explicit_namespace_declarations() {
 
     let registry = reflect::<RootContainer>();
     insta::assert_yaml_snapshot!(registry, @r"
-    ApiContainer:
-      STRUCT:
+    ? namespace: ROOT
+      name: ApiContainer
+    : STRUCT:
         - user:
             TYPENAME:
               namespace:
@@ -695,8 +751,9 @@ fn explicit_namespace_declarations() {
               namespace:
                 NAMED: api
               name: Group
-    RootContainer:
-      STRUCT:
+    ? namespace: ROOT
+      name: RootContainer
+    : STRUCT:
         - api_data:
             TYPENAME:
               namespace: ROOT
@@ -710,31 +767,39 @@ fn explicit_namespace_declarations() {
             TYPENAME:
               namespace: ROOT
               name: RootGroup
-    RootGroup:
-      STRUCT:
+    ? namespace: ROOT
+      name: RootGroup
+    : STRUCT:
         - users:
             SEQ:
               TYPENAME:
                 namespace: ROOT
                 name: RootUser
-    RootUser:
-      STRUCT:
+    ? namespace: ROOT
+      name: RootUser
+    : STRUCT:
         - id: STR
         - name: STR
-    api.Group:
-      STRUCT:
+    ? namespace:
+        NAMED: api
+      name: Group
+    : STRUCT:
         - users:
             SEQ:
               TYPENAME:
                 namespace:
                   NAMED: api
                 name: User
-    api.User:
-      STRUCT:
+    ? namespace:
+        NAMED: api
+      name: User
+    : STRUCT:
         - id: STR
         - name: STR
-    events.Event:
-      ENUM:
+    ? namespace:
+        NAMED: events
+      name: Event
+    : ENUM:
         0:
           UserCreated:
             NEWTYPE:
@@ -749,11 +814,15 @@ fn explicit_namespace_declarations() {
                 namespace:
                   NAMED: events
                 name: SystemData
-    events.SystemData:
-      STRUCT:
+    ? namespace:
+        NAMED: events
+      name: SystemData
+    : STRUCT:
         - timestamp: U64
-    events.UserData:
-      STRUCT:
+    ? namespace:
+        NAMED: events
+      name: UserData
+    : STRUCT:
         - id: STR
     ");
 }
@@ -784,15 +853,19 @@ fn collections_with_explicit_namespace() {
 
     let registry = reflect::<UserManager>();
     insta::assert_yaml_snapshot!(registry, @r"
-    UnnamedRole:
-      STRUCT:
+    ? namespace: ROOT
+      name: UnnamedRole
+    : STRUCT:
         - permissions:
             SEQ: STR
-    UnnamedUser:
-      STRUCT:
+    ? namespace: ROOT
+      name: UnnamedUser
+    : STRUCT:
         - name: STR
-    system.UserManager:
-      STRUCT:
+    ? namespace:
+        NAMED: system
+      name: UserManager
+    : STRUCT:
         - users:
             SEQ:
               TYPENAME:
@@ -864,22 +937,27 @@ fn enums_with_explicit_namespace() {
 
     let registry = reflect::<Response>();
     insta::assert_yaml_snapshot!(registry, @r"
-    ErrorData:
-      STRUCT:
+    ? namespace: ROOT
+      name: ErrorData
+    : STRUCT:
         - code: U32
         - message: STR
-    ProcessingData:
-      STRUCT:
+    ? namespace: ROOT
+      name: ProcessingData
+    : STRUCT:
         - progress: F32
         - estimate:
             TYPENAME:
               namespace: ROOT
               name: ErrorData
-    SuccessData:
-      STRUCT:
+    ? namespace: ROOT
+      name: SuccessData
+    : STRUCT:
         - result: STR
-    api.Response:
-      ENUM:
+    ? namespace:
+        NAMED: api
+      name: Response
+    : ENUM:
         0:
           Success:
             NEWTYPE:
@@ -948,11 +1026,13 @@ fn nested_structs_with_explicit_namespace() {
 
     let registry = reflect::<Container>();
     insta::assert_yaml_snapshot!(registry, @r"
-    DeepInner:
-      STRUCT:
+    ? namespace: ROOT
+      name: DeepInner
+    : STRUCT:
         - value: I32
-    MiddleLayer:
-      STRUCT:
+    ? namespace: ROOT
+      name: MiddleLayer
+    : STRUCT:
         - inner:
             TYPENAME:
               namespace: ROOT
@@ -962,8 +1042,9 @@ fn nested_structs_with_explicit_namespace() {
               TYPENAME:
                 namespace: ROOT
                 name: DeepInner
-    TopLayer:
-      STRUCT:
+    ? namespace: ROOT
+      name: TopLayer
+    : STRUCT:
         - middle:
             TYPENAME:
               namespace: ROOT
@@ -972,8 +1053,10 @@ fn nested_structs_with_explicit_namespace() {
             TYPENAME:
               namespace: ROOT
               name: DeepInner
-    nested.Container:
-      STRUCT:
+    ? namespace:
+        NAMED: nested
+      name: Container
+    : STRUCT:
         - top:
             TYPENAME:
               namespace: ROOT
@@ -1015,17 +1098,21 @@ fn transparent_struct_chains() {
 
     let registry = reflect::<IdContainer>();
     insta::assert_yaml_snapshot!(registry, @r"
-    CoreId:
-      NEWTYPESTRUCT: STR
-    IdContainer:
-      STRUCT:
+    ? namespace: ROOT
+      name: CoreId
+    : NEWTYPESTRUCT: STR
+    ? namespace: ROOT
+      name: IdContainer
+    : STRUCT:
         - id:
             TYPENAME:
               namespace:
                 NAMED: identity
               name: NamespacedWrapper
-    identity.NamespacedWrapper:
-      NEWTYPESTRUCT:
+    ? namespace:
+        NAMED: identity
+      name: NamespacedWrapper
+    : NEWTYPESTRUCT:
         TYPENAME:
           namespace: ROOT
           name: DoubleWrapperId
@@ -1054,11 +1141,14 @@ fn mixed_containers_with_explicit_namespace() {
 
     let registry = reflect::<MixedContainer>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Item:
-      STRUCT:
+    ? namespace: ROOT
+      name: Item
+    : STRUCT:
         - id: STR
-    storage.MixedContainer:
-      STRUCT:
+    ? namespace:
+        NAMED: storage
+      name: MixedContainer
+    : STRUCT:
         - single:
             TYPENAME:
               namespace: ROOT
@@ -1133,8 +1223,9 @@ fn no_namespace_pollution() {
 
     let registry = reflect::<RootContainer>();
     insta::assert_yaml_snapshot!(registry, @r"
-    RootContainer:
-      STRUCT:
+    ? namespace: ROOT
+      name: RootContainer
+    : STRUCT:
         - alpha:
             TYPENAME:
               namespace:
@@ -1149,17 +1240,22 @@ fn no_namespace_pollution() {
             TYPENAME:
               namespace: ROOT
               name: SharedType
-    SharedType:
-      STRUCT:
+    ? namespace: ROOT
+      name: SharedType
+    : STRUCT:
         - value: STR
-    alpha.AlphaContainer:
-      STRUCT:
+    ? namespace:
+        NAMED: alpha
+      name: AlphaContainer
+    : STRUCT:
         - shared:
             TYPENAME:
               namespace: ROOT
               name: SharedType
-    beta.BetaContainer:
-      STRUCT:
+    ? namespace:
+        NAMED: beta
+      name: BetaContainer
+    : STRUCT:
         - shared:
             TYPENAME:
               namespace: ROOT
@@ -1169,7 +1265,6 @@ fn no_namespace_pollution() {
 
 #[test]
 fn explicit_namespace_behavior_summary() {
-    // Summary test documenting explicit namespace behavior
     #[derive(facet::Facet)]
     struct BaseType {
         value: String,
@@ -1196,11 +1291,13 @@ fn explicit_namespace_behavior_summary() {
 
     let registry = reflect::<Root>();
     insta::assert_yaml_snapshot!(registry, @r"
-    BaseType:
-      STRUCT:
+    ? namespace: ROOT
+      name: BaseType
+    : STRUCT:
         - value: STR
-    Root:
-      STRUCT:
+    ? namespace: ROOT
+      name: Root
+    : STRUCT:
         - first:
             TYPENAME:
               namespace:
@@ -1215,14 +1312,18 @@ fn explicit_namespace_behavior_summary() {
             TYPENAME:
               namespace: ROOT
               name: BaseType
-    first.FirstContainer:
-      STRUCT:
+    ? namespace:
+        NAMED: first
+      name: FirstContainer
+    : STRUCT:
         - item:
             TYPENAME:
               namespace: ROOT
               name: BaseType
-    second.SecondContainer:
-      STRUCT:
+    ? namespace:
+        NAMED: second
+      name: SecondContainer
+    : STRUCT:
         - item:
             TYPENAME:
               namespace: ROOT

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -8,7 +8,11 @@ fn unit_struct() {
     struct MyUnitStruct;
 
     let registry = reflect::<MyUnitStruct>();
-    insta::assert_yaml_snapshot!(registry, @"MyUnitStruct: UNITSTRUCT");
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyUnitStruct
+    : UNITSTRUCT
+    ");
 }
 
 #[test]
@@ -18,9 +22,10 @@ fn newtype_bool() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: BOOL
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: BOOL
+    ");
 }
 
 #[test]
@@ -30,9 +35,10 @@ fn newtype_unit() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: UNIT
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: UNIT
+    ");
 }
 
 #[test]
@@ -42,9 +48,10 @@ fn newtype_u8() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: U8
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: U8
+    ");
 }
 
 #[test]
@@ -54,9 +61,10 @@ fn newtype_u16() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: U16
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: U16
+    ");
 }
 
 #[test]
@@ -66,9 +74,10 @@ fn newtype_u32() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: U32
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: U32
+    ");
 }
 
 #[test]
@@ -78,9 +87,10 @@ fn newtype_u64() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: U64
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: U64
+    ");
 }
 
 #[test]
@@ -90,9 +100,10 @@ fn newtype_u128() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: U128
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: U128
+    ");
 }
 
 #[test]
@@ -102,9 +113,10 @@ fn newtype_i8() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: I8
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: I8
+    ");
 }
 
 #[test]
@@ -114,9 +126,10 @@ fn newtype_i16() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: I16
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: I16
+    ");
 }
 
 #[test]
@@ -126,9 +139,10 @@ fn newtype_i32() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: I32
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: I32
+    ");
 }
 
 #[test]
@@ -138,9 +152,10 @@ fn newtype_i64() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: I64
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: I64
+    ");
 }
 
 #[test]
@@ -150,9 +165,10 @@ fn newtype_i128() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: I128
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: I128
+    ");
 }
 
 #[test]
@@ -162,9 +178,10 @@ fn newtype_f32() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: F32
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: F32
+    ");
 }
 
 #[test]
@@ -174,9 +191,10 @@ fn newtype_f64() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: F64
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: F64
+    ");
 }
 
 #[test]
@@ -186,9 +204,10 @@ fn newtype_char() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT: CHAR
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT: CHAR
+    ");
 }
 
 #[test]
@@ -201,10 +220,12 @@ fn nested_newtype() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyNewType:
-      NEWTYPESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
         TYPENAME:
           namespace: ROOT
           name: Inner
@@ -218,10 +239,11 @@ fn newtype_with_list() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT:
-            SEQ: I32
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
+        SEQ: I32
+    ");
 }
 
 #[test]
@@ -234,10 +256,12 @@ fn newtype_with_list_of_named_type() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyNewType:
-      NEWTYPESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
         SEQ:
           TYPENAME:
             namespace: ROOT
@@ -252,11 +276,12 @@ fn newtype_with_nested_list() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT:
-            SEQ:
-              SEQ: I32
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
+        SEQ:
+          SEQ: I32
+    ");
 }
 
 #[test]
@@ -269,10 +294,12 @@ fn newtype_with_nested_list_of_named_type() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyNewType:
-      NEWTYPESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
         SEQ:
           SEQ:
             TYPENAME:
@@ -291,10 +318,12 @@ fn newtype_with_triple_nested_list_of_named_type() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyNewType:
-      NEWTYPESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
         SEQ:
           SEQ:
             SEQ:
@@ -311,12 +340,13 @@ fn newtype_with_tuple_array() {
 
     let registry = reflect::<MyNewType>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyNewType:
-          NEWTYPESTRUCT:
-            TUPLEARRAY:
-              CONTENT: I32
-              SIZE: 3
-        ");
+    ? namespace: ROOT
+      name: MyNewType
+    : NEWTYPESTRUCT:
+        TUPLEARRAY:
+          CONTENT: I32
+          SIZE: 3
+    ");
 }
 
 #[test]
@@ -326,12 +356,13 @@ fn tuple_struct() {
 
     let registry = reflect::<MyTupleStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyTupleStruct:
-          TUPLESTRUCT:
-            - U8
-            - I32
-            - BOOL
-        ");
+    ? namespace: ROOT
+      name: MyTupleStruct
+    : TUPLESTRUCT:
+        - U8
+        - I32
+        - BOOL
+    ");
 }
 
 #[test]
@@ -341,12 +372,13 @@ fn tuple_struct_with_unit() {
 
     let registry = reflect::<MyTupleStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyTupleStruct:
-          TUPLESTRUCT:
-            - U8
-            - UNIT
-            - I32
-        ");
+    ? namespace: ROOT
+      name: MyTupleStruct
+    : TUPLESTRUCT:
+        - U8
+        - UNIT
+        - I32
+    ");
 }
 
 #[test]
@@ -358,11 +390,12 @@ fn option_of_unit() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a:
-                OPTION: UNIT
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a:
+            OPTION: UNIT
+    ");
 }
 
 #[test]
@@ -374,12 +407,13 @@ fn option_of_list() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a:
-                OPTION:
-                  SEQ: I32
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a:
+            OPTION:
+              SEQ: I32
+    ");
 }
 
 #[test]
@@ -391,13 +425,14 @@ fn option_of_nested_list() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a:
-                OPTION:
-                  SEQ:
-                    SEQ: I32
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a:
+            OPTION:
+              SEQ:
+                SEQ: I32
+    ");
 }
 
 #[test]
@@ -412,10 +447,12 @@ fn option_of_list_of_named_type() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             OPTION:
               SEQ:
@@ -434,12 +471,13 @@ fn list_of_options() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a:
-                SEQ:
-                  OPTION: I32
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a:
+            SEQ:
+              OPTION: I32
+    ");
 }
 
 #[test]
@@ -454,10 +492,12 @@ fn list_of_options_of_named_type() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             SEQ:
               OPTION:
@@ -476,13 +516,14 @@ fn nested_list_with_options() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a:
-                SEQ:
-                  SEQ:
-                    OPTION: I32
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a:
+            SEQ:
+              SEQ:
+                OPTION: I32
+    ");
 }
 
 #[test]
@@ -495,10 +536,12 @@ fn nested_tuple_struct_1() {
 
     let registry = reflect::<MyTupleStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyTupleStruct:
-      TUPLESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyTupleStruct
+    : TUPLESTRUCT:
         - TYPENAME:
             namespace: ROOT
             name: Inner
@@ -516,13 +559,15 @@ fn nested_tuple_struct_2() {
 
     let registry = reflect::<MyTupleStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      TUPLESTRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : TUPLESTRUCT:
         - I32
         - U8
         - BOOL
-    MyTupleStruct:
-      TUPLESTRUCT:
+    ? namespace: ROOT
+      name: MyTupleStruct
+    : TUPLESTRUCT:
         - I32
         - TYPENAME:
             namespace: ROOT
@@ -540,8 +585,9 @@ fn struct_with_vec_of_u8() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             SEQ: U8
     ");
@@ -557,8 +603,9 @@ fn struct_with_vec_of_u8_to_bytes() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a: BYTES
     ");
 }
@@ -572,8 +619,9 @@ fn struct_with_slice_of_u8() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             SEQ: U8
     ");
@@ -589,8 +637,9 @@ fn struct_with_slice_of_u8_to_bytes() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a: BYTES
     ");
 }
@@ -607,13 +656,14 @@ fn struct_with_scalar_fields() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyStruct:
-          STRUCT:
-            - a: U8
-            - b: I32
-            - c: BOOL
-            - d: UNIT
-        ");
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - a: U8
+        - b: I32
+        - c: BOOL
+        - d: UNIT
+    ");
 }
 
 #[test]
@@ -625,8 +675,9 @@ fn struct_with_tuple_field() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             TUPLE:
               - U8
@@ -650,14 +701,16 @@ fn struct_with_option_fields() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      STRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : STRUCT:
         - a:
             OPTION: BOOL
         - b:
             OPTION: U8
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             OPTION:
               TYPENAME:
@@ -684,14 +737,17 @@ fn struct_with_fields_of_newtypes_and_tuple_structs() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner1:
-      NEWTYPESTRUCT: I32
-    Inner2:
-      TUPLESTRUCT:
+    ? namespace: ROOT
+      name: Inner1
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: Inner2
+    : TUPLESTRUCT:
         - I8
         - U32
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - a:
             TYPENAME:
               namespace: ROOT
@@ -715,13 +771,14 @@ fn enum_with_unit_variants() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyEnum:
-          ENUM:
-            0:
-              Variant1: UNIT
-            1:
-              Variant2: UNIT
-        ");
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          Variant1: UNIT
+        1:
+          Variant2: UNIT
+    ");
 }
 
 #[test]
@@ -741,8 +798,9 @@ fn enum_with_newtype_variants() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             NEWTYPE: U8
@@ -782,10 +840,12 @@ fn enum_with_newtype_variants_containing_user_defined_types() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             NEWTYPE:
@@ -810,8 +870,9 @@ fn enum_with_tuple_struct_variants() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             TUPLE:
@@ -845,10 +906,12 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             TUPLE:
@@ -882,11 +945,13 @@ fn enum_with_inline_struct_variants() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      STRUCT:
+    ? namespace: ROOT
+      name: Inner
+    : STRUCT:
         - a: STR
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             STRUCT:
@@ -931,10 +996,12 @@ fn enum_with_struct_variants_mixed_types() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Inner:
-      NEWTYPESTRUCT: I32
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: Inner
+    : NEWTYPESTRUCT: I32
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1:
             STRUCT:
@@ -972,8 +1039,9 @@ fn enum_with_struct_variant() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           A: UNIT
         1:
@@ -1000,8 +1068,9 @@ fn enum_with_skip_serializing() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyEnum:
-      ENUM:
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
         0:
           Variant1: UNIT
         1:
@@ -1022,8 +1091,9 @@ fn transparent() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - inner: I32
     ");
 }
@@ -1039,15 +1109,16 @@ fn map_of_string_and_bool() {
 
     let registry = reflect::<MyEnum>();
     insta::assert_yaml_snapshot!(registry, @r"
-        MyEnum:
-          ENUM:
-            0:
-              Map:
-                NEWTYPE:
-                  MAP:
-                    KEY: STR
-                    VALUE: BOOL
-        ");
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          Map:
+            NEWTYPE:
+              MAP:
+                KEY: STR
+                VALUE: BOOL
+    ");
 }
 
 #[test]
@@ -1070,8 +1141,9 @@ fn map_with_user_defined_types() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - user_map:
             MAP:
               KEY:
@@ -1092,10 +1164,12 @@ fn map_with_user_defined_types() {
               KEY: STR
               VALUE:
                 OPTION: U64
-    UserId:
-      NEWTYPESTRUCT: U32
-    UserProfile:
-      STRUCT:
+    ? namespace: ROOT
+      name: UserId
+    : NEWTYPESTRUCT: U32
+    ? namespace: ROOT
+      name: UserProfile
+    : STRUCT:
         - name: STR
         - active: BOOL
     ");
@@ -1113,8 +1187,9 @@ fn complex_map() {
 
     let registry = reflect::<ComplexMap>();
     insta::assert_yaml_snapshot!(registry, @r"
-    ComplexMap:
-      ENUM:
+    ? namespace: ROOT
+      name: ComplexMap
+    : ENUM:
         0:
           Map:
             NEWTYPE:
@@ -1146,14 +1221,16 @@ fn struct_with_box_of_t() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - boxed:
             TYPENAME:
               namespace: ROOT
               name: UserProfile
-    UserProfile:
-      STRUCT:
+    ? namespace: ROOT
+      name: UserProfile
+    : STRUCT:
         - name: STR
         - active: BOOL
     ");
@@ -1174,14 +1251,16 @@ fn struct_with_arc_of_t() {
 
     let registry = reflect::<MyStruct>();
     insta::assert_yaml_snapshot!(registry, @r"
-    MyStruct:
-      STRUCT:
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
         - boxed:
             TYPENAME:
               namespace: ROOT
               name: UserProfile
-    UserProfile:
-      STRUCT:
+    ? namespace: ROOT
+      name: UserProfile
+    : STRUCT:
         - name: STR
         - active: BOOL
     ");
@@ -1230,8 +1309,9 @@ fn own_result_enum() {
 
     let registry = reflect::<HttpResult>();
     insta::assert_yaml_snapshot!(registry, @r"
-    HttpError:
-      ENUM:
+    ? namespace: ROOT
+      name: HttpError
+    : ENUM:
         0:
           Url:
             NEWTYPE: STR
@@ -1240,12 +1320,14 @@ fn own_result_enum() {
             NEWTYPE: STR
         2:
           Timeout: UNIT
-    HttpHeader:
-      STRUCT:
+    ? namespace: ROOT
+      name: HttpHeader
+    : STRUCT:
         - name: STR
         - value: STR
-    HttpResponse:
-      STRUCT:
+    ? namespace: ROOT
+      name: HttpResponse
+    : STRUCT:
         - status: U16
         - headers:
             SEQ:
@@ -1253,8 +1335,9 @@ fn own_result_enum() {
                 namespace: ROOT
                 name: HttpHeader
         - body: BYTES
-    HttpResult:
-      ENUM:
+    ? namespace: ROOT
+      name: HttpResult
+    : ENUM:
         0:
           Ok:
             NEWTYPE:
@@ -1281,8 +1364,9 @@ fn struct_rename() {
 
     let registry = reflect::<EffectFfi>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Effect:
-      STRUCT:
+    ? namespace: ROOT
+      name: Effect
+    : STRUCT:
         - name: STR
         - active: BOOL
     ");
@@ -1301,8 +1385,9 @@ fn enum_rename() {
 
     let registry = reflect::<EffectFfi>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Effect:
-      ENUM:
+    ? namespace: ROOT
+      name: Effect
+    : ENUM:
         0:
           One: UNIT
         1:
@@ -1326,11 +1411,13 @@ fn struct_rename_with_named_type() {
 
     let registry = reflect::<Request>();
     insta::assert_yaml_snapshot!(registry, @r"
-    Effect:
-      STRUCT:
+    ? namespace: ROOT
+      name: Effect
+    : STRUCT:
         - inner: STR
-    Request:
-      STRUCT:
+    ? namespace: ROOT
+      name: Request
+    : STRUCT:
         - id: U32
         - effect:
             TYPENAME:
@@ -1348,7 +1435,10 @@ fn self_referencing_type() {
 
     insta::assert_debug_snapshot!(registry, @r#"
     {
-        "SimpleList": NewTypeStruct(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "SimpleList",
+        }: NewTypeStruct(
             Option(
                 TypeName(
                     QualifiedTypeName {
@@ -1375,7 +1465,10 @@ fn complex_self_referencing_type() {
 
     insta::assert_debug_snapshot!(registry, @r#"
     {
-        "Node": Struct(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "Node",
+        }: Struct(
             [
                 Named {
                     name: "value",
@@ -1419,7 +1512,10 @@ fn tree_struct_with_mutual_recursion() {
 
     insta::assert_debug_snapshot!(registry, @r#"
     {
-        "Test": Enum(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "Test",
+        }: Enum(
             {
                 0: Named {
                     name: "TreeWithMutualRecursion",
@@ -1434,7 +1530,10 @@ fn tree_struct_with_mutual_recursion() {
                 },
             },
         ),
-        "Tree": Struct(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "Tree",
+        }: Struct(
             [
                 Named {
                     name: "value",
@@ -1480,7 +1579,10 @@ fn tree_enum_with_mutual_recursion() {
 
     insta::assert_debug_snapshot!(registry, @r#"
     {
-        "Test": Struct(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "Test",
+        }: Struct(
             [
                 Named {
                     name: "tree_with_mutual_recursion",
@@ -1493,7 +1595,10 @@ fn tree_enum_with_mutual_recursion() {
                 },
             ],
         ),
-        "Tree": Enum(
+        QualifiedTypeName {
+            namespace: Root,
+            name: "Tree",
+        }: Enum(
             {
                 0: Named {
                     name: "Value",


### PR DESCRIPTION
Replaces the `String` key in the registry with a `QualifiedTypeName` so that we no longer need to do any string manipulation.