### PR TITLE
fix(swift): handling of 128 bit integers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,3 +78,7 @@ jobs:
 
       - name: Test
         run: just test
+
+      - name: Swift runtime tests
+        if: runner.os != 'Windows'
+        run: just swift-test

--- a/Justfile
+++ b/Justfile
@@ -20,6 +20,16 @@ test:
     @echo '{{ style("command") }}test:{{ NORMAL }}'
     cargo nextest run --all-features
 
+# runs Swift runtime tests (macOS and Linux only)
+[unix]
+swift-test:
+    @echo '{{ style("command") }}swift-test:{{ NORMAL }}'
+    swift test --package-path crates/facet_generate/runtime/swift
+
+[windows]
+swift-test:
+    @echo '{{ style("command") }}swift-test: skipped on Windows{{ NORMAL }}'
+
 # runs tests with snapshot review (interactive, for local dev)
 test-review:
     @echo '{{ style("command") }}test-review:{{ NORMAL }}'
@@ -50,7 +60,7 @@ docs:
     cargo rustdoc --all-features -p facet_generate -- -D warnings
 
 # CI pipeline: check, build, test (matches .github/workflows/build.yaml)
-ci: check docs build test
+ci: check docs build test swift-test
 
 update-rust-deps:
     @echo '{{ style("command") }}update-rust-deps:{{ NORMAL }}'

--- a/crates/facet_generate/runtime/swift/Package.swift
+++ b/crates/facet_generate/runtime/swift/Package.swift
@@ -6,7 +6,10 @@ import PackageDescription
 let package = Package(
     name: "Serde",
     platforms: [
-        .macOS(.v15)
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/crates/facet_generate/runtime/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/runtime/swift/Sources/Serde/BinaryDeserializer.swift
@@ -117,13 +117,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_u128() throws -> UInt128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of UInt128 on ARM64.
         let low = try deserialize_u64()
         let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: UInt128.self)
+        return UInt128(high: high, low: low)
     }
 
     public func deserialize_i8() throws -> Int8 {
@@ -143,14 +139,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_i128() throws -> Int128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of Int128 on ARM64.
-        // Read both halves as UInt64 bit patterns; the cast reinterprets them.
         let low = try deserialize_u64()
-        let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: Int128.self)
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
     }
 
     public func deserialize_option_tag() throws -> Bool {

--- a/crates/facet_generate/runtime/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/runtime/swift/Sources/Serde/BinarySerializer.swift
@@ -86,13 +86,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_u128(value: UInt128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
     }
 
     public func serialize_i8(value: Int8) throws {
@@ -112,13 +107,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_i128(value: Int128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
     }
 
     public func serialize_option_tag(value: Bool) throws {

--- a/crates/facet_generate/runtime/swift/Sources/Serde/Int128.swift
+++ b/crates/facet_generate/runtime/swift/Sources/Serde/Int128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct Int128: Hashable {
+    public var high: Int64
+    public var low: UInt64
+
+    public init(high: Int64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/runtime/swift/Sources/Serde/UInt128.swift
+++ b/crates/facet_generate/runtime/swift/Sources/Serde/UInt128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct UInt128: Hashable {
+    public var high: UInt64
+    public var low: UInt64
+
+    public init(high: UInt64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/runtime/swift/Tests/SerdeTests/SerdeTests.swift
+++ b/crates/facet_generate/runtime/swift/Tests/SerdeTests/SerdeTests.swift
@@ -78,54 +78,151 @@ class SerdeTests: XCTestCase {
         XCTAssertEqual(result, 9_223_372_036_854_775_807, "should be same")
     }
 
+    // MARK: - UInt128
+
     func testSerializeU128() throws {
-        let serializer = BincodeSerializer()
-        XCTAssertNoThrow(
-            try serializer.serialize_u128(value: UInt128.max))
+        // max: all bits set — low 8 bytes then high 8 bytes, both 0xFF
+        let serMax = BincodeSerializer()
+        try serMax.serialize_u128(value: UInt128(high: UInt64.max, low: UInt64.max))
         XCTAssertEqual(
-            serializer.get_bytes(),
-            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
-            "the array should be same")
+            serMax.get_bytes(),
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255])
 
-        let serializer2 = BincodeSerializer()
-        XCTAssertNoThrow(try serializer2.serialize_u128(value: 1))
+        // one: low word = 1, high word = 0
+        let serOne = BincodeSerializer()
+        try serOne.serialize_u128(value: UInt128(high: 0, low: 1))
         XCTAssertEqual(
-            serializer2.get_bytes(), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "the array should be same")
+            serOne.get_bytes(),
+            [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-        let serializer3 = BincodeSerializer()
-        XCTAssertNoThrow(try serializer3.serialize_u128(value: 0))
+        // zero
+        let serZero = BincodeSerializer()
+        try serZero.serialize_u128(value: UInt128(high: 0, low: 0))
         XCTAssertEqual(
-            serializer3.get_bytes(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "the array should be same")
+            serZero.get_bytes(),
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
     }
 
+    func testDeserializeU128() throws {
+        // max
+        let desMax = BincodeDeserializer(
+            input: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255])
+        let max = try desMax.deserialize_u128()
+        XCTAssertEqual(max.low, UInt64.max)
+        XCTAssertEqual(max.high, UInt64.max)
+
+        // one
+        let desOne = BincodeDeserializer(
+            input: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        let one = try desOne.deserialize_u128()
+        XCTAssertEqual(one.low, 1)
+        XCTAssertEqual(one.high, 0)
+
+        // zero
+        let desZero = BincodeDeserializer(
+            input: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        let zero = try desZero.deserialize_u128()
+        XCTAssertEqual(zero.low, 0)
+        XCTAssertEqual(zero.high, 0)
+    }
+
+    func testRoundTripU128() throws {
+        let values: [UInt128] = [
+            UInt128(high: 0, low: 0),
+            UInt128(high: 0, low: 1),
+            UInt128(high: 1, low: 0),
+            UInt128(high: UInt64.max, low: UInt64.max),
+            UInt128(high: 0xDEAD_BEEF_CAFE_BABE, low: 0x0102_0304_0506_0708),
+        ]
+        for value in values {
+            let serializer = BincodeSerializer()
+            try serializer.serialize_u128(value: value)
+            let deserializer = BincodeDeserializer(input: serializer.get_bytes())
+            let result = try deserializer.deserialize_u128()
+            XCTAssertEqual(result.high, value.high, "high mismatch for \(value)")
+            XCTAssertEqual(result.low, value.low, "low mismatch for \(value)")
+        }
+    }
+
+    // MARK: - Int128
+
     func testSerializeI128() throws {
-        let serializer = BincodeSerializer()
-        XCTAssertNoThrow(try serializer.serialize_i128(value: -1))
+        // -1 in two's complement: all 128 bits set
+        // high = Int64(-1), low = UInt64.max
+        let serNeg1 = BincodeSerializer()
+        try serNeg1.serialize_i128(value: Int128(high: -1, low: UInt64.max))
         XCTAssertEqual(
-            serializer.get_bytes(),
-            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255],
-            "the array should be same")
+            serNeg1.get_bytes(),
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255])
 
-        let serializer2 = BincodeSerializer()
-        XCTAssertNoThrow(try serializer2.serialize_i128(value: 1))
+        // +1: high = 0, low = 1
+        let serPos1 = BincodeSerializer()
+        try serPos1.serialize_i128(value: Int128(high: 0, low: 1))
         XCTAssertEqual(
-            serializer2.get_bytes(), [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            "the array should be same")
+            serPos1.get_bytes(),
+            [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-        let serializer3 = BincodeSerializer()
-        XCTAssertNoThrow(
-            try serializer3.serialize_i128(value: Int128.max))
+        // max: high = Int64.max, low = UInt64.max
+        let serMax = BincodeSerializer()
+        try serMax.serialize_i128(value: Int128(high: Int64.max, low: UInt64.max))
         XCTAssertEqual(
-            serializer3.get_bytes(),
-            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 127],
-            "the array should be same")
+            serMax.get_bytes(),
+            [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 127])
 
-        let serializer4 = BincodeSerializer()
-        XCTAssertNoThrow(try serializer4.serialize_i128(value: Int128.min))
+        // min: high = Int64.min, low = 0
+        let serMin = BincodeSerializer()
+        try serMin.serialize_i128(value: Int128(high: Int64.min, low: 0))
         XCTAssertEqual(
-            serializer4.get_bytes(), [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80],
-            "the array should be same")
+            serMin.get_bytes(),
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80])
+    }
+
+    func testDeserializeI128() throws {
+        // -1
+        let desNeg1 = BincodeDeserializer(
+            input: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255])
+        let neg1 = try desNeg1.deserialize_i128()
+        XCTAssertEqual(neg1.low, UInt64.max)
+        XCTAssertEqual(neg1.high, -1)
+
+        // +1
+        let desPos1 = BincodeDeserializer(
+            input: [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        let pos1 = try desPos1.deserialize_i128()
+        XCTAssertEqual(pos1.low, 1)
+        XCTAssertEqual(pos1.high, 0)
+
+        // max
+        let desMax = BincodeDeserializer(
+            input: [255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 127])
+        let max = try desMax.deserialize_i128()
+        XCTAssertEqual(max.low, UInt64.max)
+        XCTAssertEqual(max.high, Int64.max)
+
+        // min
+        let desMin = BincodeDeserializer(
+            input: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80])
+        let min = try desMin.deserialize_i128()
+        XCTAssertEqual(min.low, 0)
+        XCTAssertEqual(min.high, Int64.min)
+    }
+
+    func testRoundTripI128() throws {
+        let values: [Int128] = [
+            Int128(high: 0, low: 0),
+            Int128(high: 0, low: 1),
+            Int128(high: -1, low: UInt64.max),
+            Int128(high: Int64.max, low: UInt64.max),
+            Int128(high: Int64.min, low: 0),
+            Int128(high: 0x1234_5678_9ABC_DEF0, low: 0xFEDC_BA98_7654_3210),
+        ]
+        for value in values {
+            let serializer = BincodeSerializer()
+            try serializer.serialize_i128(value: value)
+            let deserializer = BincodeDeserializer(input: serializer.get_bytes())
+            let result = try deserializer.deserialize_i128()
+            XCTAssertEqual(result.high, value.high, "high mismatch for \(value)")
+            XCTAssertEqual(result.low, value.low, "low mismatch for \(value)")
+        }
     }
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
@@ -117,13 +117,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_u128() throws -> UInt128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of UInt128 on ARM64.
         let low = try deserialize_u64()
         let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: UInt128.self)
+        return UInt128(high: high, low: low)
     }
 
     public func deserialize_i8() throws -> Int8 {
@@ -143,14 +139,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_i128() throws -> Int128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of Int128 on ARM64.
-        // Read both halves as UInt64 bit patterns; the cast reinterprets them.
         let low = try deserialize_u64()
-        let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: Int128.self)
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
     }
 
     public func deserialize_option_tag() throws -> Bool {

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Serde/BinarySerializer.swift
@@ -86,13 +86,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_u128(value: UInt128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
     }
 
     public func serialize_i8(value: Int8) throws {
@@ -112,13 +107,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_i128(value: Int128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
     }
 
     public func serialize_option_tag(value: Bool) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
@@ -117,13 +117,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_u128() throws -> UInt128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of UInt128 on ARM64.
         let low = try deserialize_u64()
         let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: UInt128.self)
+        return UInt128(high: high, low: low)
     }
 
     public func deserialize_i8() throws -> Int8 {
@@ -143,14 +139,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_i128() throws -> Int128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of Int128 on ARM64.
-        // Read both halves as UInt64 bit patterns; the cast reinterprets them.
         let low = try deserialize_u64()
-        let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: Int128.self)
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
     }
 
     public func deserialize_option_tag() throws -> Bool {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Serde/BinarySerializer.swift
@@ -86,13 +86,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_u128(value: UInt128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
     }
 
     public func serialize_i8(value: Int8) throws {
@@ -112,13 +107,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_i128(value: Int128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
     }
 
     public func serialize_option_tag(value: Bool) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Serde/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Serde/Sources/Serde/BinaryDeserializer.swift
@@ -117,13 +117,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_u128() throws -> UInt128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of UInt128 on ARM64.
         let low = try deserialize_u64()
         let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: UInt128.self)
+        return UInt128(high: high, low: low)
     }
 
     public func deserialize_i8() throws -> Int8 {
@@ -143,14 +139,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_i128() throws -> Int128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of Int128 on ARM64.
-        // Read both halves as UInt64 bit patterns; the cast reinterprets them.
         let low = try deserialize_u64()
-        let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: Int128.self)
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
     }
 
     public func deserialize_option_tag() throws -> Bool {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Serde/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Serde/Sources/Serde/BinarySerializer.swift
@@ -86,13 +86,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_u128(value: UInt128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
     }
 
     public func serialize_i8(value: Int8) throws {
@@ -112,13 +107,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_i128(value: Int128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
     }
 
     public func serialize_option_tag(value: Bool) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Serde/BinaryDeserializer.swift
@@ -117,13 +117,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_u128() throws -> UInt128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of UInt128 on ARM64.
         let low = try deserialize_u64()
         let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: UInt128.self)
+        return UInt128(high: high, low: low)
     }
 
     public func deserialize_i8() throws -> Int8 {
@@ -143,14 +139,9 @@ public class BinaryDeserializer: Deserializer {
     }
 
     public func deserialize_i128() throws -> Int128 {
-        // Use unsafeBitCast to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // Bincode encodes as [low 8 bytes][high 8 bytes] (little-endian),
-        // matching the in-memory layout of Int128 on ARM64.
-        // Read both halves as UInt64 bit patterns; the cast reinterprets them.
         let low = try deserialize_u64()
-        let high = try deserialize_u64()
-        return unsafeBitCast((low, high), to: Int128.self)
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
     }
 
     public func deserialize_option_tag() throws -> Bool {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Serde/BinarySerializer.swift
@@ -86,13 +86,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_u128(value: UInt128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
     }
 
     public func serialize_i8(value: Int8) throws {
@@ -112,13 +107,8 @@ public class BinarySerializer: Serializer {
     }
 
     public func serialize_i128(value: Int128) throws {
-        // Use raw byte access to avoid requiring BinaryInteger conformance,
-        // which is gated behind macOS 15 / iOS 18.
-        // On little-endian (ARM64) the memory layout matches Bincode's encoding.
-        var v = value
-        withUnsafeBytes(of: &v) { ptr in
-            output.append(contentsOf: ptr)
-        }
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
     }
 
     public func serialize_option_tag(value: Bool) throws {


### PR DESCRIPTION
## Fix Swift codegen: replace native `Int128`/`UInt128` with custom structs

### Problem

The generated Swift Serde runtime referenced `Int128` and `UInt128` by name without providing a definition. Swift therefore resolved them to the native language types, which are only available from macOS 15 / iOS 18. Any project targeting an older platform would fail to build with errors like:

```
error: 'UInt128' is only available in macOS 15.0 or newer
```

There were also two latent bugs in the serialiser and deserialiser that would have produced **silently corrupt data** once the custom struct definitions were in place:

- `serialize_u128`/`serialize_i128` used `withUnsafeBytes(of: &v)`, which dumps raw memory in field-declaration order (`high` then `low`). Bincode expects little-endian layout (`low` then `high`).
- `deserialize_u128`/`deserialize_i128` used `unsafeBitCast((low, high), to: T.self)`, which reinterprets the tuple directly — this would swap `high` and `low` in a struct whose first field is `high`.

Both tricks were only correct for the native Swift types, whose in-memory layout happens to match. The comments in the code acknowledged the architectural dependency explicitly.

A secondary issue: `Int128.swift` and `UInt128.swift` had previously existed in the snapshot directories but were never in the runtime bundle, so the generator never emitted them. The snapshot tests passed only because they iterate over *generated* files — extra files sitting in the snapshot directory are silently ignored.

### Changes

**Runtime sources** (`runtime/swift/Sources/Serde/`)

- Add `Int128.swift` and `UInt128.swift` — plain `Hashable` structs with `high` and `low` fields. No platform availability requirements.
- Fix `BinarySerializer.swift` — replace `withUnsafeBytes` with explicit `serialize_u64(value: value.low)` then `serialize_u64(value: value.high)` (and `UInt64(bitPattern:)` for the signed case). Correct on every architecture, no memory-layout assumptions.
- Fix `BinaryDeserializer.swift` — replace `unsafeBitCast` with `UInt128(high: high, low: low)` / `Int128(high: high, low: low)`. Also corrects `deserialize_i128`, which was calling `deserialize_u64()` for the high word instead of `deserialize_i64()`.

**Snapshot directories** (4 test fixture sets updated to match)

**`Package.swift`**

- Drop the platform floor from `.macOS(.v15)` to the actual minimum the runtime code requires. The only language feature with a platform constraint is `@propertyWrapper` (used in `Indirect.swift`), which needs Swift 5.1. Declared minimums: `.macOS(.v10_15)`, `.iOS(.v13)`, `.watchOS(.v6)`, `.tvOS(.v13)`.

**`SerdeTests.swift`**

- Fix the existing `testSerializeU128` and `testSerializeI128` tests, which used native-type APIs (`UInt128.max`, `Int128.min`, integer literals) that no longer compile against the custom structs. Replaced with explicit struct initialisers.
- Add `testDeserializeU128` / `testDeserializeI128` — feed known byte vectors into the deserialiser and assert `high` and `low` field values individually. This catches byte-order bugs that serialize-only tests cannot detect.
- Add `testRoundTripU128` / `testRoundTripI128` — serialize then deserialize a range of representative values (zero, one, high-word-only, boundary values, an arbitrary pattern) and assert field equality, providing end-to-end coverage of the full codec path.

### What was not changed

The emitter (`Format::I128` → `"Int128"`, `Format::U128` → `"UInt128"`) is unchanged. The generated field declarations, `serialize_i128`/`deserialize_i128` call sites, and `Serializer`/`Deserializer` protocol signatures are all unchanged. The custom structs are drop-in replacements — they just need to be present in the bundle, which they now are.