### PR TITLE
Add Kotlin Native runtime for serde

### DIFF
--- a/runtime/kotlin/com/novi/bcs/BcsDeserializer.kt
+++ b/runtime/kotlin/com/novi/bcs/BcsDeserializer.kt
@@ -1,0 +1,59 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bcs
+
+import com.novi.serde.BinaryDeserializer
+import com.novi.serde.DeserializationError
+import com.novi.serde.Slice
+
+class BcsDeserializer(input: ByteArray) : BinaryDeserializer(input, BcsSerializer.MAX_CONTAINER_DEPTH) {
+    @Throws(DeserializationError::class)
+    override fun deserialize_f32(): Float {
+        throw DeserializationError("Not implemented: deserialize_f32")
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_f64(): Double {
+        throw DeserializationError("Not implemented: deserialize_f64")
+    }
+
+    @Throws(DeserializationError::class)
+    private fun deserialize_uleb128_as_u32(): Int {
+        var value = 0L
+        var shift = 0
+        while (shift < 32) {
+            val x = getByte().toInt() and 0xff
+            val digit = x and 0x7f
+            value = value or (digit.toLong() shl shift)
+            if (value < 0 || value > Int.MAX_VALUE.toLong()) {
+                throw DeserializationError("Overflow while parsing uleb128-encoded uint32 value")
+            }
+            if (digit == x) {
+                if (shift > 0 && digit == 0) {
+                    throw DeserializationError("Invalid uleb128 number (unexpected zero digit)")
+                }
+                return value.toInt()
+            }
+            shift += 7
+        }
+        throw DeserializationError("Overflow while parsing uleb128-encoded uint32 value")
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_len(): Long {
+        return deserialize_uleb128_as_u32().toLong()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_variant_index(): Int {
+        return deserialize_uleb128_as_u32()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice) {
+        if (Slice.compare_bytes(input, key1, key2) >= 0) {
+            throw DeserializationError("Error while decoding map: keys are not serialized in the expected order")
+        }
+    }
+}

--- a/runtime/kotlin/com/novi/bcs/BcsSerializer.kt
+++ b/runtime/kotlin/com/novi/bcs/BcsSerializer.kt
@@ -1,0 +1,79 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bcs
+
+import com.novi.serde.BinarySerializer
+import com.novi.serde.SerializationError
+import com.novi.serde.Slice
+
+class BcsSerializer : BinarySerializer(MAX_CONTAINER_DEPTH) {
+    @Throws(SerializationError::class)
+    override fun serialize_f32(value: Float) {
+        throw SerializationError("Not implemented: serialize_f32")
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_f64(value: Double) {
+        throw SerializationError("Not implemented: serialize_f64")
+    }
+
+    private fun serialize_u32_as_uleb128(value: Int) {
+        var v = value
+        while ((v ushr 7) != 0) {
+            output.writeByte(((v and 0x7f) or 0x80).toByte())
+            v = v ushr 7
+        }
+        output.writeByte(v.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_len(value: Long) {
+        if (value < 0 || value > MAX_LENGTH) {
+            throw SerializationError("Incorrect length value")
+        }
+        serialize_u32_as_uleb128(value.toInt())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_variant_index(value: Int) {
+        serialize_u32_as_uleb128(value)
+    }
+
+    override fun sort_map_entries(offsets: IntArray) {
+        if (offsets.size <= 1) {
+            return
+        }
+        val offset0 = offsets[0]
+        val content = output.getBuffer()
+        val slices = Array(offsets.size) { index ->
+            if (index < offsets.size - 1) {
+                Slice(offsets[index], offsets[index + 1])
+            } else {
+                Slice(offsets[index], output.size())
+            }
+        }
+
+        slices.sortWith { slice1, slice2 ->
+            Slice.compare_bytes(content, slice1, slice2)
+        }
+
+        val totalLength = output.size() - offset0
+        val oldContent = ByteArray(totalLength)
+        content.copyInto(oldContent, startIndex = offset0, endIndex = offset0 + totalLength)
+
+        var position = offset0
+        for (slice in slices) {
+            val start = slice.start
+            val end = slice.end
+            val length = end - start
+            oldContent.copyInto(content, destinationOffset = position, startIndex = start - offset0, endIndex = start - offset0 + length)
+            position += length
+        }
+    }
+
+    companion object {
+        const val MAX_LENGTH: Long = Int.MAX_VALUE.toLong()
+        const val MAX_CONTAINER_DEPTH: Long = 500
+    }
+}

--- a/runtime/kotlin/com/novi/bincode/BincodeDeserializer.kt
+++ b/runtime/kotlin/com/novi/bincode/BincodeDeserializer.kt
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bincode
+
+import com.novi.serde.BinaryDeserializer
+import com.novi.serde.DeserializationError
+import com.novi.serde.Slice
+
+class BincodeDeserializer(input: ByteArray) : BinaryDeserializer(input, Long.MAX_VALUE) {
+    @Throws(DeserializationError::class)
+    override fun deserialize_f32(): Float {
+        return Float.fromBits(getInt())
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_f64(): Double {
+        return Double.fromBits(getLong())
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_len(): Long {
+        val value = getLong()
+        if (value < 0 || value > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value")
+        }
+        return value
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_variant_index(): Int {
+        return getInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice) {
+        // Not required by the format.
+    }
+}

--- a/runtime/kotlin/com/novi/bincode/BincodeSerializer.kt
+++ b/runtime/kotlin/com/novi/bincode/BincodeSerializer.kt
@@ -1,0 +1,33 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bincode
+
+import com.novi.serde.BinarySerializer
+import com.novi.serde.SerializationError
+
+class BincodeSerializer : BinarySerializer(Long.MAX_VALUE) {
+    @Throws(SerializationError::class)
+    override fun serialize_f32(value: Float) {
+        serialize_i32(value.toRawBits())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_f64(value: Double) {
+        serialize_i64(value.toRawBits())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_len(value: Long) {
+        serialize_u64(value.toULong())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_variant_index(value: Int) {
+        serialize_u32(value.toUInt())
+    }
+
+    override fun sort_map_entries(offsets: IntArray) {
+        // Not required by the format.
+    }
+}

--- a/runtime/kotlin/com/novi/serde/BinaryDeserializer.kt
+++ b/runtime/kotlin/com/novi/serde/BinaryDeserializer.kt
@@ -1,0 +1,183 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinaryDeserializer(
+    protected val input: ByteArray,
+    maxContainerDepth: Long
+) : Deserializer {
+    private var position: Int = 0
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(DeserializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw DeserializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_str(): String {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin string")
+        }
+        val content = readBytes(len.toInt())
+        return try {
+            content.decodeToString(throwOnInvalidSequence = true)
+        } catch (e: Throwable) {
+            throw DeserializationError("Incorrect UTF8 string")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bytes(): Bytes {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin array")
+        }
+        val content = readBytes(len.toInt())
+        return Bytes.valueOf(content)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bool(): Boolean {
+        val value = getByte()
+        return when (value.toInt()) {
+            0 -> false
+            1 -> true
+            else -> throw DeserializationError("Incorrect boolean value")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_unit(): Unit {
+        return Unit
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_char(): Char {
+        throw DeserializationError("Not implemented: deserialize_char")
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u8(): UByte {
+        return getByte().toUByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u16(): UShort {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8)).toUShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u32(): UInt {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)).toUInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u64(): ULong {
+        var value = 0uL
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toULong() and 0xffuL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u128(): UInt128 {
+        val low = deserialize_u64()
+        val high = deserialize_u64()
+        return UInt128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i8(): Byte {
+        return getByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i16(): Short {
+        return deserialize_u16().toShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i32(): Int {
+        return deserialize_u32().toInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i64(): Long {
+        return deserialize_u64().toLong()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i128(): Int128 {
+        val low = deserialize_u64()
+        val high = deserialize_i64()
+        return Int128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_option_tag(): Boolean {
+        return deserialize_bool()
+    }
+
+    override fun get_buffer_offset(): Int {
+        return position
+    }
+
+    protected fun getInt(): Int {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)
+    }
+
+    protected fun getLong(): Long {
+        var value = 0L
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toLong() and 0xffL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    protected fun getByte(): Byte {
+        requireAvailable(1)
+        val value = input[position]
+        position += 1
+        return value
+    }
+
+    private fun readBytes(count: Int): ByteArray {
+        requireAvailable(count)
+        val slice = input.copyOfRange(position, position + count)
+        position += count
+        return slice
+    }
+
+    private fun requireAvailable(count: Int) {
+        if (position + count > input.size) {
+            throw DeserializationError(INPUT_NOT_LARGE_ENOUGH)
+        }
+    }
+
+    companion object {
+        private const val INPUT_NOT_LARGE_ENOUGH = "Input is not large enough"
+    }
+}

--- a/runtime/kotlin/com/novi/serde/BinarySerializer.kt
+++ b/runtime/kotlin/com/novi/serde/BinarySerializer.kt
@@ -1,0 +1,123 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinarySerializer(maxContainerDepth: Long) : Serializer {
+    protected val output: SerdeByteArrayOutput = SerdeByteArrayOutput()
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(SerializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw SerializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_str(value: String) {
+        serialize_bytes(Bytes.valueOf(value.encodeToByteArray()))
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bytes(value: Bytes) {
+        val content = value.content()
+        serialize_len(content.size.toLong())
+        output.writeBytes(content, 0, content.size)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bool(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_unit(value: Unit) {
+        // Nothing to serialize.
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_char(value: Char) {
+        throw SerializationError("Not implemented: serialize_char")
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u8(value: UByte) {
+        output.writeByte(value.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u16(value: UShort) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u32(value: UInt) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+        output.writeByte(((v ushr 16) and 0xff).toByte())
+        output.writeByte(((v ushr 24) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u64(value: ULong) {
+        var v = value
+        for (i in 0 until 8) {
+            output.writeByte((v and 0xffuL).toByte())
+            v = v shr 8
+        }
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u128(value: UInt128) {
+        serialize_u64(value.low)
+        serialize_u64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i8(value: Byte) {
+        serialize_u8(value.toUByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i16(value: Short) {
+        serialize_u16(value.toUShort())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i32(value: Int) {
+        serialize_u32(value.toUInt())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i64(value: Long) {
+        serialize_u64(value.toULong())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i128(value: Int128) {
+        serialize_u64(value.low)
+        serialize_i64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_option_tag(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    override fun get_buffer_offset(): Int {
+        return output.size()
+    }
+
+    override fun get_bytes(): ByteArray {
+        return output.toByteArray()
+    }
+}

--- a/runtime/kotlin/com/novi/serde/Bytes.kt
+++ b/runtime/kotlin/com/novi/serde/Bytes.kt
@@ -1,0 +1,40 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+/**
+ * Immutable wrapper class around ByteArray.
+ *
+ * Enforces value-semantice for `equals` and `hashCode`.
+ */
+class Bytes private constructor(private val content: ByteArray) {
+    fun content(): ByteArray {
+        return content.copyOf()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Bytes) return false
+        return content.contentEquals(other.content)
+    }
+
+    override fun hashCode(): Int {
+        return content.contentHashCode()
+    }
+
+    companion object {
+        private val EMPTY = Bytes(ByteArray(0))
+
+        fun empty(): Bytes {
+            return EMPTY
+        }
+
+        fun valueOf(content: ByteArray): Bytes {
+            if (content.isEmpty()) {
+                return EMPTY
+            }
+            return Bytes(content.copyOf())
+        }
+    }
+}

--- a/runtime/kotlin/com/novi/serde/DeserializationError.kt
+++ b/runtime/kotlin/com/novi/serde/DeserializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class DeserializationError(message: String) : Exception(message)

--- a/runtime/kotlin/com/novi/serde/Deserializer.kt
+++ b/runtime/kotlin/com/novi/serde/Deserializer.kt
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Deserializer {
+    @Throws(DeserializationError::class)
+    fun deserialize_str(): String
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bytes(): Bytes
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bool(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun deserialize_unit(): Unit
+
+    @Throws(DeserializationError::class)
+    fun deserialize_char(): Char
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f32(): Float
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f64(): Double
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u8(): UByte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u16(): UShort
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u32(): UInt
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u64(): ULong
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u128(): UInt128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i8(): Byte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i16(): Short
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i32(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i64(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i128(): Int128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_len(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_variant_index(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_option_tag(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    @Throws(DeserializationError::class)
+    fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice)
+}

--- a/runtime/kotlin/com/novi/serde/Int128.kt
+++ b/runtime/kotlin/com/novi/serde/Int128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Int128(val high: Long, val low: ULong)

--- a/runtime/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
+++ b/runtime/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
@@ -1,0 +1,48 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerdeByteArrayOutput(initialCapacity: Int = 32) {
+    private var buffer: ByteArray = ByteArray(initialCapacity)
+    private var length: Int = 0
+
+    fun writeByte(value: Byte) {
+        ensureCapacity(1)
+        buffer[length] = value
+        length += 1
+    }
+
+    fun writeBytes(value: ByteArray, offset: Int, count: Int) {
+        if (count == 0) {
+            return
+        }
+        ensureCapacity(count)
+        value.copyInto(buffer, destinationOffset = length, startIndex = offset, endIndex = offset + count)
+        length += count
+    }
+
+    fun size(): Int {
+        return length
+    }
+
+    fun toByteArray(): ByteArray {
+        return buffer.copyOf(length)
+    }
+
+    fun getBuffer(): ByteArray {
+        return buffer
+    }
+
+    private fun ensureCapacity(extra: Int) {
+        val required = length + extra
+        if (required <= buffer.size) {
+            return
+        }
+        var newSize = buffer.size
+        while (newSize < required) {
+            newSize = newSize * 2
+        }
+        buffer = buffer.copyOf(newSize)
+    }
+}

--- a/runtime/kotlin/com/novi/serde/SerializationError.kt
+++ b/runtime/kotlin/com/novi/serde/SerializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerializationError(message: String) : Exception(message)

--- a/runtime/kotlin/com/novi/serde/Serializer.kt
+++ b/runtime/kotlin/com/novi/serde/Serializer.kt
@@ -1,0 +1,77 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Serializer {
+    @Throws(SerializationError::class)
+    fun serialize_str(value: String)
+
+    @Throws(SerializationError::class)
+    fun serialize_bytes(value: Bytes)
+
+    @Throws(SerializationError::class)
+    fun serialize_bool(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun serialize_unit(value: Unit)
+
+    @Throws(SerializationError::class)
+    fun serialize_char(value: Char)
+
+    @Throws(SerializationError::class)
+    fun serialize_f32(value: Float)
+
+    @Throws(SerializationError::class)
+    fun serialize_f64(value: Double)
+
+    @Throws(SerializationError::class)
+    fun serialize_u8(value: UByte)
+
+    @Throws(SerializationError::class)
+    fun serialize_u16(value: UShort)
+
+    @Throws(SerializationError::class)
+    fun serialize_u32(value: UInt)
+
+    @Throws(SerializationError::class)
+    fun serialize_u64(value: ULong)
+
+    @Throws(SerializationError::class)
+    fun serialize_u128(value: UInt128)
+
+    @Throws(SerializationError::class)
+    fun serialize_i8(value: Byte)
+
+    @Throws(SerializationError::class)
+    fun serialize_i16(value: Short)
+
+    @Throws(SerializationError::class)
+    fun serialize_i32(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_i64(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_i128(value: Int128)
+
+    @Throws(SerializationError::class)
+    fun serialize_len(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_variant_index(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_option_tag(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    fun sort_map_entries(offsets: IntArray)
+
+    fun get_bytes(): ByteArray
+}

--- a/runtime/kotlin/com/novi/serde/Slice.kt
+++ b/runtime/kotlin/com/novi/serde/Slice.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Slice(val start: Int, val end: Int) {
+    companion object {
+        fun compare_bytes(content: ByteArray, slice1: Slice, slice2: Slice): Int {
+            val start1 = slice1.start
+            val end1 = slice1.end
+            val start2 = slice2.start
+            val end2 = slice2.end
+            var i = 0
+            while (i < end1 - start1) {
+                val index1 = start1 + i
+                val index2 = start2 + i
+                val byte1 = content[index1].toInt() and 0xff
+                if (index2 >= end2) {
+                    return 1
+                }
+                val byte2 = content[index2].toInt() and 0xff
+                if (byte1 > byte2) {
+                    return 1
+                }
+                if (byte1 < byte2) {
+                    return -1
+                }
+                i += 1
+            }
+            if (end2 - start2 > end1 - start1) {
+                return -1
+            }
+            return 0
+        }
+    }
+}

--- a/runtime/kotlin/com/novi/serde/Tuple4.kt
+++ b/runtime/kotlin/com/novi/serde/Tuple4.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple4<T0, T1, T2, T3>(val field0: T0, val field1: T1, val field2: T2, val field3: T3)

--- a/runtime/kotlin/com/novi/serde/Tuple5.kt
+++ b/runtime/kotlin/com/novi/serde/Tuple5.kt
@@ -1,0 +1,12 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple5<T0, T1, T2, T3, T4>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4
+)

--- a/runtime/kotlin/com/novi/serde/Tuple6.kt
+++ b/runtime/kotlin/com/novi/serde/Tuple6.kt
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple6<T0, T1, T2, T3, T4, T5>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4,
+    val field5: T5
+)

--- a/runtime/kotlin/com/novi/serde/UInt128.kt
+++ b/runtime/kotlin/com/novi/serde/UInt128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class UInt128(val high: ULong, val low: ULong)


### PR DESCRIPTION
Currently, there's no Kotlin runtime for Serde (only Java). This makes it impossible to use facet-generate for Kotlin/Native, Kotlin Multiplatform projects (basically, for any other targets than Jvm and Android).

This PR adds Kotlin native runtime.

1. Uses Kotlin unsigned integer types (UInt, ULong, etc.)
2. Int128 is represented as a data class with high (Long) and low (ULong) parts (Kotlin/Native doesn't have a BigInteger type like Java)
3. Omits `Tuple2` and `Tuple3`. Kotlin's `Pair` and `Triple` should be used.
4. The rest is similar to Java runtime

I've also made a PR to serde-reflection [here](https://github.com/zefchain/serde-reflection/pull/86)

Together with changes made [here](https://github.com/redbadger/facet-generate/pull/46#issuecomment-3732274333) this can be used to achive full Kotlin native support