### PR TITLE
Kotlin, part 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "autocfg"
@@ -404,7 +404,7 @@ dependencies = [
  "strum",
  "tempfile",
  "textwrap",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "url",
 ]
 
@@ -1004,11 +1004,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ indoc = { version = "2.0.6", optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 textwrap = "0.16.2"
-thiserror = "2.0.12"
+thiserror = "2.0.14"
 
 [dev-dependencies]
-anyhow = "1.0.98"
+anyhow = "1.0.99"
 bcs = "0.1.6"
 bincode = "=1"
 chrono = "0.4.41"

--- a/src/generation/common.rs
+++ b/src/generation/common.rs
@@ -28,6 +28,7 @@ pub(crate) fn mangle_type(format: &Format) -> String {
 
         Format::Option(format) => format!("option_{}", mangle_type(format)),
         Format::Seq(format) => format!("vector_{}", mangle_type(format)),
+        Format::Set(format) => format!("set_{}", mangle_type(format)),
         Format::Map { key, value } => format!("map_{}_to_{}", mangle_type(key), mangle_type(value)),
         Format::Tuple(formats) => format!(
             "tuple{}_{}",

--- a/src/generation/java/emitter.rs
+++ b/src/generation/java/emitter.rs
@@ -110,7 +110,9 @@ where
             Format::Bytes => "com.novi.serde.Bytes".into(),
 
             Format::Option(format) => format!("java.util.Optional<{}>", self.quote_type(format)),
-            Format::Seq(format) => format!("java.util.List<{}>", self.quote_type(format)),
+            Format::Seq(format) | Format::Set(format) => {
+                format!("java.util.List<{}>", self.quote_type(format))
+            }
             Format::Map { key, value } => format!(
                 "java.util.Map<{}, {}>",
                 self.quote_type(key),
@@ -190,6 +192,7 @@ where
             format,
             Format::Option(_)
                 | Format::Seq(_)
+                | Format::Set(_)
                 | Format::Map { .. }
                 | Format::Tuple(_)
                 | Format::TupleArray { .. }
@@ -282,7 +285,7 @@ if (value.isPresent()) {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 write!(
                     self.out,
                     r"
@@ -377,7 +380,7 @@ if (!tag) {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 write!(
                     self.out,
                     r"

--- a/src/generation/java/emitter.rs
+++ b/src/generation/java/emitter.rs
@@ -813,12 +813,12 @@ public static {0} {1}Deserialize(byte[] input) throws com.novi.serde.Deserializa
     ) -> std::io::Result<()> {
         let fields = match format {
             ContainerFormat::UnitStruct(_doc) => Vec::new(),
-            ContainerFormat::NewTypeStruct(format) => vec![Named {
+            ContainerFormat::NewTypeStruct(format, _doc) => vec![Named {
                 name: "value".to_string(),
                 doc: Doc::new(),
                 value: format.as_ref().clone(),
             }],
-            ContainerFormat::TupleStruct(formats) => formats
+            ContainerFormat::TupleStruct(formats, _doc) => formats
                 .iter()
                 .enumerate()
                 .map(|(i, f)| Named {
@@ -828,7 +828,7 @@ public static {0} {1}Deserialize(byte[] input) throws com.novi.serde.Deserializa
                 })
                 .collect::<Vec<_>>(),
             ContainerFormat::Struct(fields, _doc) => fields.clone(),
-            ContainerFormat::Enum(variants) => {
+            ContainerFormat::Enum(variants, _doc) => {
                 self.output_enum_container(name, variants)?;
                 return Ok(());
             }

--- a/src/generation/kotlin/emitter.rs
+++ b/src/generation/kotlin/emitter.rs
@@ -269,6 +269,11 @@ impl Emitter<Kotlin> for Format {
                 format.write(writer)?;
                 write!(writer, ">")
             }
+            Format::Set(format) => {
+                write!(writer, "Set<")?;
+                format.write(writer)?;
+                write!(writer, ">")
+            }
             Format::Map { key, value } => {
                 write!(writer, "Map<")?;
                 key.write(writer)?;

--- a/src/generation/kotlin/emitter.rs
+++ b/src/generation/kotlin/emitter.rs
@@ -159,7 +159,22 @@ impl Emitter<Kotlin> for Format {
                 value.write(writer)?;
                 write!(writer, ">")
             }
-            Format::Tuple(_formats) => todo!(),
+            Format::Tuple(formats) => {
+                let len = formats.len();
+                match len {
+                    1 => return formats[0].write(writer),
+                    2 => write!(writer, "Pair<")?,
+                    3 => write!(writer, "Triple<")?,
+                    _ => write!(writer, "NTuple{len}<")?,
+                }
+                for (i, format) in formats.iter().enumerate() {
+                    if i > 0 {
+                        write!(writer, ", ")?;
+                    }
+                    format.write(writer)?;
+                }
+                write!(writer, ">")
+            }
             Format::TupleArray {
                 content: format,
                 size: _,

--- a/src/generation/kotlin/emitter.rs
+++ b/src/generation/kotlin/emitter.rs
@@ -259,7 +259,7 @@ impl Emitter<Kotlin> for Format {
             Format::F32 => write!(writer, "Float"),
             Format::F64 => write!(writer, "Double"),
             Format::Char | Format::Str => write!(writer, "String"),
-            Format::Bytes => todo!(),
+            Format::Bytes => write!(writer, "ByteArray"),
             Format::Option(format) => {
                 format.write(writer)?;
                 write!(writer, "?")

--- a/src/generation/kotlin/emitter.rs
+++ b/src/generation/kotlin/emitter.rs
@@ -99,6 +99,11 @@ impl Emitter<Kotlin> for Named<Format> {
 
         self.value.write(writer)?;
 
+        // Add = null default only for top-level Option types
+        if matches!(self.value, Format::Option(_)) {
+            write!(writer, " = null")?;
+        }
+
         Ok(())
     }
 }
@@ -257,7 +262,7 @@ impl Emitter<Kotlin> for Format {
             Format::Bytes => todo!(),
             Format::Option(format) => {
                 format.write(writer)?;
-                write!(writer, "? = null")
+                write!(writer, "?")
             }
             Format::Seq(format) => {
                 write!(writer, "List<")?;

--- a/src/generation/kotlin/emitter_tests.rs
+++ b/src/generation/kotlin/emitter_tests.rs
@@ -188,3 +188,51 @@ fn struct_with_fields_of_user_types() {
     )
     ");
 }
+
+#[test]
+fn struct_with_field_that_is_a_2_tuple() {
+    #[derive(Facet)]
+    struct MyStruct {
+        one: (String, i32),
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val one: Pair<String, Int>
+    )
+    ");
+}
+
+#[test]
+fn struct_with_field_that_is_a_3_tuple() {
+    #[derive(Facet)]
+    struct MyStruct {
+        one: (String, i32, u16),
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val one: Triple<String, Int, UShort>
+    )
+    ");
+}
+
+#[test]
+fn struct_with_field_that_is_a_4_tuple() {
+    #[derive(Facet)]
+    struct MyStruct {
+        one: (String, i32, u16, f32),
+    }
+
+    // TODO: The NTuple4 struct should be emitted in the preamble if required, e.g.
+    // data class NTuple4<T1, T2, T3, T4>(val t1: T1, val t2: T2, val t3: T3, val t4: T4)
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val one: NTuple4<String, Int, UShort, Float>
+    )
+    ");
+}

--- a/src/generation/kotlin/emitter_tests.rs
+++ b/src/generation/kotlin/emitter_tests.rs
@@ -452,3 +452,81 @@ fn enum_with_mixed_variants() {
     }
     "#);
 }
+
+#[test]
+fn struct_with_vec_field() {
+    #[derive(Facet)]
+    struct MyStruct {
+        items: Vec<String>,
+        numbers: Vec<i32>,
+        nested_items: Vec<Vec<String>>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val items: List<String>,
+        val numbers: List<Int>,
+        val nested_items: List<List<String>>
+    )
+    ");
+}
+
+#[test]
+fn struct_with_option_field() {
+    #[derive(Facet)]
+    struct MyStruct {
+        optional_string: Option<String>,
+        optional_number: Option<i32>,
+        optional_bool: Option<bool>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val optional_string: String? = null,
+        val optional_number: Int? = null,
+        val optional_bool: Boolean? = null
+    )
+    ");
+}
+
+#[test]
+fn struct_with_hashmap_field() {
+    #[derive(Facet)]
+    struct MyStruct {
+        string_to_int: std::collections::HashMap<String, i32>,
+        int_to_bool: std::collections::HashMap<i32, bool>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val string_to_int: Map<String, Int>,
+        val int_to_bool: Map<Int, Boolean>
+    )
+    ");
+}
+
+#[test]
+fn struct_with_nested_generics() {
+    #[derive(Facet)]
+    struct MyStruct {
+        optional_list: Option<Vec<String>>,
+        list_of_optionals: Vec<Option<i32>>,
+        map_to_list: std::collections::HashMap<String, Vec<bool>>,
+        optional_map: Option<std::collections::HashMap<String, i32>>,
+        complex: Vec<Option<std::collections::HashMap<String, Vec<bool>>>>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val optional_list: List<String>? = null,
+        val list_of_optionals: List<Int?>,
+        val map_to_list: Map<String, List<Boolean>>,
+        val optional_map: Map<String, Int>? = null,
+        val complex: List<Map<String, List<Boolean>>?>
+    )
+    ");
+}

--- a/src/generation/kotlin/emitter_tests.rs
+++ b/src/generation/kotlin/emitter_tests.rs
@@ -1,0 +1,190 @@
+use facet::Facet;
+
+use super::*;
+use crate::emit;
+
+#[test]
+fn unit_struct_1() {
+    /// line 1
+    #[derive(Facet)]
+    /// line 2
+    struct UnitStruct;
+
+    insta::assert_snapshot!(emit!(UnitStruct), @r"
+    /// line 1
+    /// line 2
+    @Serializable
+    data object UnitStruct
+    ");
+}
+
+#[test]
+fn unit_struct_2() {
+    /// line 1
+    #[derive(Facet)]
+    /// line 2
+    struct UnitStruct {}
+
+    insta::assert_snapshot!(emit!(UnitStruct), @r"
+    /// line 1
+    /// line 2
+    @Serializable
+    data object UnitStruct
+    ");
+}
+
+#[test]
+fn newtype_struct() {
+    /// line 1
+    #[derive(Facet)]
+    /// line 2
+    struct NewType(String);
+
+    insta::assert_snapshot!(emit!(NewType), @r"
+    /// line 1
+    /// line 2
+    typealias NewType = String
+    ");
+}
+
+#[test]
+fn tuple_struct() {
+    /// line 1
+    #[derive(Facet)]
+    /// line 2
+    struct TupleStruct(String, i32);
+
+    insta::assert_snapshot!(emit!(TupleStruct), @r"
+    /// line 1
+    /// line 2
+    @Serializable
+    data class TupleStruct (
+        val field_0: String,
+        val field_1: Int
+    )
+    ");
+}
+
+#[test]
+fn struct_with_fields_of_primitive_types() {
+    /// line 1
+    #[derive(Facet)]
+    /// line 2
+    struct StructWithFields {
+        /// unit
+        unit: (),
+        /// bool
+        bool: bool,
+        /// i8
+        i8: i8,
+        /// i16
+        i16: i16,
+        /// i32
+        i32: i32,
+        /// i64
+        i64: i64,
+        /// i128
+        i128: i128,
+        /// u8
+        u8: u8,
+        /// u16
+        u16: u16,
+        /// u32
+        u32: u32,
+        /// u64
+        u64: u64,
+        /// u128
+        u128: u128,
+        /// f32
+        f32: f32,
+        /// f64
+        f64: f64,
+        /// char
+        char: char,
+        /// string
+        string: String,
+    }
+
+    insta::assert_snapshot!(emit!(StructWithFields), @r"
+    /// line 1
+    /// line 2
+    @Serializable
+    data class StructWithFields (
+        /// unit
+        val unit: Unit,
+        /// bool
+        val bool: Boolean,
+        /// i8
+        val i8: Byte,
+        /// i16
+        val i16: Short,
+        /// i32
+        val i32: Int,
+        /// i64
+        val i64: Long,
+        /// i128
+        val i128: java.math.@com.novi.serde.Int128 BigInteger,
+        /// u8
+        val u8: UByte,
+        /// u16
+        val u16: UShort,
+        /// u32
+        val u32: UInt,
+        /// u64
+        val u64: ULong,
+        /// u128
+        val u128: java.math.@com.novi.serde.Unsigned @com.novi.serde.Int128 BigInteger,
+        /// f32
+        val f32: Float,
+        /// f64
+        val f64: Double,
+        /// char
+        val char: String,
+        /// string
+        val string: String
+    )
+    ");
+}
+
+#[test]
+fn struct_with_fields_of_user_types() {
+    #[derive(Facet)]
+    struct Inner1 {
+        field1: String,
+    }
+
+    #[derive(Facet)]
+    struct Inner2(String);
+
+    #[derive(Facet)]
+    struct Inner3(String, i32);
+
+    #[derive(Facet)]
+    struct Outer {
+        one: Inner1,
+        two: Inner2,
+        three: Inner3,
+    }
+
+    insta::assert_snapshot!(emit!(Outer), @r"
+    @Serializable
+    data class Inner1 (
+        val field1: String
+    )
+
+    typealias Inner2 = String
+
+    @Serializable
+    data class Inner3 (
+        val field_0: String,
+        val field_1: Int
+    )
+
+    @Serializable
+    data class Outer (
+        val one: Inner1,
+        val two: Inner2,
+        val three: Inner3
+    )
+    ");
+}

--- a/src/generation/kotlin/emitter_tests.rs
+++ b/src/generation/kotlin/emitter_tests.rs
@@ -475,6 +475,7 @@ fn struct_with_vec_field() {
 #[test]
 fn struct_with_option_field() {
     #[derive(Facet)]
+    #[allow(clippy::struct_field_names)]
     struct MyStruct {
         optional_string: Option<String>,
         optional_number: Option<i32>,
@@ -534,6 +535,7 @@ fn struct_with_nested_generics() {
 #[test]
 fn struct_with_array_field() {
     #[derive(Facet)]
+    #[allow(clippy::struct_field_names)]
     struct MyStruct {
         fixed_array: [i32; 5],
         byte_array: [u8; 32],
@@ -569,10 +571,8 @@ fn struct_with_btreemap_field() {
 
 #[test]
 fn struct_with_hashset_field() {
-    // NOTE: HashSet<T> maps to List<T> in Kotlin because the reflection system
-    // treats all set types as Format::Seq. This is functionally correct since
-    // Lists can represent sets, though we lose the uniqueness constraint.
-    // Future enhancement: Add Format::Set variant to generate Set<T> in Kotlin.
+    // NOTE: HashSet<T> now maps to Set<T> in Kotlin with the new Format::Set variant.
+    // This preserves the uniqueness constraint and provides better type safety.
     #[derive(Facet)]
     struct MyStruct {
         string_set: std::collections::HashSet<String>,
@@ -582,16 +582,16 @@ fn struct_with_hashset_field() {
     insta::assert_snapshot!(emit!(MyStruct), @r"
     @Serializable
     data class MyStruct (
-        val string_set: List<String>,
-        val int_set: List<Int>
+        val string_set: Set<String>,
+        val int_set: Set<Int>
     )
     ");
 }
 
 #[test]
 fn struct_with_btreeset_field() {
-    // NOTE: BTreeSet<T> maps to List<T> in Kotlin for the same reason as HashSet.
-    // See comment in struct_with_hashset_field test above.
+    // NOTE: BTreeSet<T> now maps to Set<T> in Kotlin with the new Format::Set variant.
+    // This preserves the uniqueness constraint and provides better type safety.
     #[derive(Facet)]
     struct MyStruct {
         string_set: std::collections::BTreeSet<String>,
@@ -601,8 +601,8 @@ fn struct_with_btreeset_field() {
     insta::assert_snapshot!(emit!(MyStruct), @r"
     @Serializable
     data class MyStruct (
-        val string_set: List<String>,
-        val int_set: List<Int>
+        val string_set: Set<String>,
+        val int_set: Set<Int>
     )
     ");
 }
@@ -672,7 +672,7 @@ fn struct_with_mixed_collections_and_pointers() {
     insta::assert_snapshot!(emit!(MyStruct), @r"
     @Serializable
     data class MyStruct (
-        val vec_of_sets: List<List<String>>,
+        val vec_of_sets: List<Set<String>>,
         val optional_btree: Map<String, Int>? = null,
         val boxed_vec: List<String>,
         val arc_option: String? = null,

--- a/src/generation/kotlin/emitter_tests.rs
+++ b/src/generation/kotlin/emitter_tests.rs
@@ -680,3 +680,47 @@ fn struct_with_mixed_collections_and_pointers() {
     )
     ");
 }
+
+#[test]
+fn struct_with_bytes_field() {
+    #[derive(Facet)]
+    struct MyStruct {
+        #[facet(bytes)]
+        data: Vec<u8>,
+        name: String,
+        #[facet(bytes)]
+        header: Vec<u8>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val data: ByteArray,
+        val name: String,
+        val header: ByteArray
+    )
+    ");
+}
+
+#[test]
+fn struct_with_bytes_field_and_slice() {
+    #[derive(Facet)]
+    struct MyStruct<'a> {
+        #[facet(bytes)]
+        data: &'a [u8],
+        name: String,
+        #[facet(bytes)]
+        header: Vec<u8>,
+        optional_bytes: Option<Vec<u8>>,
+    }
+
+    insta::assert_snapshot!(emit!(MyStruct), @r"
+    @Serializable
+    data class MyStruct (
+        val data: ByteArray,
+        val name: String,
+        val header: ByteArray,
+        val optional_bytes: List<UByte>? = null
+    )
+    ");
+}

--- a/src/generation/kotlin/generator.rs
+++ b/src/generation/kotlin/generator.rs
@@ -1,4 +1,4 @@
-use std::io::{Result, Write as _};
+use std::io::Result;
 
 use crate::{
     Registry,

--- a/src/generation/kotlin/generator.rs
+++ b/src/generation/kotlin/generator.rs
@@ -34,8 +34,6 @@ impl<'a> Language<'a> for CodeGenerator<'a> {
             item.write(w)?;
         }
 
-        writeln!(w)?;
-
         Ok(())
     }
 }

--- a/src/generation/module_tests.rs
+++ b/src/generation/module_tests.rs
@@ -1,6 +1,6 @@
 use facet::Facet;
 
-use crate::reflection::RegistryBuilder;
+use crate::reflect;
 
 use super::*;
 
@@ -27,9 +27,8 @@ fn single_namespace() {
         two: ChildTwo,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
-    let result = split("Root", &registry);
-    insta::assert_yaml_snapshot!(result, @r"
+    let registries = split("Root", &reflect!(Parent));
+    insta::assert_yaml_snapshot!(registries, @r"
     ? module_name: Root
       serialization: Bincode
       encodings: []
@@ -105,9 +104,8 @@ fn root_namespace_with_two_child_namespaces() {
         two: ChildTwo,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
-    let result = split("Root", &registry);
-    insta::assert_yaml_snapshot!(result, @r"
+    let registries = split("Root", &reflect!(Parent));
+    insta::assert_yaml_snapshot!(registries, @r"
     ? module_name: Root
       serialization: Bincode
       encodings: []

--- a/src/generation/swift/emitter.rs
+++ b/src/generation/swift/emitter.rs
@@ -705,12 +705,12 @@ switch index {{",
     pub fn output_container(&mut self, name: &str, format: &ContainerFormat) -> Result<()> {
         let fields = match format {
             ContainerFormat::UnitStruct(_doc) => Vec::new(),
-            ContainerFormat::NewTypeStruct(format) => vec![Named {
+            ContainerFormat::NewTypeStruct(format, _doc) => vec![Named {
                 name: "value".to_string(),
                 doc: Doc::new(),
                 value: format.as_ref().clone(),
             }],
-            ContainerFormat::TupleStruct(formats) => formats
+            ContainerFormat::TupleStruct(formats, _doc) => formats
                 .iter()
                 .enumerate()
                 .map(|(i, f)| Named {
@@ -727,7 +727,7 @@ switch index {{",
                     value: f.value.clone(),
                 })
                 .collect(),
-            ContainerFormat::Enum(variants) => {
+            ContainerFormat::Enum(variants, _doc) => {
                 self.output_enum_container(name, variants)?;
                 return Ok(());
             }

--- a/src/generation/swift/emitter.rs
+++ b/src/generation/swift/emitter.rs
@@ -94,7 +94,7 @@ where
             Format::Bytes => "[UInt8]".into(),
 
             Format::Option(format) => format!("{}?", self.quote_type(format)),
-            Format::Seq(format) => format!("[{}]", self.quote_type(format)),
+            Format::Seq(format) | Format::Set(format) => format!("[{}]", self.quote_type(format)),
             Format::Map { key, value } => {
                 format!("[{}: {}]", self.quote_type(key), self.quote_type(value))
             }
@@ -156,6 +156,7 @@ where
             format,
             Format::Option(_)
                 | Format::Seq(_)
+                | Format::Set(_)
                 | Format::Map { .. }
                 | Format::Tuple(_)
                 | Format::TupleArray { .. }
@@ -218,7 +219,7 @@ if let value = value {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 write!(
                     self.out,
                     r"
@@ -299,7 +300,7 @@ if tag {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 write!(
                     self.out,
                     r"

--- a/src/generation/swift/installer_tests.rs
+++ b/src/generation/swift/installer_tests.rs
@@ -5,7 +5,7 @@ use crate::{
         ExternalPackage, PackageLocation, SourceInstaller as _, module::split,
         swift::installer::Installer,
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -46,7 +46,7 @@ fn manifest_with_serde_as_target() {
         name: String,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
+    let registry = reflect!(MyStruct);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -96,7 +96,7 @@ fn manifest_with_serde_as_a_remote_dependency() {
         name: String,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
+    let registry = reflect!(MyStruct);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -155,7 +155,7 @@ fn manifest_with_serde_as_a_local_dependency() {
         name: String,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
+    let registry = reflect!(MyStruct);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -218,7 +218,7 @@ fn manifest_with_namespaces() {
         child: Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Root>().build();
+    let registry = reflect!(Root);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -270,10 +270,7 @@ fn manifest_with_disjoint_namespaces() {
         id: u32,
     }
 
-    let registry = RegistryBuilder::new()
-        .add_type::<Root>()
-        .add_type::<Another>()
-        .build();
+    let registry = reflect!(Root, Another);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -372,7 +369,7 @@ fn manifest_with_namespaces_and_dependencies() {
         child: Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Root>().build();
+    let registry = reflect!(Root);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();
@@ -438,10 +435,7 @@ fn manifest_with_disjoint_namespaces_and_dependencies() {
         id: u32,
     }
 
-    let registry = RegistryBuilder::new()
-        .add_type::<Root>()
-        .add_type::<Another>()
-        .build();
+    let registry = reflect!(Root, Another);
 
     let package_name = "MyPackage";
     let install_dir = tempfile::tempdir().unwrap();

--- a/src/generation/tests/basic/mod.rs
+++ b/src/generation/tests/basic/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_namespaces_as_external/mod.rs
+++ b/src/generation/tests/with_namespaces_as_external/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -42,7 +42,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_namespaces_as_internal/mod.rs
+++ b/src/generation/tests/with_namespaces_as_internal/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -43,7 +43,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_serialization/mod.rs
+++ b/src/generation/tests/with_serialization/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_serialization_and_namespaces_as_external/mod.rs
+++ b/src/generation/tests/with_serialization_and_namespaces_as_external/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -42,7 +42,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_serialization_and_serde_external/mod.rs
+++ b/src/generation/tests/with_serialization_and_serde_external/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -30,7 +30,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_serialization_and_serde_internal/mod.rs
+++ b/src/generation/tests/with_serialization_and_serde_internal/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/tests/with_serialization_and_serde_local/mod.rs
+++ b/src/generation/tests/with_serialization_and_serde_local/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         tests::{check, read_files_and_create_expect_dirs},
         typescript::{self, InstallTarget},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -29,7 +29,7 @@ fn test() {
         Child(Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
 
     let this_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
         .join(file!())

--- a/src/generation/typescript/emitter.rs
+++ b/src/generation/typescript/emitter.rs
@@ -153,7 +153,9 @@ where
             Format::Bytes => ("bytes".into(), "bytes"),
 
             Format::Option(format) => (format!("Optional<{}>", self.quote_type(format)), "option"),
-            Format::Seq(format) => (format!("Seq<{}>", self.quote_type(format)), "seq"),
+            Format::Seq(format) | Format::Set(format) => {
+                (format!("Seq<{}>", self.quote_type(format)), "seq")
+            }
             Format::Map { key, value } => (
                 format!("Map<{},{}>", self.quote_type(key), self.quote_type(value)),
                 "map",
@@ -213,6 +215,7 @@ where
             format,
             Format::Option(_)
                 | Format::Seq(_)
+                | Format::Set(_)
                 | Format::Map { .. }
                 | Format::Tuple(_)
                 | Format::TupleArray { .. }
@@ -312,7 +315,7 @@ if (value) {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 let type_ = self.quote_type(format);
                 let item = self.quote_serialize_value("item", format, false);
                 write!(
@@ -403,7 +406,7 @@ if (!tag) {{
                 )?;
             }
 
-            Format::Seq(format) => {
+            Format::Seq(format) | Format::Set(format) => {
                 let format0 = self.quote_type(format0);
                 write!(
                     out,

--- a/src/generation/typescript/emitter.rs
+++ b/src/generation/typescript/emitter.rs
@@ -675,12 +675,12 @@ switch (index) {{",
     ) -> std::io::Result<()> {
         let fields = match format {
             ContainerFormat::UnitStruct(_doc) => Vec::new(),
-            ContainerFormat::NewTypeStruct(format) => vec![Named {
+            ContainerFormat::NewTypeStruct(format, _doc) => vec![Named {
                 name: "value".to_string(),
                 doc: Doc::new(),
                 value: format.as_ref().clone(),
             }],
-            ContainerFormat::TupleStruct(formats) => formats
+            ContainerFormat::TupleStruct(formats, _doc) => formats
                 .iter()
                 .enumerate()
                 .map(|(i, f)| Named {
@@ -690,7 +690,7 @@ switch (index) {{",
                 })
                 .collect::<Vec<_>>(),
             ContainerFormat::Struct(fields, _doc) => fields.clone(),
-            ContainerFormat::Enum(variants) => {
+            ContainerFormat::Enum(variants, _doc) => {
                 self.output_enum_container(out, name, variants)?;
                 return Ok(());
             }

--- a/src/generation/typescript/installer_tests.rs
+++ b/src/generation/typescript/installer_tests.rs
@@ -6,7 +6,7 @@ use crate::{
         module::split,
         typescript::{InstallTarget, installer::Installer},
     },
-    reflection::RegistryBuilder,
+    reflect,
 };
 
 #[test]
@@ -144,7 +144,7 @@ fn manifest_with_serde_module() {
         name: String,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
+    let registry = reflect!(MyStruct);
 
     let package_name = "my-package";
     let install_dir = tempfile::tempdir().unwrap();
@@ -184,7 +184,7 @@ fn manifest_with_namespaces() {
         child: Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Root>().build();
+    let registry = reflect!(Root);
 
     let package_name = "my-package";
     let install_dir = tempfile::tempdir().unwrap();
@@ -221,7 +221,7 @@ fn manifest_with_external_namespace_dependencies() {
         child: Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Root>().build();
+    let registry = reflect!(Root);
 
     let package_name = "my-package";
     let install_dir = tempfile::tempdir().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,22 @@ use crate::{
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub type Registry = BTreeMap<QualifiedTypeName, ContainerFormat>;
+
+#[cfg(test)]
+#[macro_export]
+macro_rules! emit {
+    ($($ty:ident),*) => {
+        {
+            use $crate::generation::indent::{IndentConfig, IndentedWriter};
+            let mut out = Vec::new();
+            let mut w = IndentedWriter::new(&mut out, IndentConfig::Space(4));
+            let registry = $crate::reflection::RegistryBuilder::new()
+                $(.add_type::<$ty>())*
+                .build();
+            for item in &registry {
+                item.write(&mut w).unwrap();
+            }
+            String::from_utf8(out).unwrap()
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,21 +18,25 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub type Registry = BTreeMap<QualifiedTypeName, ContainerFormat>;
 
-#[cfg(test)]
 #[macro_export]
 macro_rules! emit {
-    ($($ty:ident),*) => {
-        {
-            use $crate::generation::indent::{IndentConfig, IndentedWriter};
-            let mut out = Vec::new();
-            let mut w = IndentedWriter::new(&mut out, IndentConfig::Space(4));
-            let registry = $crate::reflection::RegistryBuilder::new()
-                $(.add_type::<$ty>())*
-                .build();
-            for item in &registry {
-                item.write(&mut w).unwrap();
-            }
-            String::from_utf8(out).unwrap()
+    ($($ty:ident),*) => {{
+        use $crate::generation::indent::{IndentConfig, IndentedWriter};
+        let mut out = Vec::new();
+        let mut w = IndentedWriter::new(&mut out, IndentConfig::Space(4));
+        let registry = $crate::reflect!($($ty),*);
+        for item in &registry {
+            item.write(&mut w).unwrap();
         }
-    };
+        String::from_utf8(out).unwrap()
+    }};
+}
+
+#[macro_export]
+macro_rules! reflect {
+    ($($ty:ident),*) => {{
+        $crate::reflection::RegistryBuilder::new()
+            $(.add_type::<$ty>())*
+            .build()
+    }};
 }

--- a/src/reflection/format/mod.rs
+++ b/src/reflection/format/mod.rs
@@ -170,6 +170,8 @@ pub enum Format {
     Option(Box<Format>),
     /// A sequence, e.g. the format of `Vec<Foo>`.
     Seq(Box<Format>),
+    /// A set, e.g. the format of `HashSet<Foo>`.
+    Set(Box<Format>),
     /// A map, e.g. the format of `BTreeMap<K, V>`.
     #[serde(rename_all = "UPPERCASE")]
     Map {
@@ -507,6 +509,7 @@ impl FormatHolder for Format {
 
             Self::Option(format)
             | Self::Seq(format)
+            | Self::Set(format)
             | Self::TupleArray {
                 content: format, ..
             } => {
@@ -558,6 +561,7 @@ impl FormatHolder for Format {
 
             Self::Option(format)
             | Self::Seq(format)
+            | Self::Set(format)
             | Self::TupleArray {
                 content: format, ..
             } => {

--- a/src/reflection/format/tests.rs
+++ b/src/reflection/format/tests.rs
@@ -24,6 +24,7 @@ fn test_format_visiting() {
         )]
         .into_iter()
         .collect(),
+        Doc::new(),
     );
     let mut names = HashSet::new();
     format

--- a/src/reflection/mod.rs
+++ b/src/reflection/mod.rs
@@ -898,8 +898,8 @@ impl RegistryBuilder {
         // Get the format for the element type recursively
         let element_format = get_inner_format(element_shape);
 
-        // Sets are represented as sequences in the format system
-        let set_format = Format::Seq(Box::new(element_format));
+        // Sets are represented as sets in the format system
+        let set_format = Format::Set(Box::new(element_format));
 
         // Update the current container with the set format
         self.update_container_format(set_format);
@@ -1201,6 +1201,11 @@ fn get_inner_format(shape: &Shape) -> Format {
                 value: Box::new(value_format),
             }
         }
+        Def::Set(set_def) => {
+            // Handle Set<T> -> SET: T
+            let inner_shape = set_def.t();
+            Format::Set(Box::new(get_inner_format(inner_shape)))
+        }
         Def::Array(array_def) => {
             // Handle Array<T, N> -> TUPLEARRAY: { CONTENT: T, SIZE: N }
             let inner_shape = array_def.t();
@@ -1241,11 +1246,7 @@ fn get_inner_format(shape: &Shape) -> Format {
                 Format::TypeName(name)
             }
         }
-        Def::Set(set_def) => {
-            // Handle Set<T> -> SEQ: T (sets are represented as sequences)
-            let element_shape = set_def.t();
-            Format::Seq(Box::new(get_inner_format(element_shape)))
-        }
+
         Def::Slice(slice_def) => {
             // Handle Slice<T> -> SEQ: T
             let inner_shape = slice_def.t();

--- a/src/reflection/namespace_tests.rs
+++ b/src/reflection/namespace_tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use facet::Facet;
 
-use crate::reflection::RegistryBuilder;
+use crate::reflect;
 
 #[test]
 fn nested_namespaced_structs() {
@@ -36,7 +36,7 @@ fn nested_namespaced_structs() {
         two: two::Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: GrandChild
@@ -122,7 +122,7 @@ fn nested_namespaced_enums() {
         Two(two::Child),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: GrandChild
@@ -211,7 +211,7 @@ fn nested_namespaced_renamed_structs() {
         two: two::Child,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Parent>().build();
+    let registry = reflect!(Parent);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: GrandKid
@@ -280,7 +280,7 @@ fn namespaced_collections() {
         groups: Vec<Group>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Response>().build();
+    let registry = reflect!(Response);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Response
@@ -365,7 +365,7 @@ fn namespaced_maps() {
         user_counts: HashMap<String, u32>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Database>().build();
+    let registry = reflect!(Database);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Database
@@ -446,7 +446,7 @@ fn complex_namespaced_enums() {
         events: Vec<events::Event>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<EventLog>().build();
+    let registry = reflect!(EventLog);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: EventLog
@@ -539,7 +539,7 @@ fn namespaced_transparent_structs() {
         wrapped_id: TransparentWrapper,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Container>().build();
+    let registry = reflect!(Container);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Container
@@ -593,7 +593,7 @@ fn cross_namespace_references() {
         records: Vec<Record>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<System>().build();
+    let registry = reflect!(System);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: System
@@ -669,7 +669,7 @@ fn namespace_with_byte_attributes() {
         binary: data::BinaryData,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Document>().build();
+    let registry = reflect!(Document);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Document
@@ -726,7 +726,7 @@ fn deeply_nested_namespaces() {
         deep_direct: level1::level2::DeepStruct,
     }
 
-    let registry = RegistryBuilder::new().add_type::<RootStruct>().build();
+    let registry = reflect!(RootStruct);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: RootStruct
@@ -786,7 +786,7 @@ fn transparent_struct_explicit_namespace() {
         wrapped_id: wrappers::TransparentWrapper,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Container>().build();
+    let registry = reflect!(Container);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Container
@@ -875,7 +875,7 @@ fn explicit_namespace_declarations() {
         efficient: RootGroup,
     }
 
-    let registry = RegistryBuilder::new().add_type::<RootContainer>().build();
+    let registry = reflect!(RootContainer);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: ApiContainer
@@ -1020,7 +1020,7 @@ fn collections_with_explicit_namespace() {
         nested_lists: Vec<Vec<UnnamedUser>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<UserManager>().build();
+    let registry = reflect!(UserManager);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: UnnamedRole
@@ -1116,7 +1116,7 @@ fn enums_with_explicit_namespace() {
         Empty,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Response>().build();
+    let registry = reflect!(Response);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: ErrorData
@@ -1226,7 +1226,7 @@ fn nested_structs_with_explicit_namespace() {
         inner_direct: DeepInner,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Container>().build();
+    let registry = reflect!(Container);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: DeepInner
@@ -1311,7 +1311,7 @@ fn transparent_struct_chains() {
         id: NamespacedWrapper,
     }
 
-    let registry = RegistryBuilder::new().add_type::<IdContainer>().build();
+    let registry = reflect!(IdContainer);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: CoreId
@@ -1359,7 +1359,7 @@ fn mixed_containers_with_explicit_namespace() {
         complex_map: HashMap<String, Vec<Option<Item>>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MixedContainer>().build();
+    let registry = reflect!(MixedContainer);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Item
@@ -1452,7 +1452,7 @@ fn no_namespace_pollution() {
         unnamespaced: SharedType,
     }
 
-    let registry = RegistryBuilder::new().add_type::<RootContainer>().build();
+    let registry = reflect!(RootContainer);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: RootContainer
@@ -1531,7 +1531,7 @@ fn explicit_namespace_behavior_summary() {
         direct: BaseType,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Root>().build();
+    let registry = reflect!(Root);
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: BaseType

--- a/src/reflection/namespace_tests.rs
+++ b/src/reflection/namespace_tests.rs
@@ -127,48 +127,52 @@ fn nested_namespaced_enums() {
     ? namespace: ROOT
       name: GrandChild
     : ENUM:
-        0:
-          None:
-            - UNIT
-            - []
+        - 0:
+            None:
+              - UNIT
+              - []
+        - []
     ? namespace: ROOT
       name: Parent
     : ENUM:
-        0:
-          One:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: one
-                  name: Child
-            - []
-        1:
-          Two:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: two
-                  name: Child
-            - []
+        - 0:
+            One:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: one
+                    name: Child
+              - []
+          1:
+            Two:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: two
+                    name: Child
+              - []
+        - []
     ? namespace:
         NAMED: one
       name: Child
     : ENUM:
-        0:
-          Data:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: GrandChild
-            - []
+        - 0:
+            Data:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: GrandChild
+              - []
+        - []
     ? namespace:
         NAMED: two
       name: Child
     : ENUM:
-        0:
-          Data:
-            - NEWTYPE: STR
-            - []
+        - 0:
+            Data:
+              - NEWTYPE: STR
+              - []
+        - []
     ");
 }
 
@@ -388,7 +392,9 @@ fn namespaced_maps() {
     ? namespace:
         NAMED: models
       name: UserId
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ? namespace:
         NAMED: models
       name: UserProfile
@@ -457,42 +463,43 @@ fn complex_namespaced_enums() {
         NAMED: events
       name: Event
     : ENUM:
-        0:
-          UserCreated:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: events
-                  name: UserData
-            - []
-        1:
-          UserUpdated:
-            - STRUCT:
-                - old:
-                    - TYPENAME:
-                        namespace:
-                          NAMED: events
-                        name: UserData
-                    - []
-                - new:
-                    - TYPENAME:
-                        namespace:
-                          NAMED: events
-                        name: UserData
-                    - []
-            - []
-        2:
-          SystemEvent:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: events
-                  name: SystemData
-            - []
-        3:
-          Simple:
-            - UNIT
-            - []
+        - 0:
+            UserCreated:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: events
+                    name: UserData
+              - []
+          1:
+            UserUpdated:
+              - STRUCT:
+                  - old:
+                      - TYPENAME:
+                          namespace:
+                            NAMED: events
+                          name: UserData
+                      - []
+                  - new:
+                      - TYPENAME:
+                          namespace:
+                            NAMED: events
+                          name: UserData
+                      - []
+              - []
+          2:
+            SystemEvent:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: events
+                    name: SystemData
+              - []
+          3:
+            Simple:
+              - UNIT
+              - []
+        - []
     ? namespace:
         NAMED: events
       name: SystemData
@@ -553,7 +560,9 @@ fn namespaced_transparent_structs() {
     ? namespace:
         NAMED: wrappers
       name: UserId
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ");
 }
 
@@ -790,7 +799,9 @@ fn transparent_struct_explicit_namespace() {
         - []
     ? namespace: ROOT
       name: UserId
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ");
 }
 
@@ -949,22 +960,23 @@ fn explicit_namespace_declarations() {
         NAMED: events
       name: Event
     : ENUM:
-        0:
-          UserCreated:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: events
-                  name: UserData
-            - []
-        1:
-          SystemEvent:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace:
-                    NAMED: events
-                  name: SystemData
-            - []
+        - 0:
+            UserCreated:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: events
+                    name: UserData
+              - []
+          1:
+            SystemEvent:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: events
+                    name: SystemData
+              - []
+        - []
     ? namespace:
         NAMED: events
       name: SystemData
@@ -1139,48 +1151,49 @@ fn enums_with_explicit_namespace() {
         NAMED: api
       name: Response
     : ENUM:
-        0:
-          Success:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: SuccessData
-            - []
-        1:
-          Error:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: ErrorData
-            - []
-        2:
-          Processing:
-            - STRUCT:
-                - data:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: ProcessingData
-                    - []
-                - extra:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: SuccessData
-                    - []
-            - []
-        3:
-          Multipart:
-            - TUPLE:
-                - TYPENAME:
-                    namespace: ROOT
-                    name: ErrorData
-                - TYPENAME:
+        - 0:
+            Success:
+              - NEWTYPE:
+                  TYPENAME:
                     namespace: ROOT
                     name: SuccessData
-            - []
-        4:
-          Empty:
-            - UNIT
-            - []
+              - []
+          1:
+            Error:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: ErrorData
+              - []
+          2:
+            Processing:
+              - STRUCT:
+                  - data:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: ProcessingData
+                      - []
+                  - extra:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: SuccessData
+                      - []
+              - []
+          3:
+            Multipart:
+              - TUPLE:
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: ErrorData
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: SuccessData
+              - []
+          4:
+            Empty:
+              - UNIT
+              - []
+        - []
     ");
 }
 
@@ -1302,7 +1315,9 @@ fn transparent_struct_chains() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: CoreId
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ? namespace: ROOT
       name: IdContainer
     : STRUCT:
@@ -1317,9 +1332,10 @@ fn transparent_struct_chains() {
         NAMED: identity
       name: NamespacedWrapper
     : NEWTYPESTRUCT:
-        TYPENAME:
-          namespace: ROOT
-          name: DoubleWrapperId
+        - TYPENAME:
+            namespace: ROOT
+            name: DoubleWrapperId
+        - []
     ");
 }
 

--- a/src/reflection/regression_tests/mod.rs
+++ b/src/reflection/regression_tests/mod.rs
@@ -11,7 +11,10 @@ use crate::reflection::format::{ContainerFormat, Format, VariantFormat};
 
 #[cfg(test)]
 mod tests {
-    use crate::reflection::format::{Doc, Namespace, QualifiedTypeName};
+    use crate::{
+        reflect,
+        reflection::format::{Doc, Namespace, QualifiedTypeName},
+    };
 
     use super::*;
     use facet::Facet;
@@ -34,12 +37,8 @@ mod tests {
             Regular(u32),
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<WithSets>();
-        let builder = builder.add_type::<EnumWithSet>();
-
         // This should complete successfully - no more panics on Set types
-        let registry = builder.build();
+        let registry = reflect!(WithSets, EnumWithSet);
         assert!(!registry.is_empty());
     }
 
@@ -53,11 +52,8 @@ mod tests {
             optional_set: Option<std::collections::HashSet<u64>>,
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<NestedSets>();
-
         // All Variable placeholders should be resolved correctly
-        let registry = builder.build();
+        let registry = reflect!(NestedSets);
         assert!(!registry.is_empty());
     }
 
@@ -70,11 +66,8 @@ mod tests {
             field: u32,
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<SimpleStruct>();
-
         // This should work fine - all Variables should be resolved
-        let registry = builder.build();
+        let registry = reflect!(SimpleStruct);
         assert!(!registry.is_empty());
 
         // Verify the type was processed correctly
@@ -113,12 +106,9 @@ mod tests {
             Variant(std::collections::BTreeSet<String>),
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<WithNewtypeVariant>();
-
         // The temp container workflow in process_newtype_variant_with_temp_container
         // should now properly resolve all Variables
-        let registry = builder.build();
+        let registry = reflect!(WithNewtypeVariant);
         assert!(!registry.is_empty());
     }
 
@@ -152,12 +142,8 @@ mod tests {
             Regular(u32),
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<Complex>();
-        let builder = builder.add_type::<ComplexEnum>();
-
         // All of these previously problematic patterns should now work
-        let registry = builder.build();
+        let registry = reflect!(Complex, ComplexEnum);
         assert!(!registry.is_empty());
 
         // Should have processed both types
@@ -258,11 +244,8 @@ mod tests {
             Other(u32),
         }
 
-        let builder = RegistryBuilder::new();
-        let builder = builder.add_type::<MyEnum>();
-
         // This used to panic, now it should work
-        let registry = builder.build();
+        let registry = reflect!(MyEnum);
         assert!(!registry.is_empty());
 
         // Should contain the enum type
@@ -312,6 +295,6 @@ mod tests {
             Variant2 { result: MyResult<i32> },
         }
 
-        let _registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+        let _registry = reflect!(MyEnum);
     }
 }

--- a/src/reflection/regression_tests/mod.rs
+++ b/src/reflection/regression_tests/mod.rs
@@ -11,7 +11,7 @@ use crate::reflection::format::{ContainerFormat, Format, VariantFormat};
 
 #[cfg(test)]
 mod tests {
-    use crate::reflection::format::Doc;
+    use crate::reflection::format::{Doc, Namespace, QualifiedTypeName};
 
     use super::*;
     use facet::Facet;
@@ -78,8 +78,8 @@ mod tests {
         assert!(!registry.is_empty());
 
         // Verify the type was processed correctly
-        let type_name = crate::reflection::format::QualifiedTypeName {
-            namespace: crate::reflection::format::Namespace::Root,
+        let type_name = QualifiedTypeName {
+            namespace: Namespace::Root,
             name: "SimpleStruct".to_string(),
         };
         assert!(registry.contains_key(&type_name));
@@ -178,12 +178,12 @@ mod tests {
         let mut builder = RegistryBuilder::new();
 
         // Manually insert an unresolved Variable (simulating the old bug)
-        let type_name = crate::reflection::format::QualifiedTypeName {
-            namespace: crate::reflection::format::Namespace::Named("test".to_string()),
+        let type_name = QualifiedTypeName {
+            namespace: Namespace::Named("test".to_string()),
             name: "UnresolvedType".to_string(),
         };
 
-        let unresolved_container = ContainerFormat::NewTypeStruct(Box::default());
+        let unresolved_container = ContainerFormat::NewTypeStruct(Box::default(), Doc::new());
         builder.registry.insert(type_name, unresolved_container);
 
         // This should still panic - the safety check works
@@ -207,9 +207,9 @@ mod tests {
             },
         );
 
-        let enum_container = ContainerFormat::Enum(variants);
-        let type_name = crate::reflection::format::QualifiedTypeName {
-            namespace: crate::reflection::format::Namespace::Named("test".to_string()),
+        let enum_container = ContainerFormat::Enum(variants, Doc::new());
+        let type_name = QualifiedTypeName {
+            namespace: Namespace::Named("test".to_string()),
             name: "EnumWithUnresolvedVariant".to_string(),
         };
 
@@ -233,8 +233,8 @@ mod tests {
         }];
 
         let struct_container = ContainerFormat::Struct(fields, Doc::new());
-        let type_name = crate::reflection::format::QualifiedTypeName {
-            namespace: crate::reflection::format::Namespace::Named("test".to_string()),
+        let type_name = QualifiedTypeName {
+            namespace: Namespace::Named("test".to_string()),
             name: "StructWithUnresolvedField".to_string(),
         };
 
@@ -266,8 +266,8 @@ mod tests {
         assert!(!registry.is_empty());
 
         // Should contain the enum type
-        let type_name = crate::reflection::format::QualifiedTypeName {
-            namespace: crate::reflection::format::Namespace::Root,
+        let type_name = QualifiedTypeName {
+            namespace: Namespace::Root,
             name: "MyEnum".to_string(),
         };
         assert!(registry.contains_key(&type_name));

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -44,7 +44,9 @@ fn newtype_bool() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: BOOL
+    : NEWTYPESTRUCT:
+        - BOOL
+        - []
     ");
 }
 
@@ -57,7 +59,9 @@ fn newtype_unit() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: UNIT
+    : NEWTYPESTRUCT:
+        - UNIT
+        - []
     ");
 }
 
@@ -70,7 +74,9 @@ fn newtype_static_str() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ");
 }
 
@@ -83,7 +89,9 @@ fn newtype_u8() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: U8
+    : NEWTYPESTRUCT:
+        - U8
+        - []
     ");
 }
 
@@ -96,7 +104,9 @@ fn newtype_u16() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: U16
+    : NEWTYPESTRUCT:
+        - U16
+        - []
     ");
 }
 
@@ -109,7 +119,9 @@ fn newtype_u32() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: U32
+    : NEWTYPESTRUCT:
+        - U32
+        - []
     ");
 }
 
@@ -122,7 +134,9 @@ fn newtype_u64() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: U64
+    : NEWTYPESTRUCT:
+        - U64
+        - []
     ");
 }
 
@@ -135,7 +149,9 @@ fn newtype_u128() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: U128
+    : NEWTYPESTRUCT:
+        - U128
+        - []
     ");
 }
 
@@ -148,7 +164,9 @@ fn newtype_i8() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: I8
+    : NEWTYPESTRUCT:
+        - I8
+        - []
     ");
 }
 
@@ -161,7 +179,9 @@ fn newtype_i16() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: I16
+    : NEWTYPESTRUCT:
+        - I16
+        - []
     ");
 }
 
@@ -174,7 +194,9 @@ fn newtype_i32() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ");
 }
 
@@ -187,7 +209,9 @@ fn newtype_i64() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: I64
+    : NEWTYPESTRUCT:
+        - I64
+        - []
     ");
 }
 
@@ -200,7 +224,9 @@ fn newtype_i128() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: I128
+    : NEWTYPESTRUCT:
+        - I128
+        - []
     ");
 }
 
@@ -213,7 +239,9 @@ fn newtype_f32() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: F32
+    : NEWTYPESTRUCT:
+        - F32
+        - []
     ");
 }
 
@@ -226,7 +254,9 @@ fn newtype_f64() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: F64
+    : NEWTYPESTRUCT:
+        - F64
+        - []
     ");
 }
 
@@ -239,7 +269,9 @@ fn newtype_char() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: CHAR
+    : NEWTYPESTRUCT:
+        - CHAR
+        - []
     ");
 }
 
@@ -255,13 +287,16 @@ fn nested_newtype() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        TYPENAME:
-          namespace: ROOT
-          name: Inner
+        - TYPENAME:
+            namespace: ROOT
+            name: Inner
+        - []
     ");
 }
 
@@ -275,7 +310,8 @@ fn newtype_with_list() {
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ: I32
+        - SEQ: I32
+        - []
     ");
 }
 
@@ -291,14 +327,17 @@ fn newtype_with_list_of_named_type() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ:
-          TYPENAME:
-            namespace: ROOT
-            name: Inner
+        - SEQ:
+            TYPENAME:
+              namespace: ROOT
+              name: Inner
+        - []
     ");
 }
 
@@ -312,8 +351,9 @@ fn newtype_with_nested_list() {
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ:
-          SEQ: I32
+        - SEQ:
+            SEQ: I32
+        - []
     ");
 }
 
@@ -329,15 +369,18 @@ fn newtype_with_nested_list_of_named_type() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ:
-          SEQ:
-            TYPENAME:
-              namespace: ROOT
-              name: Inner
+        - SEQ:
+            SEQ:
+              TYPENAME:
+                namespace: ROOT
+                name: Inner
+        - []
     ");
 }
 
@@ -353,16 +396,19 @@ fn newtype_with_triple_nested_list_of_named_type() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ:
-          SEQ:
+        - SEQ:
             SEQ:
-              TYPENAME:
-                namespace: ROOT
-                name: Inner
+              SEQ:
+                TYPENAME:
+                  namespace: ROOT
+                  name: Inner
+        - []
     ");
 }
 
@@ -376,9 +422,10 @@ fn newtype_with_tuple_array() {
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        TUPLEARRAY:
-          CONTENT: I32
-          SIZE: 3
+        - TUPLEARRAY:
+            CONTENT: I32
+            SIZE: 3
+        - []
     ");
 }
 
@@ -392,9 +439,10 @@ fn tuple_struct() {
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
-        - U8
-        - I32
-        - BOOL
+        - - U8
+          - I32
+          - BOOL
+        - []
     ");
 }
 
@@ -408,9 +456,10 @@ fn tuple_struct_with_unit() {
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
-        - U8
-        - UNIT
-        - I32
+        - - U8
+          - UNIT
+          - I32
+        - []
     ");
 }
 
@@ -488,7 +537,9 @@ fn option_of_list_of_named_type() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -537,7 +588,9 @@ fn list_of_options_of_named_type() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -585,14 +638,17 @@ fn nested_tuple_struct_1() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
-        - TYPENAME:
-            namespace: ROOT
-            name: Inner
-        - U8
+        - - TYPENAME:
+              namespace: ROOT
+              name: Inner
+          - U8
+        - []
     ");
 }
 
@@ -609,17 +665,19 @@ fn nested_tuple_struct_2() {
     ? namespace: ROOT
       name: Inner
     : TUPLESTRUCT:
-        - I32
-        - U8
-        - BOOL
+        - - I32
+          - U8
+          - BOOL
+        - []
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
-        - I32
-        - TYPENAME:
-            namespace: ROOT
-            name: Inner
-        - U8
+        - - I32
+          - TYPENAME:
+              namespace: ROOT
+              name: Inner
+          - U8
+        - []
     ");
 }
 
@@ -874,12 +932,15 @@ fn struct_with_fields_of_newtypes_and_tuple_structs() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner1
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: Inner2
     : TUPLESTRUCT:
-        - I8
-        - U32
+        - - I8
+          - U32
+        - []
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -912,14 +973,15 @@ fn enum_with_unit_variants() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - UNIT
-            - []
-        1:
-          Variant2:
-            - UNIT
-            - []
+        - 0:
+            Variant1:
+              - UNIT
+              - []
+          1:
+            Variant2:
+              - UNIT
+              - []
+        - []
     ");
 }
 
@@ -943,34 +1005,35 @@ fn enum_with_newtype_variants() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - NEWTYPE: U8
-            - []
-        1:
-          Variant2:
-            - NEWTYPE: I32
-            - []
-        2:
-          Variant3:
-            - NEWTYPE: F64
-            - []
-        3:
-          Variant4:
-            - NEWTYPE: CHAR
-            - []
-        4:
-          Variant5:
-            - NEWTYPE: STR
-            - []
-        5:
-          Variant6:
-            - NEWTYPE: BOOL
-            - []
-        6:
-          Variant7:
-            - NEWTYPE: UNIT
-            - []
+        - 0:
+            Variant1:
+              - NEWTYPE: U8
+              - []
+          1:
+            Variant2:
+              - NEWTYPE: I32
+              - []
+          2:
+            Variant3:
+              - NEWTYPE: F64
+              - []
+          3:
+            Variant4:
+              - NEWTYPE: CHAR
+              - []
+          4:
+            Variant5:
+              - NEWTYPE: STR
+              - []
+          5:
+            Variant6:
+              - NEWTYPE: BOOL
+              - []
+          6:
+            Variant7:
+              - NEWTYPE: UNIT
+              - []
+        - []
     ");
 }
 
@@ -991,21 +1054,24 @@ fn enum_with_newtype_variants_containing_user_defined_types() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: Inner
-            - []
-        1:
-          Variant2:
-            - NEWTYPE: U8
-            - []
+        - 0:
+            Variant1:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Inner
+              - []
+          1:
+            Variant2:
+              - NEWTYPE: U8
+              - []
+        - []
     ");
 }
 
@@ -1024,23 +1090,24 @@ fn enum_with_tuple_struct_variants() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - TUPLE:
-                - U8
-                - I32
-                - F64
-                - CHAR
-                - STR
-                - BOOL
-                - UNIT
-            - []
-        1:
-          Variant2:
-            - TUPLE:
-                - I8
-                - U32
-            - []
+        - 0:
+            Variant1:
+              - TUPLE:
+                  - U8
+                  - I32
+                  - F64
+                  - CHAR
+                  - STR
+                  - BOOL
+                  - UNIT
+              - []
+          1:
+            Variant2:
+              - TUPLE:
+                  - I8
+                  - U32
+              - []
+        - []
     ");
 }
 
@@ -1061,26 +1128,29 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - TUPLE:
-                - TYPENAME:
-                    namespace: ROOT
-                    name: Inner
-                - U8
-            - []
-        1:
-          Variant2:
-            - TUPLE:
-                - I8
-                - TYPENAME:
-                    namespace: ROOT
-                    name: Inner
-            - []
+        - 0:
+            Variant1:
+              - TUPLE:
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: Inner
+                  - U8
+              - []
+          1:
+            Variant2:
+              - TUPLE:
+                  - I8
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: Inner
+              - []
+        - []
     ");
 }
 
@@ -1110,28 +1180,29 @@ fn enum_with_inline_struct_variants() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - STRUCT:
-                - a:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: Inner
-                    - []
-                - b:
-                    - U8
-                    - []
-                - c:
-                    - BOOL
-                    - []
-            - []
-        1:
-          Variant2:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: Inner
-            - []
+        - 0:
+            Variant1:
+              - STRUCT:
+                  - a:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: Inner
+                      - []
+                  - b:
+                      - U8
+                      - []
+                  - c:
+                      - BOOL
+                      - []
+              - []
+          1:
+            Variant2:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Inner
+              - []
+        - []
     ");
 }
 
@@ -1163,49 +1234,52 @@ fn enum_with_struct_variants_mixed_types() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: Inner
-    : NEWTYPESTRUCT: I32
+    : NEWTYPESTRUCT:
+        - I32
+        - []
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - STRUCT:
-                - a:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: Inner
-                    - []
-                - b:
-                    - U8
-                    - []
-                - c:
-                    - F32
-                    - []
-                - d:
-                    - STR
-                    - []
-                - e:
-                    - CHAR
-                    - []
-                - f:
-                    - BOOL
-                    - []
-                - g:
-                    - UNIT
-                    - []
-            - []
-        1:
-          Variant2:
-            - STRUCT:
-                - x:
-                    - I32
-                    - []
-                - y:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: Inner
-                    - []
-            - []
+        - 0:
+            Variant1:
+              - STRUCT:
+                  - a:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: Inner
+                      - []
+                  - b:
+                      - U8
+                      - []
+                  - c:
+                      - F32
+                      - []
+                  - d:
+                      - STR
+                      - []
+                  - e:
+                      - CHAR
+                      - []
+                  - f:
+                      - BOOL
+                      - []
+                  - g:
+                      - UNIT
+                      - []
+              - []
+          1:
+            Variant2:
+              - STRUCT:
+                  - x:
+                      - I32
+                      - []
+                  - y:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: Inner
+                      - []
+              - []
+        - []
     ");
 }
 
@@ -1225,21 +1299,22 @@ fn enum_with_struct_variant() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          A:
-            - UNIT
-            - []
-        1:
-          B:
-            - NEWTYPE: U64
-            - []
-        2:
-          C:
-            - STRUCT:
-                - x:
-                    - U8
-                    - []
-            - []
+        - 0:
+            A:
+              - UNIT
+              - []
+          1:
+            B:
+              - NEWTYPE: U64
+              - []
+          2:
+            C:
+              - STRUCT:
+                  - x:
+                      - U8
+                      - []
+              - []
+        - []
     ");
 }
 
@@ -1278,8 +1353,9 @@ fn tuple_struct_with_skip_serializing() {
     ? namespace: ROOT
       name: MyStruct
     : TUPLESTRUCT:
-        - U8
-        - U32
+        - - U8
+          - U32
+        - []
     ");
 }
 
@@ -1300,14 +1376,15 @@ fn enum_with_skip_serializing() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Variant1:
-            - UNIT
-            - []
-        1:
-          Variant3:
-            - UNIT
-            - []
+        - 0:
+            Variant1:
+              - UNIT
+              - []
+          1:
+            Variant3:
+              - UNIT
+              - []
+        - []
     ");
 }
 
@@ -1348,13 +1425,14 @@ fn map_of_string_and_bool() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Map:
-            - NEWTYPE:
-                MAP:
-                  KEY: STR
-                  VALUE: BOOL
-            - []
+        - 0:
+            Map:
+              - NEWTYPE:
+                  MAP:
+                    KEY: STR
+                    VALUE: BOOL
+              - []
+        - []
     ");
 }
 
@@ -1372,11 +1450,12 @@ fn set_of_string() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          Set:
-            - NEWTYPE:
-                SEQ: STR
-            - []
+        - 0:
+            Set:
+              - NEWTYPE:
+                  SEQ: STR
+              - []
+        - []
     ");
 }
 
@@ -1516,7 +1595,9 @@ fn map_with_user_defined_types() {
         - []
     ? namespace: ROOT
       name: UserId
-    : NEWTYPESTRUCT: U32
+    : NEWTYPESTRUCT:
+        - U32
+        - []
     ? namespace: ROOT
       name: UserProfile
     : STRUCT:
@@ -1545,20 +1626,21 @@ fn complex_map() {
     ? namespace: ROOT
       name: ComplexMap
     : ENUM:
-        0:
-          Map:
-            - NEWTYPE:
-                MAP:
-                  KEY:
-                    TUPLE:
-                      - TUPLEARRAY:
-                          CONTENT: U32
-                          SIZE: 2
-                      - TUPLEARRAY:
-                          CONTENT: U8
-                          SIZE: 4
-                  VALUE: UNIT
-            - []
+        - 0:
+            Map:
+              - NEWTYPE:
+                  MAP:
+                    KEY:
+                      TUPLE:
+                        - TUPLEARRAY:
+                            CONTENT: U32
+                            SIZE: 2
+                        - TUPLEARRAY:
+                            CONTENT: U8
+                            SIZE: 4
+                    VALUE: UNIT
+              - []
+        - []
     ");
 }
 
@@ -1682,18 +1764,19 @@ fn own_result_enum() {
     ? namespace: ROOT
       name: HttpError
     : ENUM:
-        0:
-          Url:
-            - NEWTYPE: STR
-            - []
-        1:
-          Io:
-            - NEWTYPE: STR
-            - []
-        2:
-          Timeout:
-            - UNIT
-            - []
+        - 0:
+            Url:
+              - NEWTYPE: STR
+              - []
+          1:
+            Io:
+              - NEWTYPE: STR
+              - []
+          2:
+            Timeout:
+              - UNIT
+              - []
+        - []
     ? namespace: ROOT
       name: HttpHeader
     : STRUCT:
@@ -1723,20 +1806,21 @@ fn own_result_enum() {
     ? namespace: ROOT
       name: HttpResult
     : ENUM:
-        0:
-          Ok:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: HttpResponse
-            - []
-        1:
-          Err:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: HttpError
-            - []
+        - 0:
+            Ok:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: HttpResponse
+              - []
+          1:
+            Err:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: HttpError
+              - []
+        - []
     ");
 }
 
@@ -1780,14 +1864,15 @@ fn enum_rename() {
     ? namespace: ROOT
       name: Effect
     : ENUM:
-        0:
-          One:
-            - UNIT
-            - []
-        1:
-          Two:
-            - UNIT
-            - []
+        - 0:
+            One:
+              - UNIT
+              - []
+          1:
+            Two:
+              - UNIT
+              - []
+        - []
     ");
 }
 
@@ -1849,6 +1934,9 @@ fn self_referencing_type() {
                         name: "SimpleList",
                     },
                 ),
+            ),
+            Doc(
+                [],
             ),
         ),
     }
@@ -1944,6 +2032,9 @@ fn tree_struct_with_mutual_recursion() {
                     ),
                 },
             },
+            Doc(
+                [],
+            ),
         ),
         QualifiedTypeName {
             namespace: Root,
@@ -2045,6 +2136,9 @@ fn tree_enum_with_mutual_recursion() {
                     ),
                 },
             },
+            Doc(
+                [],
+            ),
         ),
     }
     "#);
@@ -2061,7 +2155,9 @@ fn newtype_str_ref() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ");
 }
 
@@ -2094,7 +2190,8 @@ fn newtype_slice_ref() {
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        SEQ: U8
+        - SEQ: U8
+        - []
     ");
 }
 
@@ -2126,7 +2223,9 @@ fn newtype_mut_ref() {
     insta::assert_yaml_snapshot!(registry, @r"
     ? namespace: ROOT
       name: MyNewType
-    : NEWTYPESTRUCT: STR
+    : NEWTYPESTRUCT:
+        - STR
+        - []
     ");
 }
 
@@ -2171,9 +2270,10 @@ fn newtype_struct_ref() {
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
-        TYPENAME:
-          namespace: ROOT
-          name: Inner
+        - TYPENAME:
+            namespace: ROOT
+            name: Inner
+        - []
     ");
 }
 
@@ -2238,22 +2338,23 @@ fn enum_with_ref_variants() {
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
-        0:
-          StrRef:
-            - NEWTYPE: STR
-            - []
-        1:
-          SliceRef:
-            - NEWTYPE:
-                SEQ: U8
-            - []
-        2:
-          StructRef:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: Inner
-            - []
+        - 0:
+            StrRef:
+              - NEWTYPE: STR
+              - []
+          1:
+            SliceRef:
+              - NEWTYPE:
+                  SEQ: U8
+              - []
+          2:
+            StructRef:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Inner
+              - []
+        - []
     ");
 }
 
@@ -2314,9 +2415,10 @@ fn tuple_struct_with_multiple_refs() {
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
-        - STR
-        - SEQ: U8
-        - I32
+        - - STR
+          - SEQ: U8
+          - I32
+        - []
     ");
 }
 

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -1393,7 +1393,7 @@ fn set_of_string() {
         - 0:
             Set:
               - NEWTYPE:
-                  SEQ: STR
+                  SET: STR
               - []
         - []
     ");
@@ -1466,7 +1466,7 @@ fn sequence_and_map_types() {
                   VALUE: STR
               - []
           - hash_set:
-              - SEQ: STR
+              - SET: STR
               - []
           - btree_map:
               - MAP:
@@ -1474,7 +1474,7 @@ fn sequence_and_map_types() {
                   VALUE: STR
               - []
           - btree_set:
-              - SEQ: STR
+              - SET: STR
               - []
         - []
     ");

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -4,14 +4,14 @@ use std::{
 };
 
 use super::*;
+use crate::reflect;
 
 #[test]
 fn unit_struct() {
     #[derive(Facet)]
     struct MyUnitStruct;
 
-    let registry = RegistryBuilder::new().add_type::<MyUnitStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyUnitStruct), @r"
     ? namespace: ROOT
       name: MyUnitStruct
     : UNITSTRUCT: []
@@ -25,8 +25,7 @@ fn unit_struct_with_doc() {
     #[derive(Facet)]
     struct MyUnitStruct;
 
-    let registry = RegistryBuilder::new().add_type::<MyUnitStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyUnitStruct), @r"
     ? namespace: ROOT
       name: MyUnitStruct
     : UNITSTRUCT:
@@ -40,8 +39,7 @@ fn newtype_bool() {
     #[derive(Facet)]
     struct MyNewType(bool);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -55,8 +53,7 @@ fn newtype_unit() {
     #[derive(Facet)]
     struct MyNewType(());
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -70,8 +67,7 @@ fn newtype_static_str() {
     #[derive(Facet)]
     struct MyNewType(&'static str);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -85,8 +81,7 @@ fn newtype_u8() {
     #[derive(Facet)]
     struct MyNewType(u8);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -100,8 +95,7 @@ fn newtype_u16() {
     #[derive(Facet)]
     struct MyNewType(u16);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -115,8 +109,7 @@ fn newtype_u32() {
     #[derive(Facet)]
     struct MyNewType(u32);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -130,8 +123,7 @@ fn newtype_u64() {
     #[derive(Facet)]
     struct MyNewType(u64);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -145,8 +137,7 @@ fn newtype_u128() {
     #[derive(Facet)]
     struct MyNewType(u128);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -160,8 +151,7 @@ fn newtype_i8() {
     #[derive(Facet)]
     struct MyNewType(i8);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -175,8 +165,7 @@ fn newtype_i16() {
     #[derive(Facet)]
     struct MyNewType(i16);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -190,8 +179,7 @@ fn newtype_i32() {
     #[derive(Facet)]
     struct MyNewType(i32);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -205,8 +193,7 @@ fn newtype_i64() {
     #[derive(Facet)]
     struct MyNewType(i64);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -220,8 +207,7 @@ fn newtype_i128() {
     #[derive(Facet)]
     struct MyNewType(i128);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -235,8 +221,7 @@ fn newtype_f32() {
     #[derive(Facet)]
     struct MyNewType(f32);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -250,8 +235,7 @@ fn newtype_f64() {
     #[derive(Facet)]
     struct MyNewType(f64);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -265,8 +249,7 @@ fn newtype_char() {
     #[derive(Facet)]
     struct MyNewType(char);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -283,8 +266,7 @@ fn nested_newtype() {
     #[derive(Facet)]
     struct MyNewType(Inner);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -305,8 +287,7 @@ fn newtype_with_list() {
     #[derive(Facet)]
     struct MyNewType(Vec<i32>);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -323,8 +304,7 @@ fn newtype_with_list_of_named_type() {
     #[derive(Facet)]
     struct MyNewType(Vec<Inner>);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -346,8 +326,7 @@ fn newtype_with_nested_list() {
     #[derive(Facet)]
     struct MyNewType(Vec<Vec<i32>>);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -365,8 +344,7 @@ fn newtype_with_nested_list_of_named_type() {
     #[derive(Facet)]
     struct MyNewType(Vec<Vec<Inner>>);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -392,8 +370,7 @@ fn newtype_with_triple_nested_list_of_named_type() {
     #[derive(Facet)]
     struct MyNewType(Vec<Vec<Vec<Inner>>>);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -417,8 +394,7 @@ fn newtype_with_tuple_array() {
     #[derive(Facet)]
     struct MyNewType([i32; 3]);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -434,8 +410,7 @@ fn tuple_struct() {
     #[derive(Facet)]
     struct MyTupleStruct(u8, i32, bool);
 
-    let registry = RegistryBuilder::new().add_type::<MyTupleStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyTupleStruct), @r"
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
@@ -451,8 +426,7 @@ fn tuple_struct_with_unit() {
     #[derive(Facet)]
     struct MyTupleStruct(u8, (), i32);
 
-    let registry = RegistryBuilder::new().add_type::<MyTupleStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyTupleStruct), @r"
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
@@ -470,8 +444,7 @@ fn option_of_unit() {
         a: Option<()>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -489,8 +462,7 @@ fn option_of_list() {
         a: Option<Vec<i32>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -509,8 +481,7 @@ fn option_of_nested_list() {
         a: Option<Vec<Vec<i32>>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -533,8 +504,7 @@ fn option_of_list_of_named_type() {
         a: Option<Vec<Inner>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -561,8 +531,7 @@ fn list_of_options() {
         a: Vec<Option<i32>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -584,8 +553,7 @@ fn list_of_options_of_named_type() {
         a: Vec<Option<Inner>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -612,8 +580,7 @@ fn nested_list_with_options() {
         a: Vec<Vec<Option<i32>>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -634,8 +601,7 @@ fn nested_tuple_struct_1() {
     #[derive(Facet)]
     struct MyTupleStruct(Inner, u8);
 
-    let registry = RegistryBuilder::new().add_type::<MyTupleStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyTupleStruct), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -660,8 +626,7 @@ fn nested_tuple_struct_2() {
     #[derive(Facet)]
     struct MyTupleStruct(i32, Inner, u8);
 
-    let registry = RegistryBuilder::new().add_type::<MyTupleStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyTupleStruct), @r"
     ? namespace: ROOT
       name: Inner
     : TUPLESTRUCT:
@@ -690,8 +655,7 @@ fn struct_with_doc() {
         a: u8,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -711,8 +675,7 @@ fn struct_with_field_doc() {
         a: u8,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -730,8 +693,7 @@ fn struct_with_static_str() {
         a: &'static str,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -749,8 +711,7 @@ fn struct_with_vec_of_u8() {
         a: Vec<u8>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -769,8 +730,7 @@ fn struct_with_vec_of_u8_to_bytes() {
         a: Vec<u8>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -788,8 +748,7 @@ fn struct_with_slice_of_u8() {
         a: &'a [u8],
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -808,8 +767,7 @@ fn struct_with_slice_of_u8_to_bytes() {
         a: &'a [u8],
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -830,8 +788,7 @@ fn struct_with_scalar_fields() {
         d: (),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -858,8 +815,7 @@ fn struct_with_tuple_field() {
         a: (u8, i32),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -886,8 +842,7 @@ fn struct_with_option_fields() {
         b: Option<u8>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: Inner
     : STRUCT:
@@ -928,8 +883,7 @@ fn struct_with_fields_of_newtypes_and_tuple_structs() {
         b: Inner2,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: Inner1
     : NEWTYPESTRUCT:
@@ -968,8 +922,7 @@ fn enum_with_unit_variants() {
         Variant2,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1000,8 +953,7 @@ fn enum_with_newtype_variants() {
         Variant7(()),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1050,8 +1002,7 @@ fn enum_with_newtype_variants_containing_user_defined_types() {
         Variant2(u8),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -1085,8 +1036,7 @@ fn enum_with_tuple_struct_variants() {
         Variant2(i8, u32),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1124,8 +1074,7 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
         Variant2(i8, Inner),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -1168,8 +1117,7 @@ fn enum_with_inline_struct_variants() {
         Variant2(Inner),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: Inner
     : STRUCT:
@@ -1230,8 +1178,7 @@ fn enum_with_struct_variants_mixed_types() {
         },
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: Inner
     : NEWTYPESTRUCT:
@@ -1294,8 +1241,7 @@ fn enum_with_struct_variant() {
         C { x: u8 },
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1328,8 +1274,7 @@ fn struct_with_skip_serializing() {
         c: u8,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1348,8 +1293,7 @@ fn tuple_struct_with_skip_serializing() {
     #[derive(Facet)]
     struct MyStruct(u8, #[facet(skip)] u16, u32);
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : TUPLESTRUCT:
@@ -1371,8 +1315,7 @@ fn enum_with_skip_serializing() {
         Variant3,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1399,8 +1342,7 @@ fn transparent() {
         inner: Inner,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1420,8 +1362,7 @@ fn map_of_string_and_bool() {
         Map(BTreeMap<String, bool>),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1445,8 +1386,7 @@ fn set_of_string() {
         Set(BTreeSet<String>),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: MyEnum
     : ENUM:
@@ -1483,13 +1423,8 @@ fn test_fixed_issues() {
         optional_set: Option<std::collections::HashSet<u64>>,
     }
 
-    let builder = RegistryBuilder::new();
-    let builder = builder.add_type::<WithSet>();
-    let builder = builder.add_type::<EnumWithSet>();
-    let builder = builder.add_type::<ComplexNested>();
-
     // This should not panic - all Variable placeholders should be resolved
-    let registry = builder.build();
+    let registry = reflect!(WithSet, EnumWithSet, ComplexNested);
 
     // Verify all types were processed
     assert!(!registry.is_empty());
@@ -1518,8 +1453,7 @@ fn sequence_and_map_types() {
         btree_set: BTreeSet<String>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(&registry, @r"
+    insta::assert_yaml_snapshot!(&reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1564,8 +1498,7 @@ fn map_with_user_defined_types() {
         nested_map: BTreeMap<String, Option<u64>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1621,8 +1554,7 @@ fn complex_map() {
         Map(BTreeMap<([u32; 2], [u8; 4]), ()>),
     }
 
-    let registry = RegistryBuilder::new().add_type::<ComplexMap>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(ComplexMap), @r"
     ? namespace: ROOT
       name: ComplexMap
     : ENUM:
@@ -1657,8 +1589,7 @@ fn struct_with_box_of_t() {
         boxed: Box<UserProfile>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1694,8 +1625,7 @@ fn struct_with_arc_of_t() {
         boxed: Arc<UserProfile>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -1759,8 +1689,7 @@ fn own_result_enum() {
         Timeout,
     }
 
-    let registry = RegistryBuilder::new().add_type::<HttpResult>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(HttpResult), @r"
     ? namespace: ROOT
       name: HttpError
     : ENUM:
@@ -1833,8 +1762,7 @@ fn struct_rename() {
         active: bool,
     }
 
-    let registry = RegistryBuilder::new().add_type::<EffectFfi>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(EffectFfi), @r"
     ? namespace: ROOT
       name: Effect
     : STRUCT:
@@ -1859,8 +1787,7 @@ fn enum_rename() {
         Two,
     }
 
-    let registry = RegistryBuilder::new().add_type::<EffectFfi>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(EffectFfi), @r"
     ? namespace: ROOT
       name: Effect
     : ENUM:
@@ -1890,8 +1817,7 @@ fn struct_rename_with_named_type() {
         effect: EffectFfi,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Request>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(Request), @r"
     ? namespace: ROOT
       name: Effect
     : STRUCT:
@@ -1919,9 +1845,7 @@ fn self_referencing_type() {
     #[derive(Facet)]
     struct SimpleList(Option<Box<SimpleList>>);
 
-    let registry = RegistryBuilder::new().add_type::<SimpleList>().build();
-
-    insta::assert_debug_snapshot!(registry, @r#"
+    insta::assert_debug_snapshot!(reflect!(SimpleList), @r#"
     {
         QualifiedTypeName {
             namespace: Root,
@@ -1952,9 +1876,7 @@ fn complex_self_referencing_type() {
         children: Option<Vec<Box<Node>>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Node>().build();
-
-    insta::assert_debug_snapshot!(registry, @r#"
+    insta::assert_debug_snapshot!(reflect!(Node), @r#"
     {
         QualifiedTypeName {
             namespace: Root,
@@ -2008,9 +1930,7 @@ fn tree_struct_with_mutual_recursion() {
         TreeWithMutualRecursion(Tree<Box<Test>>),
     }
 
-    let registry = RegistryBuilder::new().add_type::<Test>().build();
-
-    insta::assert_debug_snapshot!(registry, @r#"
+    insta::assert_debug_snapshot!(reflect!(Test), @r#"
     {
         QualifiedTypeName {
             namespace: Root,
@@ -2090,9 +2010,7 @@ fn tree_enum_with_mutual_recursion() {
         tree_with_mutual_recursion: Tree<Box<Test>>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<Test>().build();
-
-    insta::assert_debug_snapshot!(registry, @r#"
+    insta::assert_debug_snapshot!(reflect!(Test), @r#"
     {
         QualifiedTypeName {
             namespace: Root,
@@ -2151,8 +2069,7 @@ fn newtype_str_ref() {
     #[derive(Facet)]
     struct MyNewType<'a>(&'a str);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -2168,8 +2085,7 @@ fn struct_with_str_ref() {
         a: &'a str,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -2185,8 +2101,7 @@ fn newtype_slice_ref() {
     #[derive(Facet)]
     struct MyNewType<'a>(&'a [u8]);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -2202,8 +2117,7 @@ fn struct_with_slice_ref() {
         a: &'a [u8],
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -2219,8 +2133,7 @@ fn newtype_mut_ref() {
     #[derive(Facet)]
     struct MyNewType<'a>(&'a mut str);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: MyNewType
     : NEWTYPESTRUCT:
@@ -2236,8 +2149,7 @@ fn struct_with_mut_ref() {
         a: &'a mut [u8],
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -2258,8 +2170,7 @@ fn newtype_struct_ref() {
     #[derive(Facet)]
     struct MyNewType<'a>(&'a Inner);
 
-    let registry = RegistryBuilder::new().add_type::<MyNewType>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyNewType), @r"
     ? namespace: ROOT
       name: Inner
     : STRUCT:
@@ -2289,8 +2200,7 @@ fn struct_with_struct_ref() {
         a: &'a Inner,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: Inner
     : STRUCT:
@@ -2326,8 +2236,7 @@ fn enum_with_ref_variants() {
         StructRef(&'a Inner),
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyEnum), @r"
     ? namespace: ROOT
       name: Inner
     : STRUCT:
@@ -2366,8 +2275,7 @@ fn struct_with_vec_ref() {
         b: &'a [Vec<String>],
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -2390,8 +2298,7 @@ fn references_with_options() {
         b: &'a Option<String>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:
@@ -2410,8 +2317,7 @@ fn tuple_struct_with_multiple_refs() {
     #[derive(Facet)]
     struct MyTupleStruct<'a>(&'a str, &'a [u8], &'a i32);
 
-    let registry = RegistryBuilder::new().add_type::<MyTupleStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyTupleStruct), @r"
     ? namespace: ROOT
       name: MyTupleStruct
     : TUPLESTRUCT:
@@ -2430,8 +2336,7 @@ fn struct_with_rc() {
         a: Rc<String>,
     }
 
-    let registry = RegistryBuilder::new().add_type::<MyStruct>().build();
-    insta::assert_yaml_snapshot!(registry, @r"
+    insta::assert_yaml_snapshot!(reflect!(MyStruct), @r"
     ? namespace: ROOT
       name: MyStruct
     : STRUCT:

--- a/src/tests/can_generate_bare_string_enum/mod.rs
+++ b/src/tests/can_generate_bare_string_enum/mod.rs
@@ -10,3 +10,7 @@ pub enum Colors {
     Blue,
     Green,
 }
+
+crate::test! {
+    Colors for kotlin
+}

--- a/src/tests/can_generate_bare_string_enum/output.kt
+++ b/src/tests/can_generate_bare_string_enum/output.kt
@@ -16,4 +16,6 @@ enum class Colors {
 
     val serialName: String
         get() = javaClass.getDeclaredField(name).getAnnotation(SerialName::class.java)!!.value
+
 }
+

--- a/src/tests/can_generate_unit_enum/mod.rs
+++ b/src/tests/can_generate_unit_enum/mod.rs
@@ -13,6 +13,6 @@ pub enum Colors {
     Green = 2,
 }
 
-// crate::tests! {
-//     Colors for java, swift, typescript
-// }
+crate::test! {
+    Colors for kotlin
+}

--- a/src/tests/can_generate_unit_enum/output.kt
+++ b/src/tests/can_generate_unit_enum/output.kt
@@ -19,4 +19,6 @@ enum class Colors {
 
     val serialName: String
         get() = javaClass.getDeclaredField(name).getAnnotation(SerialName::class.java)!!.value
+
 }
+

--- a/src/tests/can_generate_unit_enum/output.kt
+++ b/src/tests/can_generate_unit_enum/output.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.modules.*
 enum class Colors {
     @SerialName("Red") RED,
     @SerialName("Blue") BLUE,
-
     /// Green is a cool color
     @SerialName("Green") GREEN;
 

--- a/src/tests/can_generate_unit_structs/output.kt
+++ b/src/tests/can_generate_unit_structs/output.kt
@@ -10,4 +10,3 @@ import kotlinx.serialization.modules.*
 @Serializable
 data object UnitStruct
 
-

--- a/src/tests/can_recognize_types_inside_modules/mod.rs
+++ b/src/tests/can_recognize_types_inside_modules/mod.rs
@@ -2,6 +2,11 @@
 
 use facet::Facet;
 
+use a::{
+    A,
+    b::{AB, c::ABC},
+};
+
 mod a {
     use facet::Facet;
 
@@ -9,10 +14,11 @@ mod a {
     pub struct A {
         field: u32,
     }
-    mod b {
+
+    pub mod b {
         use facet::Facet;
 
-        mod c {
+        pub mod c {
             use facet::Facet;
 
             #[derive(Facet)]
@@ -20,6 +26,7 @@ mod a {
                 field: u32,
             }
         }
+
         #[derive(Facet)]
         pub struct AB {
             field: u32,
@@ -30,4 +37,8 @@ mod a {
 #[derive(Facet)]
 pub struct OutsideOfModules {
     field: u32,
+}
+
+crate::test! {
+    A, AB, ABC, OutsideOfModules for kotlin
 }

--- a/src/tests/can_recognize_types_inside_modules/output.kt
+++ b/src/tests/can_recognize_types_inside_modules/output.kt
@@ -11,14 +11,17 @@ import kotlinx.serialization.modules.*
 data class A (
     val field: UInt
 )
+
 @Serializable
 data class AB (
     val field: UInt
 )
+
 @Serializable
 data class ABC (
     val field: UInt
 )
+
 @Serializable
 data class OutsideOfModules (
     val field: UInt

--- a/src/tests/can_recognize_types_inside_modules/output.kt
+++ b/src/tests/can_recognize_types_inside_modules/output.kt
@@ -7,10 +7,20 @@ import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
-@Serializable data class A(val field: UInt)
+@Serializable
+data class A (
+    val field: UInt
+)
+@Serializable
+data class AB (
+    val field: UInt
+)
+@Serializable
+data class ABC (
+    val field: UInt
+)
+@Serializable
+data class OutsideOfModules (
+    val field: UInt
+)
 
-@Serializable data class ABC(val field: UInt)
-
-@Serializable data class AB(val field: UInt)
-
-@Serializable data class OutsideOfModules(val field: UInt)

--- a/src/tests/generates_empty_structs_and_initializers/mod.rs
+++ b/src/tests/generates_empty_structs_and_initializers/mod.rs
@@ -2,3 +2,7 @@ use facet::Facet;
 
 #[derive(Facet)]
 pub struct MyEmptyStruct {}
+
+crate::test! {
+    MyEmptyStruct for kotlin
+}

--- a/src/tests/generates_empty_structs_and_initializers/output.kt
+++ b/src/tests/generates_empty_structs_and_initializers/output.kt
@@ -10,4 +10,3 @@ import kotlinx.serialization.modules.*
 @Serializable
 data object MyEmptyStruct
 
-

--- a/src/tests/generates_empty_structs_and_initializers/output.kt
+++ b/src/tests/generates_empty_structs_and_initializers/output.kt
@@ -7,4 +7,7 @@ import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
-@Serializable data object MyEmptyStruct
+@Serializable
+data object MyEmptyStruct
+
+

--- a/src/tests/test_type_alias/mod.rs
+++ b/src/tests/test_type_alias/mod.rs
@@ -7,3 +7,7 @@ pub struct Bar(String);
 pub struct Foo {
     bar: Bar,
 }
+
+// crate::test! {
+//     Foo for kotlin
+// }

--- a/src/tests/unit_enum_is_properly_named_with_serde_overrides/mod.rs
+++ b/src/tests/unit_enum_is_properly_named_with_serde_overrides/mod.rs
@@ -14,3 +14,7 @@ pub enum Colors {
     #[facet(rename = "green-like")]
     Green = 2,
 }
+
+// crate::test! {
+//     Colors for kotlin
+// }

--- a/src/tests/use_correct_decoded_variable_name/mod.rs
+++ b/src/tests/use_correct_decoded_variable_name/mod.rs
@@ -2,3 +2,7 @@ use facet::Facet;
 
 #[derive(Facet)]
 pub struct MyEmptyStruct {}
+
+crate::test! {
+    MyEmptyStruct for kotlin
+}

--- a/src/tests/use_correct_decoded_variable_name/output.kt
+++ b/src/tests/use_correct_decoded_variable_name/output.kt
@@ -7,4 +7,6 @@ import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.*
 import kotlinx.serialization.modules.*
 
-@Serializable data object MyEmptyStruct
+@Serializable
+data object MyEmptyStruct
+

--- a/src/tests/use_correct_integer_types/mod.rs
+++ b/src/tests/use_correct_integer_types/mod.rs
@@ -10,3 +10,7 @@ pub struct Foo {
     pub f: u16,
     pub g: u32,
 }
+
+crate::test! {
+    Foo for kotlin
+}

--- a/src/tests/use_correct_integer_types/output.kt
+++ b/src/tests/use_correct_integer_types/output.kt
@@ -9,4 +9,12 @@ import kotlinx.serialization.modules.*
 
 /// This is a comment.
 @Serializable
-data class Foo(val a: Byte, val b: Short, val c: Int, val e: UByte, val f: UShort, val g: UInt)
+data class Foo (
+    val a: Byte,
+    val b: Short,
+    val c: Int,
+    val e: UByte,
+    val f: UShort,
+    val g: UInt
+)
+

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use facet::Facet;
-use facet_generate::{Registry, generation::Encoding, reflection::RegistryBuilder};
+use facet_generate::{Registry, generation::Encoding, reflect};
 use maplit::btreemap;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -24,7 +24,7 @@ pub enum Choice {
 }
 
 pub fn get_simple_registry() -> Registry {
-    RegistryBuilder::new().add_type::<Test>().build()
+    reflect!(Test)
 }
 
 // More complex data format used to test re-serialization and basic fuzzing.
@@ -136,7 +136,7 @@ pub enum CStyleEnum {
 
 /// The registry corresponding to the test data structures above.
 pub fn get_registry() -> Registry {
-    RegistryBuilder::new().add_type::<SerdeData>().build()
+    reflect!(SerdeData)
 }
 
 /// Manually generate sample values.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -623,21 +623,22 @@ fn test_get_simple_registry() {
     ? namespace: ROOT
       name: Choice
     : ENUM:
-        0:
-          A:
-            - UNIT
-            - []
-        1:
-          B:
-            - NEWTYPE: U64
-            - []
-        2:
-          C:
-            - STRUCT:
-                - x:
-                    - U8
-                    - []
-            - []
+        - 0:
+            A:
+              - UNIT
+              - []
+          1:
+            B:
+              - NEWTYPE: U64
+              - []
+          2:
+            C:
+              - STRUCT:
+                  - x:
+                      - U8
+                      - []
+              - []
+        - []
     ? namespace: ROOT
       name: Test
     : STRUCT:
@@ -666,46 +667,50 @@ fn test_get_registry() {
     ? namespace: ROOT
       name: CStyleEnum
     : ENUM:
-        0:
-          A:
-            - UNIT
-            - []
-        1:
-          B:
-            - UNIT
-            - []
-        2:
-          C:
-            - UNIT
-            - []
-        3:
-          D:
-            - UNIT
-            - []
-        4:
-          E:
-            - UNIT
-            - []
+        - 0:
+            A:
+              - UNIT
+              - []
+          1:
+            B:
+              - UNIT
+              - []
+          2:
+            C:
+              - UNIT
+              - []
+          3:
+            D:
+              - UNIT
+              - []
+          4:
+            E:
+              - UNIT
+              - []
+        - []
     ? namespace: ROOT
       name: List
     : ENUM:
-        0:
-          Empty:
-            - UNIT
-            - []
-        1:
-          Node:
-            - TUPLE:
-                - TYPENAME:
-                    namespace: ROOT
-                    name: SerdeData
-                - TYPENAME:
-                    namespace: ROOT
-                    name: List
-            - []
+        - 0:
+            Empty:
+              - UNIT
+              - []
+          1:
+            Node:
+              - TUPLE:
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: SerdeData
+                  - TYPENAME:
+                      namespace: ROOT
+                      name: List
+              - []
+        - []
     ? namespace: ROOT
       name: NewTypeStruct
-    : NEWTYPESTRUCT: U64
+    : NEWTYPESTRUCT:
+        - U64
+        - []
     ? namespace: ROOT
       name: OtherTypes
     : STRUCT:
@@ -806,123 +811,125 @@ fn test_get_registry() {
     ? namespace: ROOT
       name: SerdeData
     : ENUM:
-        0:
-          PrimitiveTypes:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: PrimitiveTypes
-            - []
-        1:
-          OtherTypes:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: OtherTypes
-            - []
-        2:
-          UnitVariant:
-            - UNIT
-            - []
-        3:
-          NewTypeVariant:
-            - NEWTYPE: STR
-            - []
-        4:
-          TupleVariant:
-            - TUPLE:
-                - U32
-                - U64
-            - []
-        5:
-          StructVariant:
-            - STRUCT:
-                - f0:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: UnitStruct
-                    - []
-                - f1:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: NewTypeStruct
-                    - []
-                - f2:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: TupleStruct
-                    - []
-                - f3:
-                    - TYPENAME:
-                        namespace: ROOT
-                        name: Struct
-                    - []
-            - []
-        6:
-          ListWithMutualRecursion:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: List
-            - []
-        7:
-          TreeWithMutualRecursion:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: Tree
-            - []
-        8:
-          TupleArray:
-            - NEWTYPE:
-                TUPLEARRAY:
-                  CONTENT: U32
-                  SIZE: 3
-            - []
-        9:
-          UnitVector:
-            - NEWTYPE:
-                SEQ: UNIT
-            - []
-        10:
-          SimpleList:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: SimpleList
-            - []
-        11:
-          CStyleEnum:
-            - NEWTYPE:
-                TYPENAME:
-                  namespace: ROOT
-                  name: CStyleEnum
-            - []
-        12:
-          ComplexMap:
-            - NEWTYPE:
-                MAP:
-                  KEY:
-                    TUPLE:
-                      - TUPLEARRAY:
-                          CONTENT: U32
-                          SIZE: 2
-                      - TUPLEARRAY:
-                          CONTENT: U8
-                          SIZE: 4
-                  VALUE: UNIT
-            - []
-        13:
-          EmptyStructVariant:
-            - UNIT
-            - []
+        - 0:
+            PrimitiveTypes:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: PrimitiveTypes
+              - []
+          1:
+            OtherTypes:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: OtherTypes
+              - []
+          2:
+            UnitVariant:
+              - UNIT
+              - []
+          3:
+            NewTypeVariant:
+              - NEWTYPE: STR
+              - []
+          4:
+            TupleVariant:
+              - TUPLE:
+                  - U32
+                  - U64
+              - []
+          5:
+            StructVariant:
+              - STRUCT:
+                  - f0:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: UnitStruct
+                      - []
+                  - f1:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: NewTypeStruct
+                      - []
+                  - f2:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: TupleStruct
+                      - []
+                  - f3:
+                      - TYPENAME:
+                          namespace: ROOT
+                          name: Struct
+                      - []
+              - []
+          6:
+            ListWithMutualRecursion:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: List
+              - []
+          7:
+            TreeWithMutualRecursion:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Tree
+              - []
+          8:
+            TupleArray:
+              - NEWTYPE:
+                  TUPLEARRAY:
+                    CONTENT: U32
+                    SIZE: 3
+              - []
+          9:
+            UnitVector:
+              - NEWTYPE:
+                  SEQ: UNIT
+              - []
+          10:
+            SimpleList:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: SimpleList
+              - []
+          11:
+            CStyleEnum:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: CStyleEnum
+              - []
+          12:
+            ComplexMap:
+              - NEWTYPE:
+                  MAP:
+                    KEY:
+                      TUPLE:
+                        - TUPLEARRAY:
+                            CONTENT: U32
+                            SIZE: 2
+                        - TUPLEARRAY:
+                            CONTENT: U8
+                            SIZE: 4
+                    VALUE: UNIT
+              - []
+          13:
+            EmptyStructVariant:
+              - UNIT
+              - []
+        - []
     ? namespace: ROOT
       name: SimpleList
     : NEWTYPESTRUCT:
-        OPTION:
-          TYPENAME:
-            namespace: ROOT
-            name: SimpleList
+        - OPTION:
+            TYPENAME:
+              namespace: ROOT
+              name: SimpleList
+        - []
     ? namespace: ROOT
       name: Struct
     : STRUCT:
@@ -951,8 +958,9 @@ fn test_get_registry() {
     ? namespace: ROOT
       name: TupleStruct
     : TUPLESTRUCT:
-        - U32
-        - U64
+        - - U32
+          - U64
+        - []
     ? namespace: ROOT
       name: UnitStruct
     : UNITSTRUCT: []


### PR DESCRIPTION
Finished off the basic Kotlin emitter. All the basic data types are now handled. Still to do (in another PR) is all the serialization code, and an installer for Kotlin modules.

Also adds `emit!` and `reflect!` macros which are variadic over the types that they add to the registry.