### PR TITLE
fix: use absolute paths with `include_dir!`

### DIFF
--- a/src/generation/java/installer.rs
+++ b/src/generation/java/installer.rs
@@ -134,14 +134,14 @@ impl SourceInstaller for Installer {
 
     fn install_serde_runtime(&mut self) -> std::result::Result<(), Error> {
         self.install_runtime(
-            &include_dir!("runtime/java/com/novi/serde"),
+            &include_dir!("$CARGO_MANIFEST_DIR/runtime/java/com/novi/serde"),
             "com/novi/serde",
         )
     }
 
     fn install_bincode_runtime(&self) -> std::result::Result<(), Error> {
         self.install_runtime(
-            &include_dir!("runtime/java/com/novi/bincode"),
+            &include_dir!("$CARGO_MANIFEST_DIR/runtime/java/com/novi/bincode"),
             "com/novi/bincode",
         )
     }

--- a/src/generation/swift/installer/mod.rs
+++ b/src/generation/swift/installer/mod.rs
@@ -278,7 +278,7 @@ impl SourceInstaller for Installer {
 
     fn install_serde_runtime(&mut self) -> std::result::Result<(), Error> {
         self.install_runtime(
-            &include_dir!("runtime/swift/Sources/Serde"),
+            &include_dir!("$CARGO_MANIFEST_DIR/runtime/swift/Sources/Serde"),
             "Sources/Serde",
         )?;
 

--- a/src/generation/typescript/mod.rs
+++ b/src/generation/typescript/mod.rs
@@ -25,11 +25,13 @@ impl InstallTarget {
     pub(crate) fn serde_runtime(self) -> &'static Dir<'static> {
         match self {
             Self::Node => {
-                static DIR: Dir<'_> = include_dir!("runtime/typescript-node/serde");
+                static DIR: Dir<'_> =
+                    include_dir!("$CARGO_MANIFEST_DIR/runtime/typescript-node/serde");
                 &DIR
             }
             Self::Deno => {
-                static DIR: Dir<'_> = include_dir!("runtime/typescript-deno/serde");
+                static DIR: Dir<'_> =
+                    include_dir!("$CARGO_MANIFEST_DIR/runtime/typescript-deno/serde");
                 &DIR
             }
         }
@@ -38,11 +40,13 @@ impl InstallTarget {
     pub(crate) fn bincode_runtime(self) -> &'static Dir<'static> {
         match self {
             Self::Node => {
-                static DIR: Dir<'_> = include_dir!("runtime/typescript-node/bincode");
+                static DIR: Dir<'_> =
+                    include_dir!("$CARGO_MANIFEST_DIR/runtime/typescript-node/bincode");
                 &DIR
             }
             Self::Deno => {
-                static DIR: Dir<'_> = include_dir!("runtime/typescript-deno/bincode");
+                static DIR: Dir<'_> =
+                    include_dir!("$CARGO_MANIFEST_DIR/runtime/typescript-deno/bincode");
                 &DIR
             }
         }


### PR DESCRIPTION
We are starting to use `facet_generate` with Bazel instead of Cargo, and Bazel likes to sandbox it’s compilation. In particular, it does not invoke `rustc` from the root of the crate like Cargo does.

The `include_dir!` macro is thus not reliable when used with relative paths and things break, see: https://docs.rs/include_dir/.

The patch here makes the paths absolute by letting `include_dir!` resolve the `$CARGO_MANIFEST_DIR` environment variable, which Bazel does set to ease the transition away from Cargo.