### PR TITLE
fix: streamlined build processes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,23 +32,20 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Check (fmt + clippy)
+        run: just check
+
+      - name: Build
+        run: just build
+
       - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "21"
           cache: "gradle"
-
-      - name: Format check
-        shell: bash
-        run: cargo fmt --all --check
-
-      - name: Clippy (pedantic)
-        shell: bash
-        run: cargo clippy --all-targets -- --no-deps -Dclippy::pedantic -Dwarnings
-
-      - name: Build
-        shell: bash
-        run: cargo build --all-features
 
       - name: Setup Additional Languages for codegen tests (deno)
         uses: denoland/setup-deno@v2
@@ -58,9 +55,8 @@ jobs:
       - name: Setup Additional Languages for codegen tests (swift)
         uses: SwiftyLab/setup-swift@latest
 
-      - name: Install latest nextest release
+      - name: Install nextest
         uses: taiki-e/install-action@nextest
 
-      - name: Test with latest nextest release
-        shell: bash
-        run: cargo nextest run --all-features
+      - name: Test
+        run: just test

--- a/Justfile
+++ b/Justfile
@@ -1,11 +1,34 @@
+# default target for local development
+default: dev
+
+# builds all crates
 build:
+    @echo '{{ style("command") }}build:{{ NORMAL }}'
     cargo build --all-features
 
+# runs tests
 test:
+    @echo '{{ style("command") }}test:{{ NORMAL }}'
+    cargo nextest run --all-features
+
+# runs tests with snapshot review (interactive, for local dev)
+test-review:
+    @echo '{{ style("command") }}test-review:{{ NORMAL }}'
     cargo insta test --review --test-runner nextest --all-features
 
-lint:
-    cargo fmt --all --check
+# auto-fix formatting issues
+fix:
+    @echo '{{ style("command") }}fix:{{ NORMAL }}'
+    cargo fmt --all
+
+# validate formatting and lint (strict, no auto-fix)
+check:
+    @echo '{{ style("command") }}check:{{ NORMAL }}'
+    cargo fmt --all -- --check
     cargo clippy --all-targets -- --no-deps -Dclippy::pedantic -Dwarnings
 
-ci: lint test
+# local development: fix, check, build, test with snapshot review
+dev: fix check build test-review
+
+# CI pipeline: check, build, test (matches .github/workflows/build.yaml)
+ci: check build test


### PR DESCRIPTION
This PR streamlines what's in the `Justfile` with what's in the GitHub Action build. This makes it more straightforward to locally ask "am I ready for a PR?"

This borrows from standards in my other projects, which are to comment the targets, making them discoverable with `just --list` (and by agents).

There are two main paths:

`dev`: what was in the `Justfile` previously, fixes everything as you go, and updates insta snapshots.
`ci`: what the GitHub Action runs, in strict mode.

It also outputs the command you're on to make it nicer to look at while you're running.

The breaking test is that `test` in the previous version becomes `test-review` - but the default target is `dev` so most of the time when you're in development mode just run `just`.

The GitHub Action calls specific `just` targets in the right order to avoid wasteful integration test installs that aren't needed if the build or linting fails.