### PR TITLE
fix(generation): fixes incorrect module splitting by namespace

### DIFF
--- a/src/generation/kotlin/emitter/mod.rs
+++ b/src/generation/kotlin/emitter/mod.rs
@@ -839,13 +839,7 @@ fn write_serialize<W: IndentWrite>(
             Ok(())
         }
 
-        Format::Seq(inner_format) => {
-            write!(w, "{field_name}.serialize(serializer) ")?;
-            write_serialize_lambda(w, inner_format, level)?;
-            Ok(())
-        }
-
-        Format::Set(inner_format) => {
+        Format::Seq(inner_format) | Format::Set(inner_format) => {
             write!(w, "{field_name}.serialize(serializer) ")?;
             write_serialize_lambda(w, inner_format, level)?;
             Ok(())

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::{Registry, generation::CodeGen};
 use anyhow::Result;
 use expect_test::ExpectFile;

--- a/tests/swift_generation.rs
+++ b/tests/swift_generation.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #![cfg(feature = "swift")]
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0


### PR DESCRIPTION
Fixes a bug in the module splitting that resulted in potentially missing external dependencies. The fix was to consider all the types in the registry, group them by namespace and create a module for each namespace that contains all their aggregated dependencies.