### PR TITLE
Deprecate Java Generator (replaced by Kotlin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Reflect types annotated with [`#[derive(Facet)]`](https://crates.io/crates/facet) into Swift, Kotlin, and TypeScript. Optionally generates serialization and deserialization code for [Bincode](https://github.com/bincode-org/bincode) and JSON encodings.
 
+> **Note:** A Java generator is also available but deprecated — use Kotlin for Android targets.
+
 ## Usage
 
 ```sh

--- a/src/generation/config.rs
+++ b/src/generation/config.rs
@@ -18,12 +18,17 @@ use crate::{
 
 /// Code generation options meant to be supported by all languages.
 #[derive(Clone, Debug, Serialize)]
+#[expect(
+    deprecated,
+    reason = "CodeGeneratorConfig still contains the deprecated CustomCode field for backwards compatibility"
+)]
 pub struct CodeGeneratorConfig {
     pub module_name: String,
     pub encoding: Encoding,
     pub external_definitions: ExternalDefinitions,
     pub external_packages: ExternalPackages,
     pub comments: DocComments,
+    /// **Deprecated since 0.16.0:** `custom_code` was only used by the Java generator, which is deprecated. Use Kotlin instead.
     pub custom_code: CustomCode,
     pub package_manifest: bool,
     pub features: BTreeSet<Feature>,
@@ -77,6 +82,10 @@ pub type ExternalPackages =
 pub type DocComments = BTreeMap</* qualified name */ Vec<String>, /* comment */ String>;
 
 /// Track custom code to be added to particular definitions (use with care!).
+#[deprecated(
+    since = "0.16.0",
+    note = "custom_code was only used by the Java generator, which is deprecated. Use Kotlin instead."
+)]
 pub type CustomCode =
     BTreeMap</* qualified name */ Vec<String>, /* custom code */ String>;
 
@@ -117,6 +126,10 @@ pub trait SourceInstaller {
     }
 }
 
+#[expect(
+    deprecated,
+    reason = "impl references the deprecated CustomCode type and with_custom_code method"
+)]
 impl CodeGeneratorConfig {
     /// Default config for the given module name.
     #[must_use]
@@ -138,7 +151,7 @@ impl CodeGeneratorConfig {
         &self.module_name
     }
 
-    /// for Java: updates the module name to be a child of the specified parent
+    /// for Kotlin: updates the module name to be a child of the specified parent
     #[must_use]
     pub fn with_parent(mut self, parent: &str) -> Self {
         if parent == self.module_name() {
@@ -181,6 +194,10 @@ impl CodeGeneratorConfig {
 
     /// Custom code attached to particular entity.
     #[must_use]
+    #[deprecated(
+        since = "0.16.0",
+        note = "custom_code was only used by the Java generator, which is deprecated. Use Kotlin instead."
+    )]
     pub fn with_custom_code(mut self, code: CustomCode) -> Self {
         self.custom_code = code;
         self
@@ -314,7 +331,7 @@ impl ConfigBuilder {
 
 #[derive(Debug, Clone, Serialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PackageLocation {
-    /// Either a local file path or, for Java, a dot-separated package name.
+    /// Either a local file path or, for Kotlin, a dot-separated package name.
     Path(String),
     // The URL of a remote package.
     Url(String),

--- a/src/generation/java/emitter/tests.rs
+++ b/src/generation/java/emitter/tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_lines)]
+#![expect(deprecated, reason = "tests use deprecated emit_java macro")]
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     rc::Rc,

--- a/src/generation/java/emitter/tests_bincode.rs
+++ b/src/generation/java/emitter/tests_bincode.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_lines)]
+#![expect(deprecated, reason = "tests use deprecated emit_java macro")]
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     rc::Rc,

--- a/src/generation/java/emitter/tests_json.rs
+++ b/src/generation/java/emitter/tests_json.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_lines)]
+#![expect(deprecated, reason = "tests use deprecated emit_java macro")]
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     rc::Rc,

--- a/src/generation/java/generator.rs
+++ b/src/generation/java/generator.rs
@@ -11,6 +11,10 @@ use crate::{
 };
 
 /// Main configuration object for code-generation in Java.
+#[deprecated(
+    since = "0.16.0",
+    note = "The Java generator is deprecated. Use the Kotlin generator instead."
+)]
 pub struct CodeGenerator<'a> {
     /// Language-independent configuration.
     pub(crate) config: &'a CodeGeneratorConfig,

--- a/src/generation/java/installer.rs
+++ b/src/generation/java/installer.rs
@@ -14,6 +14,10 @@ use crate::{
 };
 
 /// Installer for generated source files in Java.
+#[deprecated(
+    since = "0.16.0",
+    note = "The Java generator is deprecated. Use the Kotlin generator instead."
+)]
 pub struct Installer {
     package_name: String,
     install_dir: PathBuf,

--- a/src/generation/java/mod.rs
+++ b/src/generation/java/mod.rs
@@ -1,4 +1,8 @@
 #![allow(clippy::missing_errors_doc)]
+#![expect(
+    deprecated,
+    reason = "internal implementation of the deprecated Java generator"
+)]
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -4,7 +4,9 @@ pub mod indent;
 /// Modules for code generation that map to Namespaces declared as `#[facet(namespace = "my_namespace")]`
 pub mod module;
 
-/// Support for code-generation in Java
+/// Support for code-generation in Java.
+///
+/// **Deprecated since 0.16.0:** The Java generator is deprecated. Use the Kotlin generator instead.
 #[cfg(feature = "java")]
 pub mod java;
 /// Support for code-generation in Kotlin
@@ -47,12 +49,20 @@ pub trait CodeGen<'a> {
 }
 
 pub enum Language {
+    #[deprecated(
+        since = "0.16.0",
+        note = "The Java generator is deprecated. Use Kotlin instead."
+    )]
     Java,
     Kotlin,
     Swift,
     TypeScript,
 }
 
+#[expect(
+    deprecated,
+    reason = "Display must handle all variants including deprecated Language::Java"
+)]
 impl Display for Language {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/generation/tests/mod.rs
+++ b/src/generation/tests/mod.rs
@@ -6,14 +6,46 @@ use std::{
 use expect_test::ExpectFile;
 use ignore::WalkBuilder;
 
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod basic;
 mod with_bytes;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_namespaces_as_external;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_namespaces_as_internal;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_serialization;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_serialization_and_namespaces_as_external;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_serialization_and_serde_external;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_serialization_and_serde_internal;
+#[expect(
+    deprecated,
+    reason = "snapshot tests cover the deprecated Java generator"
+)]
 mod with_serialization_and_serde_local;
 
 fn read_files_and_create_expect_dirs(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,15 @@ macro_rules! emit {
     };
 }
 
+/// **Deprecated since 0.16.0:** The Java generator is deprecated. Use the Kotlin generator instead.
 #[macro_export]
+#[deprecated(
+    since = "0.16.0",
+    note = "The Java generator is deprecated. Use the Kotlin generator instead."
+)]
 macro_rules! emit_java {
     ($($ty:ident),* as $encoding:path) => {
+        #[allow(deprecated)]
         || -> anyhow::Result<String> {
             use $crate::generation::{Encoding, indent::{IndentConfig, IndentedWriter}};
             let mut out = Vec::new();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ macro_rules! test {
 
     (@generate_tests [$($ty:ident),*] $language:ident $(, $rest:ident)*) => {
         #[test]
+        #[allow(deprecated)]
         fn $language() -> Result<()> {
             let registry = RegistryBuilder::new()
                 $(.add_type::<$ty>().unwrap())*

--- a/tests/java_generation.rs
+++ b/tests/java_generation.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "java")]
+#![expect(deprecated, reason = "tests for the deprecated Java generator")]
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 

--- a/tests/java_runtime.rs
+++ b/tests/java_runtime.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "java")]
+#![expect(deprecated, reason = "tests for the deprecated Java generator")]
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pub mod common;


### PR DESCRIPTION
This PR address #68 which deprecates java generation support now that we have Kotlin support. This simplifies everything under our second generation, testable generator that Kotlin was based on.