### PR TITLE
Fix incomplete reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.11.2] - 2025-09-08
+
+### 🐛 Bug Fixes
+
+There was a problem reflecting enums inside struct variants, which is now fixed.
+
+Also changed the handling of generic types, which are supported if:
+- `Arc`, `Rc`, `Box`, which are reflected as the inner type
+- `Option`, which is reflected as `OPTION`
+- `Vec`, `HashSet`, `BTreeSet`, reflected as `SEQ`
+- `HashMap`, `BTreeMap`, reflected as `MAP`
+- `DateTime`, reflected as `STR`, for serialization as RFC3339 (using the serde feature of DateTime)
+- other generic types are reflected as `TYPENAME`, with the type parameters currently removed. This means that if the type is used more than once with different parameters, the reflection will panic.
+
 ## [0.11.1] - 2025-09-03
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.16",
+ "tracing",
  "url",
 ]
 
@@ -661,9 +662,9 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
  "console",
  "once_cell",
@@ -749,6 +750,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "potential_utf"
@@ -1041,6 +1048,37 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bstr"
@@ -87,10 +81,11 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -102,16 +97,15 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -381,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -414,6 +408,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "fnv"
@@ -680,9 +680,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -708,9 +708,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "maplit"
@@ -1141,30 +1141,31 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.4+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1176,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1186,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,20 +1200,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1223,7 +1224,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -1257,12 +1258,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1271,7 +1278,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1290,6 +1297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1314,7 +1330,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -1423,9 +1439,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "facet_generate"
 description = "Generate Swift, Kotlin and TypeScript from types annotated with `#[derive(Facet)]`"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Red Badger Consulting Limited"]
 repository = "https://github.com/redbadger/facet-generate"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 textwrap = "0.16.2"
 thiserror = "2.0.16"
+tracing = "0.1.41"
 
 [dev-dependencies]
 anyhow = "1.0.99"
@@ -30,7 +31,7 @@ difficient = "0.1.0"
 expect-test = "1.5.1"
 facet = { version = "0.28.1", features = ["chrono", "url"] }
 ignore = "0.4.23"
-insta = { version = "1.43.1", features = ["yaml", "json"] }
+insta = { version = "1.43.2", features = ["yaml", "json"] }
 maplit = "1.0.2"
 regex = "1.11.2"
 strum = { version = "0.27.2", features = ["derive"] }

--- a/codebook.toml
+++ b/codebook.toml
@@ -1,0 +1,1 @@
+words = ["tuplearray"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum Error {
-    #[error("Incomplete reflection detected")]
+    #[error("incomplete reflection detected")]
     UnknownFormat,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,9 +95,9 @@ macro_rules! emit_java {
 
 #[macro_export]
 macro_rules! reflect {
-    ($($ty:ident),*) => {{
+    ($($ty:ident),*) => {
         $crate::reflection::RegistryBuilder::new()
             $(.add_type::<$ty>())*
             .build()
-    }};
+    };
 }

--- a/src/reflection/mod.rs
+++ b/src/reflection/mod.rs
@@ -1135,13 +1135,10 @@ fn type_to_format(shape: &Shape) -> Format {
             },
             PrimitiveType::Never => unimplemented!("Never type not supported"),
         },
-        Type::User(UserType::Opaque) => {
-            // Handle opaque types like String based on type identifier
-            match shape.type_identifier {
-                "String" => Format::Str,
-                _ => unimplemented!("Unsupported opaque type: {}", shape.type_identifier),
-            }
-        }
+        Type::User(UserType::Opaque) => match shape.type_identifier {
+            "String" | "DateTime<Utc>" => Format::Str,
+            _ => unimplemented!("Unsupported opaque type: {}", shape.type_identifier),
+        },
         _ => unimplemented!("Unsupported type for scalar format: {:?}", shape.ty),
     }
 }

--- a/src/reflection/regression_tests/mod.rs
+++ b/src/reflection/regression_tests/mod.rs
@@ -3,7 +3,7 @@
 //! These tests verify that the Variable resolution problems in `RegistryBuilder` have been fixed
 //! and serve as regression tests to prevent these issues from reoccurring.
 //!
-//! Previously, these scenarios would cause panics with "There was a problem building the registry".
+//! Previously, these scenarios would cause panics with "There was a problem reflecting type".
 //! Now they should all work correctly, demonstrating that the underlying issues have been resolved.
 
 use crate::reflection::RegistryBuilder;
@@ -161,7 +161,7 @@ mod tests {
     /// Diagnostic test: Manually create unresolved Variables to verify `build()` catches them
     /// This simulates what used to happen in the problematic code paths
     #[test]
-    #[should_panic(expected = "There was a problem building the registry")]
+    #[should_panic(expected = "There was a problem reflecting type")]
     fn test_build_catches_unresolved_variables() {
         let mut builder = RegistryBuilder::new();
 
@@ -180,7 +180,7 @@ mod tests {
 
     /// Test with enum variants that have unresolved Variables
     #[test]
-    #[should_panic(expected = "There was a problem building the registry")]
+    #[should_panic(expected = "There was a problem reflecting type")]
     fn test_enum_with_unresolved_variant_caught() {
         let mut builder = RegistryBuilder::new();
 
@@ -209,7 +209,7 @@ mod tests {
 
     /// Test with struct fields that have unresolved Variables
     #[test]
-    #[should_panic(expected = "There was a problem building the registry")]
+    #[should_panic(expected = "There was a problem reflecting type")]
     fn test_struct_with_unresolved_field_caught() {
         let mut builder = RegistryBuilder::new();
 
@@ -260,7 +260,7 @@ mod tests {
 
     /// This will pass eventually, once we fully support generic types.
     #[test]
-    #[should_panic(expected = "There was a problem building the registry")]
+    #[should_panic(expected = "Unsupported generic type")]
     fn test_enum_with_anon_struct_variants_with_result_of_t() {
         use thiserror::Error;
 

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -2649,3 +2649,53 @@ fn chrono_date_time() {
     ");
 }
 
+#[test]
+fn generics_supported_if_used_once() {
+    #[derive(Facet)]
+    struct SupportedGenerics<T> {
+        field: T,
+    }
+
+    #[derive(Facet)]
+    struct MyStruct {
+        field1: SupportedGenerics<String>,
+    }
+
+    let registry = reflect!(MyStruct);
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - - field1:
+              - TYPENAME:
+                  namespace: ROOT
+                  name: SupportedGenerics
+              - []
+        - []
+    ? namespace: ROOT
+      name: SupportedGenerics
+    : STRUCT:
+        - - field:
+              - STR
+              - []
+        - []
+    ");
+}
+
+/// TODO: Eventually we should support generics used more than once
+#[test]
+#[should_panic(expected = "Unsupported generic type")]
+fn generics_unsupported_if_used_twice() {
+    #[derive(Facet)]
+    struct UnsupportedGenerics<T> {
+        field: T,
+    }
+
+    #[derive(Facet)]
+    struct MyStruct {
+        field1: UnsupportedGenerics<String>,
+        field2: UnsupportedGenerics<u16>,
+    }
+
+    let _registry = reflect!(MyStruct);
+}

--- a/src/reflection/tests.rs
+++ b/src/reflection/tests.rs
@@ -3,6 +3,8 @@ use std::{
     sync::Arc,
 };
 
+use chrono::{DateTime, Utc};
+
 use super::*;
 use crate::reflect;
 
@@ -2598,3 +2600,52 @@ fn enum_with_tuple_variant_of_set_of_user_types() {
     : UNITSTRUCT: []
     ");
 }
+
+#[test]
+fn chrono_date_time() {
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum MyEnum {
+        Date(DateTime<Utc>),
+        Date2 { date: DateTime<Utc> },
+    }
+
+    #[derive(Facet)]
+    struct MyStruct {
+        field1: DateTime<Utc>,
+        field2: MyEnum,
+    }
+
+    let registry = reflect!(MyStruct);
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: MyEnum
+    : ENUM:
+        - 0:
+            Date:
+              - NEWTYPE: STR
+              - []
+          1:
+            Date2:
+              - STRUCT:
+                  - date:
+                      - STR
+                      - []
+              - []
+        - []
+    ? namespace: ROOT
+      name: MyStruct
+    : STRUCT:
+        - - field1:
+              - STR
+              - []
+          - field2:
+              - TYPENAME:
+                  namespace: ROOT
+                  name: MyEnum
+              - []
+        - []
+    ");
+}
+


### PR DESCRIPTION
There was a problem reflecting enums inside struct variants, which is now fixed. 

Also changed the handling of generic types, which are supported if:
- `Arc`, `Rc`, `Box`, which are reflected as the inner type
- `Option`, which is reflected as `OPTION`
- `Vec`, `HashSet`, `BTreeSet`, reflected as `SEQ`
- `HashMap`, `BTreeMap`, reflected as `MAP`
- `DateTime`, reflected as `STR`, for serialization as RFC3339 (using the serde feature of DateTime)
- other generic types are reflected as `TYPENAME`, with the type parameters currently removed. This means that if the type is used more than once with different parameters, the reflection will panic.