### PR TITLE
v0.10.3 fix for 2-tuple variant with nested user structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.10.3] - 2025-08-15
+
+### 🐛 Bug Fixes
+
+- fixes a bug when reflecting over enums that have tuple variants with more than one value _and_ are user structs nested within option or sequence types.
+
 ## [0.10.2] - 2025-08-06
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "autocfg"
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "bcs",
@@ -404,7 +404,7 @@ dependencies = [
  "strum",
  "tempfile",
  "textwrap",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "url",
 ]
 
@@ -1004,11 +1004,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "facet_generate"
 description = "Generate Swift, Kotlin and TypeScript from types annotated with `#[derive(Facet)]`"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Red Badger Consulting Limited"]
 repository = "https://github.com/redbadger/facet-generate"
 license = "Apache-2.0"

--- a/src/generation/swift/emitter.rs
+++ b/src/generation/swift/emitter.rs
@@ -3,13 +3,10 @@ use std::io::{Result, Write};
 
 use heck::{AsUpperCamelCase, ToLowerCamelCase as _, ToUpperCamelCase};
 
-use crate::generation::Encoding;
-use crate::generation::swift::generator::CodeGenerator;
-use crate::reflection::format::{ContainerFormat, Named, VariantFormat};
 use crate::{
     Registry,
-    generation::{common, indent::IndentedWriter},
-    reflection::format::{Format, FormatHolder as _},
+    generation::{Encoding, common, indent::IndentedWriter, swift::generator::CodeGenerator},
+    reflection::format::{ContainerFormat, Format, FormatHolder as _, Named, VariantFormat},
 };
 
 /// Shared state for the code generation of a Swift source file.
@@ -760,3 +757,7 @@ fn quote_deserialize(format: &Format) -> String {
         ),
     }
 }
+
+#[cfg(test)]
+#[path = "emitter_tests.rs"]
+mod tests;

--- a/src/generation/swift/emitter_tests.rs
+++ b/src/generation/swift/emitter_tests.rs
@@ -1,0 +1,165 @@
+//! these tests will be updated once the Swift emitter is converted
+//! to use the new Emitter<Language> trait
+
+use facet::Facet;
+
+use crate::{
+    generation::{
+        CodeGeneratorConfig,
+        indent::{IndentConfig, IndentedWriter},
+        swift::{CodeGenerator, emitter::SwiftEmitter},
+    },
+    reflection::RegistryBuilder,
+};
+
+#[test]
+fn unit_struct_1() {
+    /// comments not yet supported
+    #[derive(Facet)]
+    /// line 2
+    struct UnitStruct;
+
+    let registry = RegistryBuilder::new().add_type::<UnitStruct>().build();
+    let config = CodeGeneratorConfig::new("Root".to_string()).without_serialization();
+    let generator = CodeGenerator::new(&config);
+    let mut out = vec![];
+    let mut emitter = SwiftEmitter {
+        out: IndentedWriter::new(&mut out, IndentConfig::Space(4)),
+        generator: &generator,
+        current_namespace: Vec::new(),
+    };
+    for (name, format) in &registry {
+        emitter.output_container(&name.name, format).unwrap();
+    }
+
+    let actual = String::from_utf8(out).unwrap();
+    insta::assert_snapshot!(actual, @r"
+    public struct UnitStruct: Hashable {
+
+        public init() {
+        }
+    }
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant() {
+    #[derive(Facet)]
+    #[repr(C)]
+    enum MyEnum {
+        Variant1(String, i32),
+        Variant2(f64),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    let config = CodeGeneratorConfig::new("Root".to_string()).without_serialization();
+    let generator = CodeGenerator::new(&config);
+    let mut out = vec![];
+    let mut emitter = SwiftEmitter {
+        out: IndentedWriter::new(&mut out, IndentConfig::Space(4)),
+        generator: &generator,
+        current_namespace: Vec::new(),
+    };
+    for (name, format) in &registry {
+        emitter.output_container(&name.name, format).unwrap();
+    }
+
+    let actual = String::from_utf8(out).unwrap();
+    insta::assert_snapshot!(actual, @r"
+    indirect public enum MyEnum: Hashable {
+        case variant1(String, Int32)
+        case variant2(Double)
+    }
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant_containing_vecs() {
+    use facet::Facet;
+
+    #[derive(Facet)]
+    pub struct Test1 {
+        field1: String,
+        field2: i32,
+    }
+
+    #[derive(Facet)]
+    pub struct Test2 {
+        field1: String,
+        field2: i32,
+    }
+
+    #[derive(Facet)]
+    #[repr(C)]
+    enum MyEnum {
+        MyVariant(Vec<Test1>, Vec<Test2>),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    let config = CodeGeneratorConfig::new("Root".to_string()).without_serialization();
+    let generator = CodeGenerator::new(&config);
+    let mut out = vec![];
+    let mut emitter = SwiftEmitter {
+        out: IndentedWriter::new(&mut out, IndentConfig::Space(4)),
+        generator: &generator,
+        current_namespace: Vec::new(),
+    };
+
+    insta::assert_yaml_snapshot!(&registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test1
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : STRUCT:
+        - field1: STR
+        - field2: I32
+    ? namespace: ROOT
+      name: Test2
+    : STRUCT:
+        - field1: STR
+        - field2: I32
+    ");
+
+    for (name, format) in &registry {
+        emitter.output_container(&name.name, format).unwrap();
+    }
+
+    let actual = String::from_utf8(out).unwrap();
+    insta::assert_snapshot!(actual, @r"
+    indirect public enum MyEnum: Hashable {
+        case myVariant([Test1], [Test2])
+    }
+
+    public struct Test1: Hashable {
+        @Indirect public var field1: String
+        @Indirect public var field2: Int32
+
+        public init(field1: String, field2: Int32) {
+            self.field1 = field1
+            self.field2 = field2
+        }
+    }
+
+    public struct Test2: Hashable {
+        @Indirect public var field1: String
+        @Indirect public var field2: Int32
+
+        public init(field1: String, field2: Int32) {
+            self.field1 = field1
+            self.field2 = field2
+        }
+    }
+    ");
+}

--- a/src/reflection/format/mod.rs
+++ b/src/reflection/format/mod.rs
@@ -320,12 +320,12 @@ impl<T> Variable<T> {
     }
 
     #[must_use]
-    pub fn borrow(&self) -> Ref<Option<T>> {
+    pub fn borrow(&self) -> Ref<'_, Option<T>> {
         self.0.as_ref().borrow()
     }
 
     #[must_use]
-    pub fn borrow_mut(&self) -> RefMut<Option<T>> {
+    pub fn borrow_mut(&self) -> RefMut<'_, Option<T>> {
         self.0.as_ref().borrow_mut()
     }
 }

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeSet, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use super::*;
 
@@ -1684,4 +1687,219 @@ fn tree_enum_with_mutual_recursion() {
         ),
     }
     "#);
+}
+
+#[test]
+fn enum_with_tuple_variant_of_user_types_in_a_mod() {
+    mod api {
+        use facet::Facet;
+
+        #[derive(Facet)]
+        pub struct Test1;
+
+        #[derive(Facet)]
+        pub struct Test2;
+    }
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum MyEnum {
+        MyVariant(api::Test1, api::Test2),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - TYPENAME:
+                  namespace: ROOT
+                  name: Test1
+              - TYPENAME:
+                  namespace: ROOT
+                  name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : UNITSTRUCT
+    ? namespace: ROOT
+      name: Test2
+    : UNITSTRUCT
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant_of_lists_of_user_types() {
+    use facet::Facet;
+
+    #[derive(Facet)]
+    pub struct Test1;
+
+    #[derive(Facet)]
+    pub struct Test2;
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum MyEnum {
+        MyVariant(Vec<Test1>, Vec<Test2>),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test1
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : UNITSTRUCT
+    ? namespace: ROOT
+      name: Test2
+    : UNITSTRUCT
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant_of_option_of_user_types() {
+    use facet::Facet;
+
+    #[derive(Facet)]
+    pub struct Test1;
+
+    #[derive(Facet)]
+    pub struct Test2;
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum MyEnum {
+        MyVariant(Option<Test1>, Option<Test2>),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - OPTION:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test1
+              - OPTION:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : UNITSTRUCT
+    ? namespace: ROOT
+      name: Test2
+    : UNITSTRUCT
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant_of_map_of_user_types() {
+    use facet::Facet;
+
+    #[derive(Facet)]
+    pub struct Test1;
+
+    #[derive(Facet)]
+    pub struct Test2;
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    #[allow(clippy::zero_sized_map_values)]
+    enum MyEnum {
+        MyVariant(HashMap<String, Test1>, HashMap<String, Test2>),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - MAP:
+                  KEY: STR
+                  VALUE:
+                    TYPENAME:
+                      namespace: ROOT
+                      name: Test1
+              - MAP:
+                  KEY: STR
+                  VALUE:
+                    TYPENAME:
+                      namespace: ROOT
+                      name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : UNITSTRUCT
+    ? namespace: ROOT
+      name: Test2
+    : UNITSTRUCT
+    ");
+}
+
+#[test]
+fn enum_with_tuple_variant_of_set_of_user_types() {
+    use facet::Facet;
+
+    #[derive(Facet, PartialEq, Eq, Hash)]
+    pub struct Test1;
+
+    #[derive(Facet, PartialEq, Eq, Hash)]
+    pub struct Test2;
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum MyEnum {
+        MyVariant(HashSet<Test1>, HashSet<Test2>),
+    }
+
+    let registry = RegistryBuilder::new().add_type::<MyEnum>().build();
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        0:
+          MyVariant:
+            TUPLE:
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test1
+              - SEQ:
+                  TYPENAME:
+                    namespace: ROOT
+                    name: Test2
+    ? namespace: ROOT
+      name: Test1
+    : UNITSTRUCT
+    ? namespace: ROOT
+      name: Test2
+    : UNITSTRUCT
+    ");
 }


### PR DESCRIPTION
## [0.10.3] - 2025-08-15

### 🐛 Bug Fixes

- fixes a bug when reflecting over enums that have tuple variants with more than one value _and_ are user structs nested within option or sequence types.
