### PR TITLE
fix(generation): fixes type name mangling for serialize fn names

### DIFF
--- a/src/generation/common.rs
+++ b/src/generation/common.rs
@@ -7,7 +7,7 @@ use crate::reflection::format::Format;
 
 pub(crate) fn mangle_type(format: &Format) -> String {
     match format {
-        Format::TypeName(qualified_name) => qualified_name.to_legacy_string(ToString::to_string),
+        Format::TypeName(qualified_name) => qualified_name.to_string(ToString::to_string, "_"),
         Format::Unit => "unit".into(),
         Format::Bool => "bool".into(),
         Format::I8 => "i8".into(),

--- a/src/generation/swift/emitter/mod.rs
+++ b/src/generation/swift/emitter/mod.rs
@@ -728,7 +728,7 @@ fn quote_deserialize(format: &Format) -> String {
     match format {
         Format::TypeName(name) => format!(
             "try {}.deserialize(deserializer: deserializer)",
-            &name.to_legacy_string(ToUpperCamelCase::to_upper_camel_case)
+            &name.to_string(ToUpperCamelCase::to_upper_camel_case, ".")
         ),
         Format::Unit => "try deserializer.deserialize_unit()".to_string(),
         Format::Bool => "try deserializer.deserialize_bool()".to_string(),

--- a/src/generation/swift/emitter/tests.rs
+++ b/src/generation/swift/emitter/tests.rs
@@ -769,3 +769,36 @@ fn struct_with_bytes_field_and_slice() {
     }
     ");
 }
+
+#[test]
+fn namespaced_child() {
+    #[derive(Facet)]
+    #[facet(namespace = "Test")]
+    struct Child {
+        test: String,
+    }
+
+    #[derive(Facet)]
+    struct Parent {
+        child: Child,
+    }
+
+    let actual = emit_swift!(Parent as Encoding::None).unwrap();
+    insta::assert_snapshot!(actual, @r"
+    public struct Parent: Hashable {
+        @Indirect public var child: Child
+
+        public init(child: Child) {
+            self.child = child
+        }
+    }
+
+    public struct Child: Hashable {
+        @Indirect public var test: String
+
+        public init(test: String) {
+            self.test = test
+        }
+    }
+    ");
+}

--- a/src/generation/swift/emitter/tests_bincode.rs
+++ b/src/generation/swift/emitter/tests_bincode.rs
@@ -1891,3 +1891,92 @@ fn struct_with_bytes_field_and_slice() {
     }
     "#);
 }
+
+#[test]
+fn namespaced_child() {
+    #[derive(Facet)]
+    #[facet(namespace = "Test")]
+    struct Child {
+        test: String,
+    }
+
+    #[derive(Facet)]
+    struct Parent {
+        child: Vec<Child>,
+    }
+
+    let actual = emit_swift!(Parent as Encoding::Bincode).unwrap();
+    insta::assert_snapshot!(actual, @r#"
+    public struct Parent: Hashable {
+        @Indirect public var child: [Child]
+
+        public init(child: [Child]) {
+            self.child = child
+        }
+
+        public func serialize<S: Serializer>(serializer: S) throws {
+            try serializer.increase_container_depth()
+            try serialize_vector_Test_Child(value: self.child, serializer: serializer)
+            try serializer.decrease_container_depth()
+        }
+
+        public func bincodeSerialize() throws -> [UInt8] {
+            let serializer = BincodeSerializer.init();
+            try self.serialize(serializer: serializer)
+            return serializer.get_bytes()
+        }
+
+        public static func deserialize<D: Deserializer>(deserializer: D) throws -> Parent {
+            try deserializer.increase_container_depth()
+            let child = try deserialize_vector_Test_Child(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return Parent.init(child: child)
+        }
+
+        public static func bincodeDeserialize(input: [UInt8]) throws -> Parent {
+            let deserializer = BincodeDeserializer.init(input: input);
+            let obj = try deserialize(deserializer: deserializer)
+            if deserializer.get_buffer_offset() < input.count {
+                throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+            }
+            return obj
+        }
+    }
+
+    public struct Child: Hashable {
+        @Indirect public var test: String
+
+        public init(test: String) {
+            self.test = test
+        }
+
+        public func serialize<S: Serializer>(serializer: S) throws {
+            try serializer.increase_container_depth()
+            try serializer.serialize_str(value: self.test)
+            try serializer.decrease_container_depth()
+        }
+
+        public func bincodeSerialize() throws -> [UInt8] {
+            let serializer = BincodeSerializer.init();
+            try self.serialize(serializer: serializer)
+            return serializer.get_bytes()
+        }
+
+        public static func deserialize<D: Deserializer>(deserializer: D) throws -> Child {
+            try deserializer.increase_container_depth()
+            let test = try deserializer.deserialize_str()
+            try deserializer.decrease_container_depth()
+            return Child.init(test: test)
+        }
+
+        public static func bincodeDeserialize(input: [UInt8]) throws -> Child {
+            let deserializer = BincodeDeserializer.init(input: input);
+            let obj = try deserialize(deserializer: deserializer)
+            if deserializer.get_buffer_offset() < input.count {
+                throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+            }
+            return obj
+        }
+    }
+    "#);
+}

--- a/src/generation/swift/emitter/tests_json.rs
+++ b/src/generation/swift/emitter/tests_json.rs
@@ -1891,3 +1891,92 @@ fn struct_with_bytes_field_and_slice() {
     }
     "#);
 }
+
+#[test]
+fn namespaced_child() {
+    #[derive(Facet)]
+    #[facet(namespace = "Test")]
+    struct Child {
+        test: String,
+    }
+
+    #[derive(Facet)]
+    struct Parent {
+        child: Child,
+    }
+
+    let actual = emit_swift!(Parent as Encoding::Json).unwrap();
+    insta::assert_snapshot!(actual, @r#"
+    public struct Parent: Hashable {
+        @Indirect public var child: Child
+
+        public init(child: Child) {
+            self.child = child
+        }
+
+        public func serialize<S: Serializer>(serializer: S) throws {
+            try serializer.increase_container_depth()
+            try self.child.serialize(serializer: serializer)
+            try serializer.decrease_container_depth()
+        }
+
+        public func jsonSerialize() throws -> [UInt8] {
+            let serializer = JsonSerializer.init();
+            try self.serialize(serializer: serializer)
+            return serializer.get_bytes()
+        }
+
+        public static func deserialize<D: Deserializer>(deserializer: D) throws -> Parent {
+            try deserializer.increase_container_depth()
+            let child = try Test.Child.deserialize(deserializer: deserializer)
+            try deserializer.decrease_container_depth()
+            return Parent.init(child: child)
+        }
+
+        public static func jsonDeserialize(input: [UInt8]) throws -> Parent {
+            let deserializer = JsonDeserializer.init(input: input);
+            let obj = try deserialize(deserializer: deserializer)
+            if deserializer.get_buffer_offset() < input.count {
+                throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+            }
+            return obj
+        }
+    }
+
+    public struct Child: Hashable {
+        @Indirect public var test: String
+
+        public init(test: String) {
+            self.test = test
+        }
+
+        public func serialize<S: Serializer>(serializer: S) throws {
+            try serializer.increase_container_depth()
+            try serializer.serialize_str(value: self.test)
+            try serializer.decrease_container_depth()
+        }
+
+        public func jsonSerialize() throws -> [UInt8] {
+            let serializer = JsonSerializer.init();
+            try self.serialize(serializer: serializer)
+            return serializer.get_bytes()
+        }
+
+        public static func deserialize<D: Deserializer>(deserializer: D) throws -> Child {
+            try deserializer.increase_container_depth()
+            let test = try deserializer.deserialize_str()
+            try deserializer.decrease_container_depth()
+            return Child.init(test: test)
+        }
+
+        public static func jsonDeserialize(input: [UInt8]) throws -> Child {
+            let deserializer = JsonDeserializer.init(input: input);
+            let obj = try deserialize(deserializer: deserializer)
+            if deserializer.get_buffer_offset() < input.count {
+                throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+            }
+            return obj
+        }
+    }
+    "#);
+}

--- a/src/reflection/format/tests.rs
+++ b/src/reflection/format/tests.rs
@@ -30,8 +30,7 @@ fn test_format_visiting() {
     format
         .visit(&mut |f| {
             if let TypeName(x) = f {
-                // Insert a &str borrowed from `format`.
-                names.insert(x.to_legacy_string(ToString::to_string));
+                names.insert(x.to_string(ToString::to_string, "."));
             }
             Ok(())
         })

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,6 +14,7 @@ pub struct Test {
 }
 
 #[derive(Facet, Serialize, Deserialize)]
+#[facet(namespace = "another")]
 #[repr(C)]
 pub enum Choice {
     A,

--- a/tests/common_tests.rs
+++ b/tests/common_tests.rs
@@ -24,6 +24,25 @@ fn test_get_simple_registry() {
     let registry = get_simple_registry();
     insta::assert_yaml_snapshot!(&registry, @r"
     ? namespace: ROOT
+      name: Test
+    : STRUCT:
+        - - a:
+              - SEQ: U32
+              - []
+          - b:
+              - TUPLE:
+                  - I64
+                  - U64
+              - []
+          - c:
+              - TYPENAME:
+                  namespace:
+                    NAMED: test
+                  name: Choice
+              - []
+        - []
+    ? namespace:
+        NAMED: test
       name: Choice
     : ENUM:
         - 0:
@@ -40,23 +59,6 @@ fn test_get_simple_registry() {
                   - x:
                       - U8
                       - []
-              - []
-        - []
-    ? namespace: ROOT
-      name: Test
-    : STRUCT:
-        - - a:
-              - SEQ: U32
-              - []
-          - b:
-              - TUPLE:
-                  - I64
-                  - U64
-              - []
-          - c:
-              - TYPENAME:
-                  namespace: ROOT
-                  name: Choice
               - []
         - []
     ");


### PR DESCRIPTION
Fixes a problem in the name generation for serialization functions in Swift. This now uses an underscore instead of a dot (which is not syntactically correct). The fix is temporary, as we intend to rewrite the Swift generation to follow the same pattern used in the Kotlin generation. This will not only lead to better Swift generated, but also remove the need for this fix.