### PR TITLE
feat(reflect): support call-site namespace annotations

### DIFF
--- a/src/reflection/namespace_tests.rs
+++ b/src/reflection/namespace_tests.rs
@@ -1583,3 +1583,78 @@ fn explicit_namespace_behavior_summary() {
         - []
     ");
 }
+
+#[test]
+fn struct_field_points_to_type_in_a_namespace() {
+    #[derive(Facet)]
+    struct Child {
+        value: String,
+    }
+
+    #[derive(Facet)]
+    struct Parent {
+        #[facet(namespace = "other_namespace")]
+        value: Child,
+    }
+
+    let registry = reflect!(Parent);
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: Parent
+    : STRUCT:
+        - - value:
+              - TYPENAME:
+                  namespace:
+                    NAMED: other_namespace
+                  name: Child
+              - []
+        - []
+    ? namespace:
+        NAMED: other_namespace
+      name: Child
+    : STRUCT:
+        - - value:
+              - STR
+              - []
+        - []
+    ");
+}
+
+#[test]
+fn enum_variant_field_points_to_type_in_a_namespace() {
+    #[derive(Facet)]
+    struct Child {
+        value: String,
+    }
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum Parent {
+        Value(#[facet(namespace = "other_namespace")] Child),
+    }
+
+    let registry = reflect!(Parent);
+    insta::assert_yaml_snapshot!(registry, @r"
+    ? namespace: ROOT
+      name: Parent
+    : ENUM:
+        - 0:
+            Value:
+              - NEWTYPE:
+                  TYPENAME:
+                    namespace:
+                      NAMED: other_namespace
+                    name: Child
+              - []
+        - []
+    ? namespace:
+        NAMED: other_namespace
+      name: Child
+    : STRUCT:
+        - - value:
+              - STR
+              - []
+        - []
+    ");
+}


### PR DESCRIPTION
Adds support for specifying namespaces at the call-site. This allows you to specify that the type (struct or enum) that a field _points to_ is in another (possibly external) namespace. 

This allows us to generate types for crates, independently of each other. For example, if you have references in `crate-a` to types in `crate-b`, you can annotate those references in `crate-a` with the namespace that corresponds to the root namespace in `crate-b`, then run the typegen for each crate separately, specifying a package name for `crate-b` that corresponds to the call-site namespace annotations in `crate-a` (and an `ExternalPackage` for `crate-a` with `for_namespace` set to the call-site namespace).

Current behaviour:
* Call-site annotations take precedence over type-level annotations.
* If there are multiple references to the same type, they should all be annotated with the same namespace (the type will be generated in the first namespace seen).

In this example, the struct field `value` points to the type `Child` which will now be in the `other_namespace` (as though `Child` itself had been annotated).
```rust
    #[derive(Facet)]
    struct Child {
        value: String,
    }

    #[derive(Facet)]
    struct Parent {
        #[facet(namespace = "other_namespace")]
        value: Child,
    }
```

Here, the enum variant points to the type `Child` which will now be in the `other_namespace` (as though `Child` itself had been annotated).
```rust
    #[derive(Facet)]
    struct Child {
        value: String,
    }

    #[derive(Facet)]
    #[repr(C)]
    #[allow(unused)]
    enum Parent {
        Value(#[facet(namespace = "other_namespace")] Child),
    }
```