### PR TITLE
Add native UUID support for all four target languages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,14 +106,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -314,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -351,6 +350,7 @@ dependencies = [
  "iddqd",
  "impls",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -433,6 +433,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.18",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -745,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -929,7 +930,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1085,7 +1086,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1203,6 +1204,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,7 +1328,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1379,85 +1392,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/facet_generate/Cargo.toml
+++ b/crates/facet_generate/Cargo.toml
@@ -28,9 +28,10 @@ chrono = "0.4.44"
 difficient = "0.1.0"
 anyhow.workspace = true
 expect-test.workspace = true
-facet = { workspace = true, features = ["chrono", "url", "bytes"] }
+facet = { workspace = true, features = ["chrono", "url", "bytes", "uuid"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 ignore = "0.4"
-insta = { version = "1.46.3", features = ["yaml", "json"] }
+insta = { version = "1.47.2", features = ["yaml", "json"] }
 maplit = "1.0.2"
 strum = { version = "0.28.0", features = ["derive"] }
 tempfile = "3.27.0"

--- a/crates/facet_generate/src/generation/bincode/csharp.rs
+++ b/crates/facet_generate/src/generation/bincode/csharp.rs
@@ -28,7 +28,7 @@ use super::BincodePlugin;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
 use crate::generation::{
-    CodeGeneratorConfig,
+    CodeGeneratorConfig, Feature,
     csharp::CSharp,
     indent::{IndentWrite, Newlines, with_block},
     plugin::{EmitContext, EmitterPlugin, RuntimeFile},
@@ -36,6 +36,40 @@ use crate::generation::{
 use crate::reflection::format::{
     ContainerFormat, Format, Named, Namespace, QualifiedTypeName, VariantFormat,
 };
+
+// ---------------------------------------------------------------------------
+// Feature helper snippets
+// ---------------------------------------------------------------------------
+
+/// C# UUID serialization helper class.
+///
+/// Emitted once per module (via `module_helpers`) when `Feature::Uuid` is
+/// active.  Uses the .NET 5+ `bigEndian: true` overloads of
+/// `Guid.TryWriteBytes` / `new Guid(bytes, bigEndian: true)` to produce
+/// RFC 4122 byte order, matching Rust's `uuid::Uuid::as_bytes()` wire
+/// format.
+const FEATURE_UUID: &str = r#"internal static class UuidSerde
+{
+    public static void Serialize(Guid value, ISerializer serializer)
+    {
+        // .NET 5+: bigEndian: true produces RFC 4122 byte order,
+        // matching Rust's uuid::Uuid::as_bytes() wire format.
+        Span<byte> bytes = stackalloc byte[16];
+        value.TryWriteBytes(bytes, bigEndian: true, out _);
+        serializer.SerializeBytes(bytes.ToArray());
+    }
+
+    public static Guid Deserialize(IDeserializer deserializer)
+    {
+        var bytes = deserializer.DeserializeBytes();
+        if (bytes.Length != 16)
+        {
+            throw new DeserializationError($"UUID must be 16 bytes, got {bytes.Length}");
+        }
+        return new Guid(bytes, bigEndian: true);
+    }
+}
+"#;
 
 impl EmitterPlugin<CSharp> for BincodePlugin {
     /// Returns the core, serde, and bincode C# runtime sources to be written
@@ -104,9 +138,32 @@ impl EmitterPlugin<CSharp> for BincodePlugin {
         ]
     }
 
-    /// Returns the single `using` directive needed for bincode support.
-    fn imports(&self, _config: &CodeGeneratorConfig) -> Vec<String> {
-        vec!["using Facet.Runtime.Bincode;".to_string()]
+    /// Returns `using` directives needed for bincode support.
+    ///
+    /// Always includes `Facet.Runtime.Bincode`.  When `Feature::Uuid` is
+    /// active, also adds `System` so that `Guid` resolves.
+    fn imports(&self, config: &CodeGeneratorConfig) -> Vec<String> {
+        let mut imports = vec!["using Facet.Runtime.Bincode;".to_string()];
+        if config.features.contains(&Feature::Uuid) {
+            imports.push("using System;".to_string());
+        }
+        imports
+    }
+
+    /// Emits the `UuidSerde` helper class when `Feature::Uuid` is active.
+    ///
+    /// C# puts collection-type helpers (`FacetHelpers`) into a shared runtime
+    /// file, so only UUID needs a per-module snippet.
+    fn module_helpers(
+        &self,
+        w: &mut dyn IndentWrite,
+        config: &CodeGeneratorConfig,
+    ) -> io::Result<()> {
+        if config.features.contains(&Feature::Uuid) {
+            write!(w, "{FEATURE_UUID}")?;
+            writeln!(w)?;
+        }
+        Ok(())
     }
 
     /// Injects `IFacetSerializable` and `IFacetDeserializable<T>` conformances.
@@ -623,6 +680,7 @@ fn write_serialize_expr(
         Format::Char => write!(w, "{ser}.SerializeChar({val})"),
         Format::Str => write!(w, "{ser}.SerializeStr({val})"),
         Format::Bytes => write!(w, "{ser}.SerializeBytes({val})"),
+        Format::Uuid => write!(w, "UuidSerde.Serialize({val}, {ser})"),
         Format::Option(inner) => {
             let helper = option_serialize_helper(inner);
             write!(w, "FacetHelpers.{helper}({val}, {ser}, ")?;
@@ -693,6 +751,7 @@ fn write_deserialize_expr(
         Format::Char => write!(w, "{de}.DeserializeChar()"),
         Format::Str => write!(w, "{de}.DeserializeStr()"),
         Format::Bytes => write!(w, "{de}.DeserializeBytes()"),
+        Format::Uuid => write!(w, "UuidSerde.Deserialize({de})"),
         Format::Option(inner) => {
             let helper = option_deserialize_helper(inner);
             write!(w, "FacetHelpers.{helper}({de}, ")?;
@@ -933,6 +992,7 @@ fn csharp_type(format: &Format) -> String {
         Format::Char => "char".to_string(),
         Format::Str => "string".to_string(),
         Format::Bytes => "byte[]".to_string(),
+        Format::Uuid => "Guid".to_string(),
         Format::Option(inner) => format!("{}?", csharp_type(inner)),
         Format::Seq(inner) => format!("ObservableCollection<{}>", csharp_type(inner)),
         Format::Set(inner) => format!("HashSet<{}>", csharp_type(inner)),
@@ -997,6 +1057,7 @@ const fn is_csharp_value_type(format: &Format) -> bool {
             | Format::F32
             | Format::F64
             | Format::Char
+            | Format::Uuid
             | Format::Tuple(_)
     )
 }

--- a/crates/facet_generate/src/generation/bincode/kotlin.rs
+++ b/crates/facet_generate/src/generation/bincode/kotlin.rs
@@ -775,6 +775,7 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
                     imports.push(format!("import {sp}.Bytes"));
                 }
                 Feature::Uuid => {
+                    imports.push(format!("import {sp}.Bytes"));
                     imports.push("import java.util.UUID".to_string());
                 }
                 Feature::BigInt => {

--- a/crates/facet_generate/src/generation/bincode/kotlin.rs
+++ b/crates/facet_generate/src/generation/bincode/kotlin.rs
@@ -125,6 +125,32 @@ fun <T> Deserializer.deserializeSetOf(deserializeElement: (Deserializer) -> T): 
 }
 ";
 
+const FEATURE_UUID: &str = r#"fun UUID.serialize(serializer: Serializer) {
+    val bytes = ByteArray(16)
+    val msb = mostSignificantBits
+    val lsb = leastSignificantBits
+    for (i in 0..7) {
+        bytes[i]     = (msb ushr (56 - i * 8) and 0xff).toByte()
+        bytes[8 + i] = (lsb ushr (56 - i * 8) and 0xff).toByte()
+    }
+    serializer.serialize_bytes(Bytes(bytes))
+}
+
+fun Deserializer.deserializeUuid(): UUID {
+    val bytes = deserialize_bytes().content
+    if (bytes.size != 16) {
+        throw DeserializationError("UUID must be 16 bytes, got ${bytes.size}")
+    }
+    var msb = 0L
+    var lsb = 0L
+    for (i in 0..7) {
+        msb = (msb shl 8) or (bytes[i].toLong() and 0xff)
+        lsb = (lsb shl 8) or (bytes[8 + i].toLong() and 0xff)
+    }
+    return UUID(msb, lsb)
+}
+"#;
+
 fn write_bincode_serialize<W: Write>(w: &mut W) -> Result<()> {
     writedoc!(
         w,
@@ -182,6 +208,7 @@ fn write_serialize<W: IndentWrite>(
         Format::Char => writeln!(w, "serializer.serialize_char({field_name})"),
         Format::Str => writeln!(w, "serializer.serialize_str({field_name})"),
         Format::Bytes => writeln!(w, "serializer.serialize_bytes({field_name})"),
+        Format::Uuid => writeln!(w, "{field_name}.serialize(serializer)"),
 
         Format::Option(inner_format) => {
             write!(w, "{field_name}.serializeOptionOf(serializer) ")?;
@@ -304,6 +331,7 @@ fn write_deserialize<W: IndentWrite>(
         Format::Char => write!(w, "deserializer.deserialize_char()"),
         Format::Str => write!(w, "deserializer.deserialize_str()"),
         Format::Bytes => write!(w, "deserializer.deserialize_bytes()"),
+        Format::Uuid => write!(w, "deserializer.deserializeUuid()"),
         Format::Seq(format) => {
             write!(w, "deserializer.deserializeListOf ")?;
             write_deserialize_lambda(w, format)
@@ -746,6 +774,9 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
                 Feature::Bytes => {
                     imports.push(format!("import {sp}.Bytes"));
                 }
+                Feature::Uuid => {
+                    imports.push("import java.util.UUID".to_string());
+                }
                 Feature::BigInt => {
                     // BigInteger is JVM-only; kept for backward compat.
                     imports.push("import java.math.BigInteger".to_string());
@@ -788,6 +819,10 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
                 }
                 Feature::MapOfT => {
                     write!(w, "{FEATURE_MAP_OF_T}")?;
+                    writeln!(w)?;
+                }
+                Feature::Uuid => {
+                    write!(w, "{FEATURE_UUID}")?;
                     writeln!(w)?;
                 }
                 // BigInt and Bytes add imports (handled above); TupleArray is

--- a/crates/facet_generate/src/generation/bincode/swift.rs
+++ b/crates/facet_generate/src/generation/bincode/swift.rs
@@ -143,6 +143,34 @@ func deserializeSet<T: Hashable, D: Deserializer>(
 }
 ";
 
+const FEATURE_UUID: &str = r#"func serializeUuid<S: Serializer>(
+    value: UUID,
+    serializer: S
+) throws {
+    let u = value.uuid
+    let bytes: [UInt8] = [
+        u.0,  u.1,  u.2,  u.3,  u.4,  u.5,  u.6,  u.7,
+        u.8,  u.9,  u.10, u.11, u.12, u.13, u.14, u.15,
+    ]
+    try serializer.serialize_bytes(value: bytes)
+}
+
+func deserializeUuid<D: Deserializer>(
+    deserializer: D
+) throws -> UUID {
+    let bytes = try deserializer.deserialize_bytes()
+    guard bytes.count == 16 else {
+        throw DeserializationError.invalidInput(issue: "UUID must be 16 bytes, got \(bytes.count)")
+    }
+    return UUID(uuid: (
+        bytes[0],  bytes[1],  bytes[2],  bytes[3],
+        bytes[4],  bytes[5],  bytes[6],  bytes[7],
+        bytes[8],  bytes[9],  bytes[10], bytes[11],
+        bytes[12], bytes[13], bytes[14], bytes[15]
+    ))
+}
+"#;
+
 const FEATURE_TUPLE_ARRAY: &str = r"func serializeTupleArray<T, S: Serializer>(
     value: [T],
     serializer: S,
@@ -187,8 +215,12 @@ impl EmitterPlugin<Swift> for BincodePlugin {
             .collect()
     }
 
-    fn imports(&self, _config: &CodeGeneratorConfig) -> Vec<String> {
-        vec!["Serde".to_string()]
+    fn imports(&self, config: &CodeGeneratorConfig) -> Vec<String> {
+        let mut imports = vec!["Serde".to_string()];
+        if config.features.contains(&Feature::Uuid) {
+            imports.push("Foundation".to_string());
+        }
+        imports
     }
 
     fn module_helpers(
@@ -217,6 +249,10 @@ impl EmitterPlugin<Swift> for BincodePlugin {
                 Feature::TupleArray => {
                     writeln!(w)?;
                     write!(w, "{FEATURE_TUPLE_ARRAY}")?;
+                }
+                Feature::Uuid => {
+                    writeln!(w)?;
+                    write!(w, "{FEATURE_UUID}")?;
                 }
                 _ => {}
             }
@@ -569,6 +605,12 @@ fn write_format_serialize(
                 write_format_serialize(w, content, "item")
             })
         }
+        Format::Uuid => {
+            writeln!(
+                w,
+                "try serializeUuid(value: {value_expr}, serializer: serializer)"
+            )
+        }
         primitive => {
             let t = format!("{primitive:?}").to_lowercase();
             writeln!(w, "try serializer.serialize_{t}(value: {value_expr})")
@@ -676,6 +718,7 @@ fn write_deserialize_expr(w: &mut dyn IndentWrite, format: &Format) -> io::Resul
             w.unindent();
             write!(w, "}}")
         }
+        Format::Uuid => write!(w, "try deserializeUuid(deserializer: deserializer)"),
         primitive => {
             let t = format!("{primitive:?}").to_lowercase();
             write!(w, "try deserializer.deserialize_{t}()")

--- a/crates/facet_generate/src/generation/bincode/typescript.rs
+++ b/crates/facet_generate/src/generation/bincode/typescript.rs
@@ -162,6 +162,50 @@ function deserializeTupleArray<T>(
 }
 ";
 
+const FEATURE_UUID: &str = r"export type Uuid = string & { readonly __uuid: unique symbol };
+
+const HEX = '0123456789abcdef';
+
+function uuidStringToBytes(value: Uuid): Uint8Array {
+    const hex = (value as string).replace(/-/g, '');
+    if (hex.length !== 32) {
+        throw new Error(`Invalid UUID: ${value}`);
+    }
+    const bytes = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+        const hi = HEX.indexOf(hex[i * 2].toLowerCase());
+        const lo = HEX.indexOf(hex[i * 2 + 1].toLowerCase());
+        if (hi < 0 || lo < 0) {
+            throw new Error(`Invalid UUID: ${value}`);
+        }
+        bytes[i] = (hi << 4) | lo;
+    }
+    return bytes;
+}
+
+function bytesToUuidString(bytes: Uint8Array): Uuid {
+    if (bytes.length !== 16) {
+        throw new Error(`UUID must be 16 bytes, got ${bytes.length}`);
+    }
+    let s = '';
+    for (let i = 0; i < 16; i++) {
+        s += HEX[(bytes[i] >> 4) & 0xf] + HEX[bytes[i] & 0xf];
+        if (i === 3 || i === 5 || i === 7 || i === 9) {
+            s += '-';
+        }
+    }
+    return s as Uuid;
+}
+
+function serializeUuid(value: Uuid, serializer: Serializer): void {
+    serializer.serializeBytes(uuidStringToBytes(value));
+}
+
+function deserializeUuid(deserializer: Deserializer): Uuid {
+    return bytesToUuidString(deserializer.deserializeBytes());
+}
+";
+
 // ---------------------------------------------------------------------------
 // EmitterPlugin implementation
 // ---------------------------------------------------------------------------
@@ -236,6 +280,10 @@ impl EmitterPlugin<TypeScript> for BincodePlugin {
                 Feature::TupleArray => {
                     writeln!(w)?;
                     write!(w, "{FEATURE_TUPLE_ARRAY}")?;
+                }
+                Feature::Uuid => {
+                    writeln!(w)?;
+                    write!(w, "{FEATURE_UUID}")?;
                 }
                 Feature::BigInt | Feature::Bytes => {}
             }
@@ -390,6 +438,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
         Format::Char => writeln!(w, "serializer.serializeChar({value_expr});"),
         Format::Str => writeln!(w, "serializer.serializeStr({value_expr});"),
         Format::Bytes => writeln!(w, "serializer.serializeBytes({value_expr});"),
+        Format::Uuid => writeln!(w, "serializeUuid({value_expr}, serializer);"),
         Format::Option(inner) => {
             write!(
                 w,
@@ -471,6 +520,7 @@ fn quote_type(format: &Format) -> String {
         Format::Char => "char".to_string(),
         Format::Str => "str".to_string(),
         Format::Bytes => "bytes".to_string(),
+        Format::Uuid => "Uuid".to_string(),
         Format::Option(inner) => format!("Optional<{}>", quote_type(inner)),
         Format::Seq(inner) | Format::Set(inner) => format!("Seq<{}>", quote_type(inner)),
         Format::Map { key, value } => {
@@ -515,6 +565,7 @@ fn deserialize_primitive_expr(format: &Format) -> String {
         Format::Char => "deserializer.deserializeChar()".to_string(),
         Format::Str => "deserializer.deserializeStr()".to_string(),
         Format::Bytes => "deserializer.deserializeBytes()".to_string(),
+        Format::Uuid => "deserializeUuid(deserializer)".to_string(),
         _ => panic!("deserialize_primitive_expr called with non-primitive format"),
     }
 }
@@ -541,6 +592,7 @@ const fn is_primitive_or_named(format: &Format) -> bool {
             | Format::Char
             | Format::Str
             | Format::Bytes
+            | Format::Uuid
     )
 }
 

--- a/crates/facet_generate/src/generation/config.rs
+++ b/crates/facet_generate/src/generation/config.rs
@@ -77,6 +77,7 @@ pub enum Feature {
     OptionOfT,
     SetOfT,
     TupleArray,
+    Uuid,
 }
 
 /// Track type definitions provided by other modules (key = `module`, value = `type names`).
@@ -209,6 +210,9 @@ impl CodeGeneratorConfig {
                         Format::Bytes => {
                             self.features.insert(Feature::Bytes);
                         }
+                        Format::Uuid => {
+                            self.features.insert(Feature::Uuid);
+                        }
                         Format::Seq(..) => {
                             self.features.insert(Feature::ListOfT);
                         }
@@ -254,6 +258,7 @@ impl CodeGeneratorConfig {
                         Format::Char => "char",
                         Format::Str => "str",
                         Format::Bytes => "bytes",
+                        Format::Uuid => "uuid",
                         Format::Option(_) => "option",
                         Format::Seq(_) | Format::Set(_) => "seq",
                         Format::Map { .. } => "map",

--- a/crates/facet_generate/src/generation/csharp/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/csharp/emitter/mod.rs
@@ -124,7 +124,7 @@ impl CSharp {
 }
 
 impl Emitter<CSharp> for Module {
-    fn write<W: Write>(&self, w: &mut W, lang: &CSharp) -> Result<()> {
+    fn write<W: IndentWrite>(&self, w: &mut W, lang: &CSharp) -> Result<()> {
         let CodeGeneratorConfig { module_name, .. } = self.config();
         writeln!(w, "using CommunityToolkit.Mvvm.ComponentModel;")?;
         writeln!(w, "using Facet.Runtime.Serde;")?;
@@ -138,6 +138,13 @@ impl Emitter<CSharp> for Module {
         }
         writeln!(w)?;
         writeln!(w, "namespace {};", namespace_name(module_name))?;
+        // Plugin module helpers (e.g. UuidSerde from BincodePlugin).
+        // These are emitted per-module file rather than into a shared runtime
+        // file because they reference types (e.g. Guid) that may not be in
+        // scope in the shared runtime namespace.
+        for plugin in lang.plugins() {
+            plugin.module_helpers(w, self.config())?;
+        }
         writeln!(w)
     }
 }

--- a/crates/facet_generate/src/generation/csharp/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/csharp/emitter/mod.rs
@@ -476,6 +476,7 @@ fn csharp_type(format: &Format) -> String {
         Format::Char => "char".to_string(),
         Format::Str => "string".to_string(),
         Format::Bytes => "byte[]".to_string(),
+        Format::Uuid => "Guid".to_string(),
         Format::Option(inner) => format!("{}?", csharp_type(inner)),
         Format::Seq(inner) => format!("ObservableCollection<{}>", csharp_type(inner)),
         Format::Set(inner) => format!("HashSet<{}>", csharp_type(inner)),

--- a/crates/facet_generate/src/generation/json/csharp.rs
+++ b/crates/facet_generate/src/generation/json/csharp.rs
@@ -20,7 +20,7 @@ use std::io;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
 use crate::generation::{
-    CodeGeneratorConfig,
+    CodeGeneratorConfig, Feature,
     csharp::CSharp,
     indent::{IndentWrite, Newlines, with_block},
     plugin::{EmitContext, EmitterPlugin, RuntimeFile},
@@ -72,11 +72,20 @@ impl EmitterPlugin<CSharp> for JsonPlugin {
     }
 
     /// Returns `using` directives for JSON support.
-    fn imports(&self, _config: &CodeGeneratorConfig) -> Vec<String> {
-        vec![
+    ///
+    /// Always includes `Facet.Runtime.Json` and `System.Text.Json.Serialization`.
+    /// When `Feature::Uuid` is active, also adds `System` so that `Guid`
+    /// resolves — `System.Text.Json` serializes `Guid` as a hyphenated
+    /// lowercase UUID string automatically.
+    fn imports(&self, config: &CodeGeneratorConfig) -> Vec<String> {
+        let mut imports = vec![
             "using Facet.Runtime.Json;".to_string(),
             "using System.Text.Json.Serialization;".to_string(),
-        ]
+        ];
+        if config.features.contains(&Feature::Uuid) {
+            imports.push("using System;".to_string());
+        }
+        imports
     }
 
     /// Emits JSON type-level annotations.

--- a/crates/facet_generate/src/generation/json/kotlin.rs
+++ b/crates/facet_generate/src/generation/json/kotlin.rs
@@ -38,6 +38,17 @@ private object BigIntegerSerializer : KSerializer<BigInteger> {
 }
 "#;
 
+/// The `UUID` JSON helper — a custom `KSerializer<java.util.UUID>` that
+/// round-trips `UUID` values through JSON string literals.
+const FEATURE_UUID: &str = r#"private object UUIDSerializer : KSerializer<java.util.UUID> {
+    override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+    override fun deserialize(decoder: Decoder): java.util.UUID = java.util.UUID.fromString(decoder.decodeString())
+    override fun serialize(encoder: Encoder, value: java.util.UUID) = encoder.encodeString(value.toString())
+}
+
+typealias UUID = @Serializable(with = UUIDSerializer::class) java.util.UUID
+"#;
+
 impl EmitterPlugin<Kotlin> for JsonPlugin {
     /// Returns the serde Kotlin runtime sources needed for JSON encoding.
     fn runtime_files(&self) -> Vec<RuntimeFile> {
@@ -71,6 +82,17 @@ impl EmitterPlugin<Kotlin> for JsonPlugin {
             "import kotlinx.serialization.SerialName".to_string(),
         ];
 
+        // UUID JSON-specific imports
+        if config.features.contains(&Feature::Uuid) {
+            imports.extend([
+                "import kotlinx.serialization.KSerializer".to_string(),
+                "import kotlinx.serialization.descriptors.PrimitiveKind".to_string(),
+                "import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor".to_string(),
+                "import kotlinx.serialization.encoding.Decoder".to_string(),
+                "import kotlinx.serialization.encoding.Encoder".to_string(),
+            ]);
+        }
+
         // BigInt JSON-specific imports
         if config.features.contains(&Feature::BigInt) {
             imports.extend([
@@ -98,6 +120,10 @@ impl EmitterPlugin<Kotlin> for JsonPlugin {
         w: &mut dyn IndentWrite,
         config: &CodeGeneratorConfig,
     ) -> io::Result<()> {
+        if config.features.contains(&Feature::Uuid) {
+            write!(w, "{FEATURE_UUID}")?;
+            writeln!(w)?;
+        }
         if config.features.contains(&Feature::BigInt) {
             write!(w, "{FEATURE_BIGINT}")?;
             writeln!(w)?;

--- a/crates/facet_generate/src/generation/json/swift.rs
+++ b/crates/facet_generate/src/generation/json/swift.rs
@@ -168,6 +168,24 @@ func deserializeTupleArray<T, D: Deserializer>(
 }
 ";
 
+const FEATURE_UUID: &str = r#"func serializeUuid<S: Serializer>(
+    value: UUID,
+    serializer: S
+) throws {
+    try serializer.serialize_str(value: value.uuidString.lowercased())
+}
+
+func deserializeUuid<D: Deserializer>(
+    deserializer: D
+) throws -> UUID {
+    let s = try deserializer.deserialize_str()
+    guard let uuid = UUID(uuidString: s) else {
+        throw DeserializationError.invalidInput(issue: "Invalid UUID string: \(s)")
+    }
+    return uuid
+}
+"#;
+
 // ---------------------------------------------------------------------------
 // EmitterPlugin implementation
 // ---------------------------------------------------------------------------
@@ -185,8 +203,12 @@ impl EmitterPlugin<Swift> for JsonPlugin {
             .collect()
     }
 
-    fn imports(&self, _config: &CodeGeneratorConfig) -> Vec<String> {
-        vec!["Serde".to_string()]
+    fn imports(&self, config: &CodeGeneratorConfig) -> Vec<String> {
+        let mut imports = vec!["Serde".to_string()];
+        if config.features.contains(&Feature::Uuid) {
+            imports.push("Foundation".to_string());
+        }
+        imports
     }
 
     fn module_helpers(
@@ -215,6 +237,10 @@ impl EmitterPlugin<Swift> for JsonPlugin {
                 Feature::TupleArray => {
                     writeln!(w)?;
                     write!(w, "{FEATURE_TUPLE_ARRAY}")?;
+                }
+                Feature::Uuid => {
+                    writeln!(w)?;
+                    write!(w, "{FEATURE_UUID}")?;
                 }
                 _ => {}
             }
@@ -616,6 +642,12 @@ fn write_format_serialize(
                 write_format_serialize(w, content, "item")
             })
         }
+        Format::Uuid => {
+            writeln!(
+                w,
+                "try serializeUuid(value: {value_expr}, serializer: serializer)"
+            )
+        }
         primitive => {
             let t = format!("{primitive:?}").to_lowercase();
             writeln!(w, "try serializer.serialize_{t}(value: {value_expr})")
@@ -723,6 +755,7 @@ fn write_deserialize_expr(w: &mut dyn IndentWrite, format: &Format) -> io::Resul
             w.unindent();
             write!(w, "}}")
         }
+        Format::Uuid => write!(w, "try deserializeUuid(deserializer: deserializer)"),
         primitive => {
             let t = format!("{primitive:?}").to_lowercase();
             write!(w, "try deserializer.deserialize_{t}()")

--- a/crates/facet_generate/src/generation/json/typescript.rs
+++ b/crates/facet_generate/src/generation/json/typescript.rs
@@ -162,6 +162,23 @@ function deserializeTupleArray<T>(
 }
 ";
 
+const FEATURE_UUID: &str = r"export type Uuid = string & { readonly __uuid: unique symbol };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function serializeUuid(value: Uuid, serializer: Serializer): void {
+    serializer.serializeStr(value as string);
+}
+
+function deserializeUuid(deserializer: Deserializer): Uuid {
+    const s = deserializer.deserializeStr();
+    if (!UUID_RE.test(s)) {
+        throw new Error(`Invalid UUID string: ${s}`);
+    }
+    return s.toLowerCase() as Uuid;
+}
+";
+
 // ---------------------------------------------------------------------------
 // EmitterPlugin implementation
 // ---------------------------------------------------------------------------
@@ -223,6 +240,10 @@ impl EmitterPlugin<TypeScript> for JsonPlugin {
                 Feature::TupleArray => {
                     writeln!(w)?;
                     write!(w, "{FEATURE_TUPLE_ARRAY}")?;
+                }
+                Feature::Uuid => {
+                    writeln!(w)?;
+                    write!(w, "{FEATURE_UUID}")?;
                 }
                 Feature::BigInt | Feature::Bytes => {}
             }
@@ -377,6 +398,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
         Format::Char => writeln!(w, "serializer.serializeChar({value_expr});"),
         Format::Str => writeln!(w, "serializer.serializeStr({value_expr});"),
         Format::Bytes => writeln!(w, "serializer.serializeBytes({value_expr});"),
+        Format::Uuid => writeln!(w, "serializeUuid({value_expr}, serializer);"),
         Format::Option(inner) => {
             write!(
                 w,
@@ -458,6 +480,7 @@ fn quote_type(format: &Format) -> String {
         Format::Char => "char".to_string(),
         Format::Str => "str".to_string(),
         Format::Bytes => "bytes".to_string(),
+        Format::Uuid => "Uuid".to_string(),
         Format::Option(inner) => format!("Optional<{}>", quote_type(inner)),
         Format::Seq(inner) | Format::Set(inner) => format!("Seq<{}>", quote_type(inner)),
         Format::Map { key, value } => {
@@ -502,6 +525,7 @@ fn deserialize_primitive_expr(format: &Format) -> String {
         Format::Char => "deserializer.deserializeChar()".to_string(),
         Format::Str => "deserializer.deserializeStr()".to_string(),
         Format::Bytes => "deserializer.deserializeBytes()".to_string(),
+        Format::Uuid => "deserializeUuid(deserializer)".to_string(),
         _ => panic!("deserialize_primitive_expr called with non-primitive format"),
     }
 }
@@ -528,6 +552,7 @@ const fn is_primitive_or_named(format: &Format) -> bool {
             | Format::Char
             | Format::Str
             | Format::Bytes
+            | Format::Uuid
     )
 }
 

--- a/crates/facet_generate/src/generation/kotlin/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/kotlin/emitter/mod.rs
@@ -409,6 +409,7 @@ impl Emitter<Kotlin> for Format {
             Self::F64 => write!(w, "Double"),
             Self::Char | Self::Str => write!(w, "String"),
             Self::Bytes => write!(w, "Bytes"),
+            Self::Uuid => write!(w, "UUID"),
 
             Self::Option(format) => {
                 format.write(w, lang)?;

--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -167,7 +167,8 @@ pub fn is_hashable(format: &Format, lang: &Swift) -> bool {
         | Format::F64
         | Format::Char
         | Format::Str
-        | Format::Bytes => true,
+        | Format::Bytes
+        | Format::Uuid => true,
 
         Format::Option(inner)
         | Format::Set(inner)
@@ -246,7 +247,8 @@ fn is_equatable_auto(format: &Format, lang: &Swift) -> bool {
         | Format::F64
         | Format::Char
         | Format::Str
-        | Format::Bytes => true,
+        | Format::Bytes
+        | Format::Uuid => true,
         Format::Option(inner) | Format::Set(inner) => is_equatable_auto(inner, lang),
         Format::Seq(inner) | Format::TupleArray { content: inner, .. } => {
             is_equatable_auto(inner, lang)
@@ -381,6 +383,7 @@ impl Emitter<Swift> for Format {
             Self::Char => write!(w, "Character"),
             Self::Str => write!(w, "String"),
             Self::Bytes => write!(w, "[UInt8]"),
+            Self::Uuid => write!(w, "UUID"),
 
             Self::Option(format) => {
                 format.write(w, lang)?;

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -232,7 +232,8 @@ fn fmt_can_be_hashable(
         | Format::F64
         | Format::Char
         | Format::Str
-        | Format::Bytes => true,
+        | Format::Bytes
+        | Format::Uuid => true,
         Format::Option(inner)
         | Format::Set(inner)
         | Format::Seq(inner)
@@ -366,7 +367,8 @@ fn fmt_can_be_equatable(
         | Format::F64
         | Format::Char
         | Format::Str
-        | Format::Bytes => true,
+        | Format::Bytes
+        | Format::Uuid => true,
         Format::Option(inner)
         | Format::Set(inner)
         | Format::Seq(inner)

--- a/crates/facet_generate/src/generation/tests/mod.rs
+++ b/crates/facet_generate/src/generation/tests/mod.rs
@@ -34,6 +34,7 @@ mod with_serialization_and_namespaces_as_external;
 mod with_serialization_and_serde_external;
 mod with_serialization_and_serde_internal;
 mod with_serialization_and_serde_local;
+mod with_uuid;
 
 fn read_files_and_create_expect_dirs(
     tmp_path: impl AsRef<Path>,

--- a/crates/facet_generate/src/generation/tests/with_uuid/mod.rs
+++ b/crates/facet_generate/src/generation/tests/with_uuid/mod.rs
@@ -1,0 +1,121 @@
+use std::fs;
+
+use expect_test::expect_file;
+use facet::Facet;
+use tempfile::tempdir;
+use uuid::Uuid;
+
+use crate::{
+    generation::{
+        bincode::BincodePlugin,
+        json::JsonPlugin,
+        kotlin, swift,
+        tests::{TargetLanguage, check, read_files_and_create_expect_dirs},
+        typescript,
+    },
+    reflect, source_dir,
+};
+
+/// A struct with a required and an optional UUID field, exercising both
+/// bincode (16 raw bytes) and JSON (hyphenated string) encoding paths.
+#[test]
+fn test_bincode() {
+    #[derive(Facet)]
+    struct StructWithUuid {
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        name: String,
+    }
+
+    let registry = reflect!(StructWithUuid).unwrap();
+
+    let this_dir = source_dir!().join("snapshots_bincode");
+
+    for target in [
+        TargetLanguage::Kotlin,
+        TargetLanguage::Swift,
+        TargetLanguage::TypeScript,
+    ] {
+        let tmp_dir = tempdir().unwrap();
+        let tmp_path = tmp_dir.path();
+
+        let snapshot_dir = this_dir.join(target.to_string().to_lowercase());
+        fs::create_dir_all(&snapshot_dir).unwrap();
+
+        match target {
+            TargetLanguage::Kotlin => {
+                kotlin::Installer::new("com.example", tmp_path)
+                    .plugin(BincodePlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+            TargetLanguage::Swift => {
+                swift::Installer::new("Example", tmp_path)
+                    .plugin(BincodePlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+            TargetLanguage::TypeScript => {
+                typescript::Installer::new("example", tmp_path)
+                    .plugin(BincodePlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+        }
+
+        for (actual, expected) in read_files_and_create_expect_dirs(tmp_path, &snapshot_dir) {
+            check(&actual, &expect_file!(&expected));
+        }
+    }
+}
+
+#[test]
+fn test_json() {
+    #[derive(Facet)]
+    struct StructWithUuid {
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        name: String,
+    }
+
+    let registry = reflect!(StructWithUuid).unwrap();
+
+    let this_dir = source_dir!().join("snapshots_json");
+
+    for target in [
+        TargetLanguage::Kotlin,
+        TargetLanguage::Swift,
+        TargetLanguage::TypeScript,
+    ] {
+        let tmp_dir = tempdir().unwrap();
+        let tmp_path = tmp_dir.path();
+
+        let snapshot_dir = this_dir.join(target.to_string().to_lowercase());
+        fs::create_dir_all(&snapshot_dir).unwrap();
+
+        match target {
+            TargetLanguage::Kotlin => {
+                kotlin::Installer::new("com.example", tmp_path)
+                    .plugin(JsonPlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+            TargetLanguage::Swift => {
+                swift::Installer::new("Example", tmp_path)
+                    .plugin(JsonPlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+            TargetLanguage::TypeScript => {
+                typescript::Installer::new("example", tmp_path)
+                    .plugin(JsonPlugin)
+                    .generate(&registry)
+                    .unwrap();
+            }
+        }
+
+        for (actual, expected) in read_files_and_create_expect_dirs(tmp_path, &snapshot_dir) {
+            check(&actual, &expect_file!(&expected));
+        }
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/build.gradle.kts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.serialization") version "2.2.0"
+    `java-library`
+}
+
+group = "com.example"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {}
+
+tasks.withType<Jar> {
+    manifest {
+        attributes["Implementation-Title"] = "com.example"
+        attributes["Implementation-Version"] = "1.0.0"
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/example/Example.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/example/Example.kt
@@ -2,6 +2,7 @@ package com.example
 
 import com.novi.bincode.BincodeDeserializer
 import com.novi.bincode.BincodeSerializer
+import com.novi.serde.Bytes
 import com.novi.serde.DeserializationError
 import com.novi.serde.Deserializer
 import com.novi.serde.Serializer

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/example/Example.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/example/Example.kt
@@ -1,0 +1,103 @@
+package com.example
+
+import com.novi.bincode.BincodeDeserializer
+import com.novi.bincode.BincodeSerializer
+import com.novi.serde.DeserializationError
+import com.novi.serde.Deserializer
+import com.novi.serde.Serializer
+import java.util.UUID
+
+fun <T> T?.serializeOptionOf(
+    serializer: Serializer,
+    serializeElement: Serializer.(T) -> Unit,
+) {
+    if (this != null) {
+        serializer.serialize_option_tag(true)
+        serializer.serializeElement(this)
+    } else {
+        serializer.serialize_option_tag(false)
+    }
+}
+
+fun <T> Deserializer.deserializeOptionOf(deserializeElement: (Deserializer) -> T): T? {
+    val tag = deserialize_option_tag()
+    return if (tag) {
+        deserializeElement(this)
+    } else {
+        null
+    }
+}
+
+fun UUID.serialize(serializer: Serializer) {
+    val bytes = ByteArray(16)
+    val msb = mostSignificantBits
+    val lsb = leastSignificantBits
+    for (i in 0..7) {
+        bytes[i]     = (msb ushr (56 - i * 8) and 0xff).toByte()
+        bytes[8 + i] = (lsb ushr (56 - i * 8) and 0xff).toByte()
+    }
+    serializer.serialize_bytes(Bytes(bytes))
+}
+
+fun Deserializer.deserializeUuid(): UUID {
+    val bytes = deserialize_bytes().content
+    if (bytes.size != 16) {
+        throw DeserializationError("UUID must be 16 bytes, got ${bytes.size}")
+    }
+    var msb = 0L
+    var lsb = 0L
+    for (i in 0..7) {
+        msb = (msb shl 8) or (bytes[i].toLong() and 0xff)
+        lsb = (lsb shl 8) or (bytes[8 + i].toLong() and 0xff)
+    }
+    return UUID(msb, lsb)
+}
+
+data class StructWithUuid(
+    val id: UUID,
+    val parentId: UUID? = null,
+    val name: String,
+) {
+    fun serialize(serializer: Serializer) {
+        serializer.increase_container_depth()
+        id.serialize(serializer)
+        parentId.serializeOptionOf(serializer) {
+            it.serialize(serializer)
+        }
+        serializer.serialize_str(name)
+        serializer.decrease_container_depth()
+    }
+
+    fun bincodeSerialize(): ByteArray {
+        val serializer = BincodeSerializer()
+        serialize(serializer)
+        return serializer.get_bytes()
+    }
+
+    companion object {
+        fun deserialize(deserializer: Deserializer): StructWithUuid {
+            deserializer.increase_container_depth()
+            val id = deserializer.deserializeUuid()
+            val parentId =
+                deserializer.deserializeOptionOf {
+                    deserializer.deserializeUuid()
+                }
+            val name = deserializer.deserialize_str()
+            deserializer.decrease_container_depth()
+            return StructWithUuid(id, parentId, name)
+        }
+
+        @Throws(DeserializationError::class)
+        fun bincodeDeserialize(input: ByteArray?): StructWithUuid {
+            if (input == null) {
+                throw DeserializationError("Cannot deserialize null array")
+            }
+            val deserializer = BincodeDeserializer(input)
+            val value = deserialize(deserializer)
+            if (deserializer.get_buffer_offset() < input.size) {
+                throw DeserializationError("Some input bytes were not read")
+            }
+            return value
+        }
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/bincode/BincodeDeserializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/bincode/BincodeDeserializer.kt
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bincode
+
+import com.novi.serde.BinaryDeserializer
+import com.novi.serde.DeserializationError
+import com.novi.serde.Slice
+
+class BincodeDeserializer(input: ByteArray) : BinaryDeserializer(input, Long.MAX_VALUE) {
+    @Throws(DeserializationError::class)
+    override fun deserialize_f32(): Float {
+        return Float.fromBits(getInt())
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_f64(): Double {
+        return Double.fromBits(getLong())
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_len(): Long {
+        val value = getLong()
+        if (value < 0 || value > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value")
+        }
+        return value
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_variant_index(): Int {
+        return getInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice) {
+        // Not required by the format.
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/bincode/BincodeSerializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/bincode/BincodeSerializer.kt
@@ -1,0 +1,33 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.bincode
+
+import com.novi.serde.BinarySerializer
+import com.novi.serde.SerializationError
+
+class BincodeSerializer : BinarySerializer(Long.MAX_VALUE) {
+    @Throws(SerializationError::class)
+    override fun serialize_f32(value: Float) {
+        serialize_i32(value.toRawBits())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_f64(value: Double) {
+        serialize_i64(value.toRawBits())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_len(value: Long) {
+        serialize_u64(value.toULong())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_variant_index(value: Int) {
+        serialize_u32(value.toUInt())
+    }
+
+    override fun sort_map_entries(offsets: IntArray) {
+        // Not required by the format.
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/BinaryDeserializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/BinaryDeserializer.kt
@@ -1,0 +1,182 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinaryDeserializer(
+    protected val input: ByteArray,
+    maxContainerDepth: Long
+) : Deserializer {
+    private var position: Int = 0
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(DeserializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw DeserializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_str(): String {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin string")
+        }
+        val content = readBytes(len.toInt())
+        return try {
+            content.decodeToString(throwOnInvalidSequence = true)
+        } catch (e: Throwable) {
+            throw DeserializationError("Incorrect UTF8 string")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bytes(): Bytes {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin array")
+        }
+        return Bytes(readBytes(len.toInt()))
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bool(): Boolean {
+        val value = getByte()
+        return when (value.toInt()) {
+            0 -> false
+            1 -> true
+            else -> throw DeserializationError("Incorrect boolean value")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_unit(): Unit {
+        return Unit
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_char(): Char {
+        throw DeserializationError("Not implemented: deserialize_char")
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u8(): UByte {
+        return getByte().toUByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u16(): UShort {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8)).toUShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u32(): UInt {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)).toUInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u64(): ULong {
+        var value = 0uL
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toULong() and 0xffuL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u128(): UInt128 {
+        val low = deserialize_u64()
+        val high = deserialize_u64()
+        return UInt128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i8(): Byte {
+        return getByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i16(): Short {
+        return deserialize_u16().toShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i32(): Int {
+        return deserialize_u32().toInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i64(): Long {
+        return deserialize_u64().toLong()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i128(): Int128 {
+        val low = deserialize_u64()
+        val high = deserialize_i64()
+        return Int128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_option_tag(): Boolean {
+        return deserialize_bool()
+    }
+
+    override fun get_buffer_offset(): Int {
+        return position
+    }
+
+    protected fun getInt(): Int {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)
+    }
+
+    protected fun getLong(): Long {
+        var value = 0L
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toLong() and 0xffL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    protected fun getByte(): Byte {
+        requireAvailable(1)
+        val value = input[position]
+        position += 1
+        return value
+    }
+
+    private fun readBytes(count: Int): ByteArray {
+        requireAvailable(count)
+        val slice = input.copyOfRange(position, position + count)
+        position += count
+        return slice
+    }
+
+    private fun requireAvailable(count: Int) {
+        if (position + count > input.size) {
+            throw DeserializationError(INPUT_NOT_LARGE_ENOUGH)
+        }
+    }
+
+    companion object {
+        private const val INPUT_NOT_LARGE_ENOUGH = "Input is not large enough"
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/BinarySerializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/BinarySerializer.kt
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinarySerializer(maxContainerDepth: Long) : Serializer {
+    protected val output: SerdeByteArrayOutput = SerdeByteArrayOutput()
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(SerializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw SerializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_str(value: String) {
+        serialize_bytes(Bytes(value.encodeToByteArray()))
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bytes(value: Bytes) {
+        serialize_len(value.content.size.toLong())
+        output.writeBytes(value.content, 0, value.content.size)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bool(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_unit(value: Unit) {
+        // Nothing to serialize.
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_char(value: Char) {
+        throw SerializationError("Not implemented: serialize_char")
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u8(value: UByte) {
+        output.writeByte(value.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u16(value: UShort) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u32(value: UInt) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+        output.writeByte(((v ushr 16) and 0xff).toByte())
+        output.writeByte(((v ushr 24) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u64(value: ULong) {
+        var v = value
+        for (i in 0 until 8) {
+            output.writeByte((v and 0xffuL).toByte())
+            v = v shr 8
+        }
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u128(value: UInt128) {
+        serialize_u64(value.low)
+        serialize_u64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i8(value: Byte) {
+        serialize_u8(value.toUByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i16(value: Short) {
+        serialize_u16(value.toUShort())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i32(value: Int) {
+        serialize_u32(value.toUInt())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i64(value: Long) {
+        serialize_u64(value.toULong())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i128(value: Int128) {
+        serialize_u64(value.low)
+        serialize_i64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_option_tag(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    override fun get_buffer_offset(): Int {
+        return output.size()
+    }
+
+    override fun get_bytes(): ByteArray {
+        return output.toByteArray()
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Bytes.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Bytes.kt
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+/**
+ * Inline value class wrapper around ByteArray.
+ *
+ * Provides proper value semantics for `equals` and `hashCode` using
+ * structural equality (contentEquals/contentHashCode) instead of
+ * referential equality.
+ *
+ * As a value class, this wrapper has zero runtime overhead - it's
+ * inlined at compile time and compiles down to ByteArray at runtime.
+ */
+@JvmInline
+value class Bytes(val content: ByteArray) {
+    override fun toString(): String = content.contentToString()
+
+    companion object {
+        fun empty(): Bytes = Bytes(ByteArray(0))
+
+        fun valueOf(content: ByteArray): Bytes = Bytes(content)
+    }
+}
+
+/**
+ * Extension function for structural equality comparison.
+ * Required because value classes don't support overriding equals.
+ */
+fun Bytes.contentEquals(other: Bytes): Boolean =
+    this.content.contentEquals(other.content)
+
+/**
+ * Extension function for structural hash code.
+ * Required because value classes don't support overriding hashCode.
+ */
+fun Bytes.contentHashCode(): Int =
+    content.contentHashCode()

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/DeserializationError.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/DeserializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class DeserializationError(message: String) : Exception(message)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Deserializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Deserializer.kt
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Deserializer {
+    @Throws(DeserializationError::class)
+    fun deserialize_str(): String
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bytes(): Bytes
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bool(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun deserialize_unit(): Unit
+
+    @Throws(DeserializationError::class)
+    fun deserialize_char(): Char
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f32(): Float
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f64(): Double
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u8(): UByte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u16(): UShort
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u32(): UInt
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u64(): ULong
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u128(): UInt128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i8(): Byte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i16(): Short
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i32(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i64(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i128(): Int128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_len(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_variant_index(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_option_tag(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    @Throws(DeserializationError::class)
+    fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice)
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Int128.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Int128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Int128(val high: Long, val low: ULong)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
@@ -1,0 +1,48 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerdeByteArrayOutput(initialCapacity: Int = 32) {
+    private var buffer: ByteArray = ByteArray(initialCapacity)
+    private var length: Int = 0
+
+    fun writeByte(value: Byte) {
+        ensureCapacity(1)
+        buffer[length] = value
+        length += 1
+    }
+
+    fun writeBytes(value: ByteArray, offset: Int, count: Int) {
+        if (count == 0) {
+            return
+        }
+        ensureCapacity(count)
+        value.copyInto(buffer, destinationOffset = length, startIndex = offset, endIndex = offset + count)
+        length += count
+    }
+
+    fun size(): Int {
+        return length
+    }
+
+    fun toByteArray(): ByteArray {
+        return buffer.copyOf(length)
+    }
+
+    fun getBuffer(): ByteArray {
+        return buffer
+    }
+
+    private fun ensureCapacity(extra: Int) {
+        val required = length + extra
+        if (required <= buffer.size) {
+            return
+        }
+        var newSize = buffer.size
+        while (newSize < required) {
+            newSize = newSize * 2
+        }
+        buffer = buffer.copyOf(newSize)
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/SerializationError.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/SerializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerializationError(message: String) : Exception(message)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Serializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Serializer.kt
@@ -1,0 +1,77 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Serializer {
+    @Throws(SerializationError::class)
+    fun serialize_str(value: String)
+
+    @Throws(SerializationError::class)
+    fun serialize_bytes(value: Bytes)
+
+    @Throws(SerializationError::class)
+    fun serialize_bool(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun serialize_unit(value: Unit)
+
+    @Throws(SerializationError::class)
+    fun serialize_char(value: Char)
+
+    @Throws(SerializationError::class)
+    fun serialize_f32(value: Float)
+
+    @Throws(SerializationError::class)
+    fun serialize_f64(value: Double)
+
+    @Throws(SerializationError::class)
+    fun serialize_u8(value: UByte)
+
+    @Throws(SerializationError::class)
+    fun serialize_u16(value: UShort)
+
+    @Throws(SerializationError::class)
+    fun serialize_u32(value: UInt)
+
+    @Throws(SerializationError::class)
+    fun serialize_u64(value: ULong)
+
+    @Throws(SerializationError::class)
+    fun serialize_u128(value: UInt128)
+
+    @Throws(SerializationError::class)
+    fun serialize_i8(value: Byte)
+
+    @Throws(SerializationError::class)
+    fun serialize_i16(value: Short)
+
+    @Throws(SerializationError::class)
+    fun serialize_i32(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_i64(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_i128(value: Int128)
+
+    @Throws(SerializationError::class)
+    fun serialize_len(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_variant_index(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_option_tag(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    fun sort_map_entries(offsets: IntArray)
+
+    fun get_bytes(): ByteArray
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Slice.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Slice.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Slice(val start: Int, val end: Int) {
+    companion object {
+        fun compare_bytes(content: ByteArray, slice1: Slice, slice2: Slice): Int {
+            val start1 = slice1.start
+            val end1 = slice1.end
+            val start2 = slice2.start
+            val end2 = slice2.end
+            var i = 0
+            while (i < end1 - start1) {
+                val index1 = start1 + i
+                val index2 = start2 + i
+                val byte1 = content[index1].toInt() and 0xff
+                if (index2 >= end2) {
+                    return 1
+                }
+                val byte2 = content[index2].toInt() and 0xff
+                if (byte1 > byte2) {
+                    return 1
+                }
+                if (byte1 < byte2) {
+                    return -1
+                }
+                i += 1
+            }
+            if (end2 - start2 > end1 - start1) {
+                return -1
+            }
+            return 0
+        }
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple4.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple4.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple4<T0, T1, T2, T3>(val field0: T0, val field1: T1, val field2: T2, val field3: T3)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple5.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple5.kt
@@ -1,0 +1,12 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple5<T0, T1, T2, T3, T4>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple6.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/Tuple6.kt
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple6<T0, T1, T2, T3, T4, T5>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4,
+    val field5: T5
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/UInt128.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/kotlin/com/novi/serde/UInt128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class UInt128(val high: ULong, val low: ULong)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Package.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.8
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    products: [
+        .library(
+            name: "Example",
+            targets: ["Example"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: ["Serde"]
+        ),
+        .target(
+            name: "Serde",
+            dependencies: []
+        ),
+    ]
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Example/Example.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Serde
+
+func serializeOption<T, S: Serializer>(
+    value: T?,
+    serializer: S,
+    serializeElement: (T, S) throws -> Void
+) throws {
+    if let value = value {
+        try serializer.serialize_option_tag(value: true)
+        try serializeElement(value, serializer)
+    } else {
+        try serializer.serialize_option_tag(value: false)
+    }
+}
+
+func deserializeOption<T, D: Deserializer>(
+    deserializer: D,
+    deserializeElement: (D) throws -> T
+) throws -> T? {
+    let tag = try deserializer.deserialize_option_tag()
+    if tag {
+        return try deserializeElement(deserializer)
+    } else {
+        return nil
+    }
+}
+
+func serializeUuid<S: Serializer>(
+    value: UUID,
+    serializer: S
+) throws {
+    let u = value.uuid
+    let bytes: [UInt8] = [
+        u.0,  u.1,  u.2,  u.3,  u.4,  u.5,  u.6,  u.7,
+        u.8,  u.9,  u.10, u.11, u.12, u.13, u.14, u.15,
+    ]
+    try serializer.serialize_bytes(value: bytes)
+}
+
+func deserializeUuid<D: Deserializer>(
+    deserializer: D
+) throws -> UUID {
+    let bytes = try deserializer.deserialize_bytes()
+    guard bytes.count == 16 else {
+        throw DeserializationError.invalidInput(issue: "UUID must be 16 bytes, got \(bytes.count)")
+    }
+    return UUID(uuid: (
+        bytes[0],  bytes[1],  bytes[2],  bytes[3],
+        bytes[4],  bytes[5],  bytes[6],  bytes[7],
+        bytes[8],  bytes[9],  bytes[10], bytes[11],
+        bytes[12], bytes[13], bytes[14], bytes[15]
+    ))
+}
+
+public struct StructWithUuid: Hashable {
+    public var id: UUID
+    public var parentId: UUID?
+    public var name: String
+
+    public init(id: UUID, parentId: UUID?, name: String) {
+        self.id = id
+        self.parentId = parentId
+        self.name = name
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializeUuid(value: self.id, serializer: serializer)
+        try serializeOption(value: self.parentId, serializer: serializer) { value, serializer in
+            try serializeUuid(value: value, serializer: serializer)
+        }
+        try serializer.serialize_str(value: self.name)
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> StructWithUuid {
+        try deserializer.increase_container_depth()
+        let id = try deserializeUuid(deserializer: deserializer)
+        let parentId = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializeUuid(deserializer: deserializer)
+        }
+        let name = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return StructWithUuid(id: id, parentId: parentId, name: name)
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> StructWithUuid {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BinaryDeserializer.swift
@@ -1,0 +1,162 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BinaryDeserializer: Deserializer {
+    let input: [UInt8]
+    private var location: Int
+    private var containerDepthBudget: Int
+
+    init(input: [UInt8], maxContainerDepth: Int) {
+        self.input = input
+        location = 0
+        containerDepthBudget = maxContainerDepth
+    }
+
+    private func readBytes(count: Int) throws -> [UInt8] {
+        let newLocation = location + count
+        if newLocation > input.count {
+            throw DeserializationError.invalidInput(issue: "Input is too small")
+        }
+        let bytes = input[location..<newLocation]
+        location = newLocation
+        return Array(bytes)
+    }
+
+    public func deserialize_len() throws -> Int {
+        assertionFailure("Not implemented")
+        return 0
+    }
+
+    public func deserialize_variant_index() throws -> UInt32 {
+        assertionFailure("Not implemented")
+        return 0
+    }
+
+    public func deserialize_char() throws -> Character {
+        throw DeserializationError.invalidInput(issue: "Not implemented: char deserialization")
+    }
+
+    public func deserialize_f32() throws -> Float {
+        throw DeserializationError.invalidInput(issue: "Not implemented: f32 deserialization")
+    }
+
+    public func deserialize_f64() throws -> Double {
+        throw DeserializationError.invalidInput(issue: "Not implemented: f64 deserialization")
+    }
+
+    public func increase_container_depth() throws {
+        if containerDepthBudget == 0 {
+            throw DeserializationError.invalidInput(issue: "Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    public func decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    public func deserialize_str() throws -> String {
+        let bytes = try deserialize_bytes()
+        guard let value = String(bytes: bytes, encoding: .utf8) else {
+            throw DeserializationError.invalidInput(issue: "Incorrect UTF8 string")
+        }
+        return value
+    }
+
+    public func deserialize_bytes() throws -> [UInt8] {
+        let len = try deserialize_len()
+        let content = try readBytes(count: len)
+        return content
+    }
+
+    public func deserialize_bool() throws -> Bool {
+        let value = try deserialize_u8()
+        switch value {
+        case 0: return false
+        case 1: return true
+        default:
+            throw DeserializationError.invalidInput(issue: "Incorrect value for boolean: \(value)")
+        }
+    }
+
+    public func deserialize_unit() throws {}
+
+    public func deserialize_u8() throws -> UInt8 {
+        let bytes = try readBytes(count: 1)
+        return bytes[0]
+    }
+
+    public func deserialize_u16() throws -> UInt16 {
+        let bytes = try readBytes(count: 2)
+        var x = UInt16(bytes[0])
+        x += UInt16(bytes[1]) << 8
+        return x
+    }
+
+    public func deserialize_u32() throws -> UInt32 {
+        let bytes = try readBytes(count: 4)
+        var x = UInt32(bytes[0])
+        x += UInt32(bytes[1]) << 8
+        x += UInt32(bytes[2]) << 16
+        x += UInt32(bytes[3]) << 24
+        return x
+    }
+
+    public func deserialize_u64() throws -> UInt64 {
+        let bytes = try readBytes(count: 8)
+        var x = UInt64(bytes[0])
+        x += UInt64(bytes[1]) << 8
+        x += UInt64(bytes[2]) << 16
+        x += UInt64(bytes[3]) << 24
+        x += UInt64(bytes[4]) << 32
+        x += UInt64(bytes[5]) << 40
+        x += UInt64(bytes[6]) << 48
+        x += UInt64(bytes[7]) << 56
+        return x
+    }
+
+    public func deserialize_u128() throws -> UInt128 {
+        let low = try deserialize_u64()
+        let high = try deserialize_u64()
+        return UInt128(high: high, low: low)
+    }
+
+    public func deserialize_i8() throws -> Int8 {
+        return Int8(bitPattern: try deserialize_u8())
+    }
+
+    public func deserialize_i16() throws -> Int16 {
+        return Int16(bitPattern: try deserialize_u16())
+    }
+
+    public func deserialize_i32() throws -> Int32 {
+        return Int32(bitPattern: try deserialize_u32())
+    }
+
+    public func deserialize_i64() throws -> Int64 {
+        return Int64(bitPattern: try deserialize_u64())
+    }
+
+    public func deserialize_i128() throws -> Int128 {
+        let low = try deserialize_u64()
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
+    }
+
+    public func deserialize_option_tag() throws -> Bool {
+        let value = try deserialize_u8()
+        switch value {
+        case 0: return false
+        case 1: return true
+        default:
+            throw DeserializationError.invalidInput(
+                issue: "Incorrect value for option tag: \(value)")
+        }
+    }
+
+    public func get_buffer_offset() -> Int {
+        return location
+    }
+
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BinarySerializer.swift
@@ -1,0 +1,133 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BinarySerializer: Serializer {
+    var output: [UInt8]
+    private var containerDepthBudget: Int
+
+    public init(maxContainerDepth: Int) {
+        output = []
+        output.reserveCapacity(64)
+        containerDepthBudget = maxContainerDepth
+    }
+
+    public func increase_container_depth() throws {
+        if containerDepthBudget == 0 {
+            throw SerializationError.invalidValue(issue: "Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    public func decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    public func serialize_char(value _: Character) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: char serialization")
+    }
+
+    public func serialize_f32(value: Float) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: f32 serialization")
+    }
+
+    public func serialize_f64(value: Double) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: f64 serialization")
+    }
+
+    public func get_bytes() -> [UInt8] {
+        return output
+    }
+
+    public func serialize_str(value: String) throws {
+        try serialize_bytes(value: Array(value.utf8))
+    }
+
+    public func serialize_bytes(value: [UInt8]) throws {
+        try serialize_len(value: value.count)
+        output.append(contentsOf: value)
+    }
+
+    public func serialize_bool(value: Bool) throws {
+        writeByte(value ? 1 : 0)
+    }
+
+    public func serialize_unit(value _: ()) throws {}
+
+    func writeByte(_ value: UInt8) {
+        output.append(value)
+    }
+
+    public func serialize_u8(value: UInt8) throws {
+        writeByte(value)
+    }
+
+    public func serialize_u16(value: UInt16) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+    }
+
+    public func serialize_u32(value: UInt32) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+        writeByte(UInt8(truncatingIfNeeded: value >> 16))
+        writeByte(UInt8(truncatingIfNeeded: value >> 24))
+    }
+
+    public func serialize_u64(value: UInt64) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+        writeByte(UInt8(truncatingIfNeeded: value >> 16))
+        writeByte(UInt8(truncatingIfNeeded: value >> 24))
+        writeByte(UInt8(truncatingIfNeeded: value >> 32))
+        writeByte(UInt8(truncatingIfNeeded: value >> 40))
+        writeByte(UInt8(truncatingIfNeeded: value >> 48))
+        writeByte(UInt8(truncatingIfNeeded: value >> 56))
+    }
+
+    public func serialize_u128(value: UInt128) throws {
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
+    }
+
+    public func serialize_i8(value: Int8) throws {
+        try serialize_u8(value: UInt8(bitPattern: value))
+    }
+
+    public func serialize_i16(value: Int16) throws {
+        try serialize_u16(value: UInt16(bitPattern: value))
+    }
+
+    public func serialize_i32(value: Int32) throws {
+        try serialize_u32(value: UInt32(bitPattern: value))
+    }
+
+    public func serialize_i64(value: Int64) throws {
+        try serialize_u64(value: UInt64(bitPattern: value))
+    }
+
+    public func serialize_i128(value: Int128) throws {
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
+    }
+
+    public func serialize_option_tag(value: Bool) throws {
+        writeByte(value ? 1 : 0)
+    }
+
+    public func get_buffer_offset() -> Int {
+        return output.count
+    }
+
+    public func serialize_len(value _: Int) throws {
+        assertionFailure("Not implemented")
+    }
+
+    public func serialize_variant_index(value _: UInt32) throws {
+        assertionFailure("Not implemented")
+    }
+
+    public func sort_map_entries(offsets _: [Int]) {
+        assertionFailure("Not implemented")
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BincodeDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BincodeDeserializer.swift
@@ -1,0 +1,34 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BincodeDeserializer: BinaryDeserializer {
+    public let MAX_LENGTH: Int = 1 << 31 - 1
+
+    public init(input: [UInt8]) {
+        super.init(input: input, maxContainerDepth: Int.max)
+    }
+
+    override public func deserialize_len() throws -> Int {
+        let value = try deserialize_i64()
+        if value < 0 || value > MAX_LENGTH {
+            throw DeserializationError.invalidInput(issue: "Incorrect length value")
+        }
+        return Int(value)
+    }
+
+    override public func deserialize_f32() throws -> Float {
+        let num = try deserialize_u32()
+        return Float(bitPattern: num)
+    }
+
+    override public func deserialize_f64() throws -> Double {
+        let num = try deserialize_u64()
+        return Double(bitPattern: num)
+    }
+
+    override public func deserialize_variant_index() throws -> UInt32 {
+        return try deserialize_u32()
+    }
+
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BincodeSerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/BincodeSerializer.swift
@@ -1,0 +1,34 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BincodeSerializer: BinarySerializer {
+    public let MAX_LENGTH: Int = 1 << 31 - 1
+
+    public init() {
+        super.init(maxContainerDepth: Int.max)
+    }
+
+    override public func serialize_len(value: Int) throws {
+        if value < 0 || value > MAX_LENGTH {
+            throw SerializationError.invalidValue(issue: "Invalid length value")
+        }
+        try serialize_u64(value: UInt64(value))
+    }
+
+    override public func serialize_f32(value: Float) throws {
+        try serialize_u32(value: value.bitPattern)
+    }
+
+    override public func serialize_f64(value: Double) throws {
+        try serialize_u64(value: value.bitPattern)
+    }
+
+    override public func serialize_variant_index(value: UInt32) throws {
+        try serialize_u32(value: value)
+    }
+
+    override public func sort_map_entries(offsets _: [Int]) {
+        // Not required by the format.
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Deserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Deserializer.swift
@@ -1,0 +1,33 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public enum DeserializationError: Error {
+    case invalidInput(issue: String)
+}
+
+public protocol Deserializer {
+    func deserialize_str() throws -> String
+    func deserialize_bytes() throws -> [UInt8]
+    func deserialize_bool() throws -> Bool
+    func deserialize_unit() throws
+    func deserialize_char() throws -> Character
+    func deserialize_f32() throws -> Float
+    func deserialize_f64() throws -> Double
+    func deserialize_u8() throws -> UInt8
+    func deserialize_u16() throws -> UInt16
+    func deserialize_u32() throws -> UInt32
+    func deserialize_u64() throws -> UInt64
+    func deserialize_u128() throws -> UInt128
+    func deserialize_i8() throws -> Int8
+    func deserialize_i16() throws -> Int16
+    func deserialize_i32() throws -> Int32
+    func deserialize_i64() throws -> Int64
+    func deserialize_i128() throws -> Int128
+    func deserialize_len() throws -> Int
+    func deserialize_variant_index() throws -> UInt32
+    func deserialize_option_tag() throws -> Bool
+    func get_buffer_offset() -> Int
+    func increase_container_depth() throws
+    func decrease_container_depth() throws
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Indirect.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Indirect.swift
@@ -1,0 +1,23 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+// See https://forums.swift.org/t/using-indirect-modifier-for-struct-properties/37600/16
+@propertyWrapper
+public indirect enum Indirect<T> {
+    case wrapped(T)
+
+    public init(wrappedValue initialValue: T) {
+        self = .wrapped(initialValue)
+    }
+
+    public var wrappedValue: T {
+        get {
+            switch self {
+            case .wrapped(let x): return x
+            }
+        }
+        set { self = .wrapped(newValue) }
+    }
+}
+
+extension Indirect: Equatable where T: Equatable {}
+extension Indirect: Hashable where T: Hashable {}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Int128.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Int128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct Int128: Hashable {
+    public var high: Int64
+    public var low: UInt64
+
+    public init(high: Int64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Serializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/Serializer.swift
@@ -1,0 +1,35 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public enum SerializationError: Error {
+    case invalidValue(issue: String)
+}
+
+public protocol Serializer {
+    func serialize_str(value: String) throws
+    func serialize_bytes(value: [UInt8]) throws
+    func serialize_bool(value: Bool) throws
+    func serialize_unit(value: ()) throws
+    func serialize_char(value: Character) throws
+    func serialize_f32(value: Float) throws
+    func serialize_f64(value: Double) throws
+    func serialize_u8(value: UInt8) throws
+    func serialize_u16(value: UInt16) throws
+    func serialize_u32(value: UInt32) throws
+    func serialize_u64(value: UInt64) throws
+    func serialize_u128(value: UInt128) throws
+    func serialize_i8(value: Int8) throws
+    func serialize_i16(value: Int16) throws
+    func serialize_i32(value: Int32) throws
+    func serialize_i64(value: Int64) throws
+    func serialize_i128(value: Int128) throws
+    func serialize_len(value: Int) throws
+    func serialize_variant_index(value: UInt32) throws
+    func serialize_option_tag(value: Bool) throws
+    func increase_container_depth() throws
+    func decrease_container_depth() throws
+    func get_buffer_offset() -> Int
+    func sort_map_entries(offsets: [Int])
+    func get_bytes() -> [UInt8]
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/UInt128.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Serde/UInt128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct UInt128: Hashable {
+    public var high: UInt64
+    public var low: UInt64
+
+    public init(high: UInt64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/bincodeDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/bincodeDeserializer.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { BinaryDeserializer } from "../serde/binaryDeserializer";
+
+export class BincodeDeserializer extends BinaryDeserializer {
+  deserializeLen(): number {
+    return Number(this.deserializeU64());
+  }
+
+  public deserializeVariantIndex(): number {
+    return this.deserializeU32();
+  }
+
+  checkThatKeySlicesAreIncreasing(
+    key1: [number, number],
+    key2: [number, number],
+  ): void {
+    return;
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/bincodeSerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/bincodeSerializer.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { BinarySerializer } from "../serde/binarySerializer";
+
+export class BincodeSerializer extends BinarySerializer {
+  serializeLen(value: number): void {
+    this.serializeU64(value);
+  }
+
+  public serializeVariantIndex(value: number): void {
+    this.serializeU32(value);
+  }
+
+  public sortMapEntries(offsets: number[]): void {
+    return;
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/index.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/bincode/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export { BincodeSerializer } from "./bincodeSerializer";
+export { BincodeDeserializer } from "./bincodeDeserializer";

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/example.ts
@@ -1,0 +1,93 @@
+import { Serializer, Deserializer } from "./serde";
+type Optional<T> = T | null;
+type str = string;
+
+function serializeOption<T>(
+    value: T | null,
+    serializer: Serializer,
+    serializeElement: (value: T, serializer: Serializer) => void,
+): void {
+    if (value !== null) {
+        serializer.serializeOptionTag(true);
+        serializeElement(value, serializer);
+    } else {
+        serializer.serializeOptionTag(false);
+    }
+}
+
+function deserializeOption<T>(
+    deserializer: Deserializer,
+    deserializeElement: (deserializer: Deserializer) => T,
+): T | null {
+    const tag = deserializer.deserializeOptionTag();
+    if (!tag) {
+        return null;
+    } else {
+        return deserializeElement(deserializer);
+    }
+}
+
+export type Uuid = string & { readonly __uuid: unique symbol };
+
+const HEX = '0123456789abcdef';
+
+function uuidStringToBytes(value: Uuid): Uint8Array {
+    const hex = (value as string).replace(/-/g, '');
+    if (hex.length !== 32) {
+        throw new Error(`Invalid UUID: ${value}`);
+    }
+    const bytes = new Uint8Array(16);
+    for (let i = 0; i < 16; i++) {
+        const hi = HEX.indexOf(hex[i * 2].toLowerCase());
+        const lo = HEX.indexOf(hex[i * 2 + 1].toLowerCase());
+        if (hi < 0 || lo < 0) {
+            throw new Error(`Invalid UUID: ${value}`);
+        }
+        bytes[i] = (hi << 4) | lo;
+    }
+    return bytes;
+}
+
+function bytesToUuidString(bytes: Uint8Array): Uuid {
+    if (bytes.length !== 16) {
+        throw new Error(`UUID must be 16 bytes, got ${bytes.length}`);
+    }
+    let s = '';
+    for (let i = 0; i < 16; i++) {
+        s += HEX[(bytes[i] >> 4) & 0xf] + HEX[bytes[i] & 0xf];
+        if (i === 3 || i === 5 || i === 7 || i === 9) {
+            s += '-';
+        }
+    }
+    return s as Uuid;
+}
+
+function serializeUuid(value: Uuid, serializer: Serializer): void {
+    serializer.serializeBytes(uuidStringToBytes(value));
+}
+
+function deserializeUuid(deserializer: Deserializer): Uuid {
+    return bytesToUuidString(deserializer.deserializeBytes());
+}
+
+export class StructWithUuid {
+    constructor (public id: Uuid, public parent_id: Optional<Uuid>, public name: str) {
+    }
+
+    public serialize(serializer: Serializer): void {
+        serializeUuid(this.id, serializer);
+        serializeOption(this.parent_id, serializer, (value, serializer) => {
+            serializeUuid(value, serializer);
+        });
+        serializer.serializeStr(this.name);
+    }
+
+    static deserialize(deserializer: Deserializer): StructWithUuid {
+        const id = deserializeUuid(deserializer);
+        const parent_id = deserializeOption(deserializer, (deserializer) => {
+            return deserializeUuid(deserializer);
+        });
+        const name = deserializer.deserializeStr();
+        return new StructWithUuid(id,parent_id,name);
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/package.json
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "name": "example",
+  "version": "0.1.0"
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { Deserializer } from "./deserializer";
+
+export abstract class BinaryDeserializer implements Deserializer {
+  private static readonly BIG_32: bigint = BigInt(32);
+  private static readonly BIG_64: bigint = BigInt(64);
+  private static readonly textDecoder = new TextDecoder();
+  public buffer: ArrayBuffer;
+  public offset: number;
+
+  constructor(data: Uint8Array) {
+    // copies data to prevent outside mutation of buffer.
+    this.buffer = new ArrayBuffer(data.length);
+    new Uint8Array(this.buffer).set(data, 0);
+    this.offset = 0;
+  }
+
+  private read(length: number): ArrayBuffer {
+    const bytes = this.buffer.slice(this.offset, this.offset + length);
+    this.offset += length;
+    return bytes;
+  }
+
+  abstract deserializeLen(): number;
+
+  abstract deserializeVariantIndex(): number;
+
+  abstract checkThatKeySlicesAreIncreasing(
+    key1: [number, number],
+    key2: [number, number],
+  ): void;
+
+  public deserializeStr(): string {
+    const value = this.deserializeBytes();
+    return BinaryDeserializer.textDecoder.decode(value);
+  }
+
+  public deserializeBytes(): Uint8Array {
+    const len = this.deserializeLen();
+    if (len < 0) {
+      throw new Error("Length of a bytes array can't be negative");
+    }
+    return new Uint8Array(this.read(len));
+  }
+
+  public deserializeBool(): boolean {
+    const bool = new Uint8Array(this.read(1))[0];
+    return bool == 1;
+  }
+
+  public deserializeUnit(): null {
+    return null;
+  }
+
+  public deserializeU8(): number {
+    return new DataView(this.read(1)).getUint8(0);
+  }
+
+  public deserializeU16(): number {
+    return new DataView(this.read(2)).getUint16(0, true);
+  }
+
+  public deserializeU32(): number {
+    return new DataView(this.read(4)).getUint32(0, true);
+  }
+
+  public deserializeU64(): bigint {
+    const low = this.deserializeU32();
+    const high = this.deserializeU32();
+
+    // combine the two 32-bit values and return (little endian)
+    return BigInt(
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
+        BigInt(low.toString()),
+    );
+  }
+
+  public deserializeU128(): bigint {
+    const low = this.deserializeU64();
+    const high = this.deserializeU64();
+
+    // combine the two 64-bit values and return (little endian)
+    return BigInt(
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
+        BigInt(low.toString()),
+    );
+  }
+
+  public deserializeI8(): number {
+    return new DataView(this.read(1)).getInt8(0);
+  }
+
+  public deserializeI16(): number {
+    return new DataView(this.read(2)).getInt16(0, true);
+  }
+
+  public deserializeI32(): number {
+    return new DataView(this.read(4)).getInt32(0, true);
+  }
+
+  public deserializeI64(): bigint {
+    const low = this.deserializeI32();
+    const high = this.deserializeI32();
+
+    // combine the two 32-bit values and return (little endian)
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
+      BigInt(low.toString())
+    );
+  }
+
+  public deserializeI128(): bigint {
+    const low = this.deserializeI64();
+    const high = this.deserializeI64();
+
+    // combine the two 64-bit values and return (little endian)
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
+      BigInt(low.toString())
+    );
+  }
+
+  public deserializeOptionTag(): boolean {
+    return this.deserializeBool();
+  }
+
+  public getBufferOffset(): number {
+    return this.offset;
+  }
+
+  public deserializeChar(): string {
+    throw new Error("Method deserializeChar not implemented.");
+  }
+
+  public deserializeF32(): number {
+    return new DataView(this.read(4)).getFloat32(0, true);
+  }
+
+  public deserializeF64(): number {
+    return new DataView(this.read(8)).getFloat64(0, true);
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binarySerializer.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { Serializer } from "./serializer";
+
+export abstract class BinarySerializer implements Serializer {
+  private static readonly BIG_32: bigint = BigInt(32);
+  private static readonly BIG_64: bigint = BigInt(64);
+
+  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
+  private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
+
+  private static readonly textEncoder = new TextEncoder();
+
+  private buffer: ArrayBuffer;
+  private offset: number;
+
+  constructor() {
+    this.buffer = new ArrayBuffer(64);
+    this.offset = 0;
+  }
+
+  private ensureBufferWillHandleSize(bytes: number) {
+    while (this.buffer.byteLength < this.offset + bytes) {
+      const newBuffer = new ArrayBuffer(this.buffer.byteLength * 2);
+      new Uint8Array(newBuffer).set(new Uint8Array(this.buffer));
+      this.buffer = newBuffer;
+    }
+  }
+
+  protected serialize(values: Uint8Array) {
+    this.ensureBufferWillHandleSize(values.length);
+    new Uint8Array(this.buffer, this.offset).set(values);
+    this.offset += values.length;
+  }
+
+  abstract serializeLen(value: number): void;
+
+  abstract serializeVariantIndex(value: number): void;
+
+  abstract sortMapEntries(offsets: number[]): void;
+
+  public serializeStr(value: string): void {
+    this.serializeBytes(BinarySerializer.textEncoder.encode(value));
+  }
+
+  public serializeBytes(value: Uint8Array): void {
+    this.serializeLen(value.length);
+    this.serialize(value);
+  }
+
+  public serializeBool(value: boolean): void {
+    const byteValue = value ? 1 : 0;
+    this.serialize(new Uint8Array([byteValue]));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/explicit-module-boundary-types
+  public serializeUnit(_value: null): void {
+    return;
+  }
+
+  private serializeWithFunction(
+    fn: (byteOffset: number, value: number, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: number,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
+  public serializeU8(value: number): void {
+    this.serialize(new Uint8Array([value]));
+  }
+
+  public serializeU16(value: number): void {
+    this.serializeWithFunction(DataView.prototype.setUint16, 2, value);
+  }
+
+  public serializeU32(value: number): void {
+    this.serializeWithFunction(DataView.prototype.setUint32, 4, value);
+  }
+
+  public serializeU64(value: BigInt | number): void {
+    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
+    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
+
+    // write little endian number
+    this.serializeU32(Number(low));
+    this.serializeU32(Number(high));
+  }
+
+  public serializeU128(value: BigInt | number): void {
+    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
+    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+
+    // write little endian number
+    this.serializeU64(low);
+    this.serializeU64(high);
+  }
+
+  public serializeI8(value: number): void {
+    const bytes = 1;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt8(0, value);
+    this.offset += bytes;
+  }
+
+  public serializeI16(value: number): void {
+    const bytes = 2;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt16(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeI32(value: number): void {
+    const bytes = 4;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt32(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeI64(value: bigint | number): void {
+    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
+    const high = BigInt(value) >> BinarySerializer.BIG_32;
+
+    // write little endian number
+    this.serializeI32(Number(low));
+    this.serializeI32(Number(high));
+  }
+
+  public serializeI128(value: bigint | number): void {
+    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
+    const high = BigInt(value) >> BinarySerializer.BIG_64;
+
+    // write little endian number
+    this.serializeI64(low);
+    this.serializeI64(high);
+  }
+
+  public serializeOptionTag(value: boolean): void {
+    this.serializeBool(value);
+  }
+
+  public getBufferOffset(): number {
+    return this.offset;
+  }
+
+  public getBytes(): Uint8Array {
+    return new Uint8Array(this.buffer).slice(0, this.offset);
+  }
+
+  public serializeChar(_value: string): void {
+    throw new Error("Method serializeChar not implemented.");
+  }
+
+  public serializeF32(value: number): void {
+    const bytes = 4;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setFloat32(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeF64(value: number): void {
+    const bytes = 8;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setFloat64(0, value, true);
+    this.offset += bytes;
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/deserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/deserializer.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export interface Deserializer {
+  deserializeStr(): string;
+
+  deserializeBytes(): Uint8Array;
+
+  deserializeBool(): boolean;
+
+  deserializeUnit(): null;
+
+  deserializeChar(): string;
+
+  deserializeF32(): number;
+
+  deserializeF64(): number;
+
+  deserializeU8(): number;
+
+  deserializeU16(): number;
+
+  deserializeU32(): number;
+
+  deserializeU64(): bigint;
+
+  deserializeU128(): bigint;
+
+  deserializeI8(): number;
+
+  deserializeI16(): number;
+
+  deserializeI32(): number;
+
+  deserializeI64(): bigint;
+
+  deserializeI128(): bigint;
+
+  deserializeLen(): number;
+
+  deserializeVariantIndex(): number;
+
+  deserializeOptionTag(): boolean;
+
+  getBufferOffset(): number;
+
+  checkThatKeySlicesAreIncreasing(
+    key1: [number, number],
+    key2: [number, number],
+  ): void;
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/index.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export * from "./types";
+export * from "./serializer";
+export * from "./deserializer";
+export * from "./binarySerializer";
+export * from "./binaryDeserializer";

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/serializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/serializer.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export interface Serializer {
+  serializeStr(value: string): void;
+
+  serializeBytes(value: Uint8Array): void;
+
+  serializeBool(value: boolean): void;
+
+  serializeUnit(value: null): void;
+
+  serializeChar(value: string): void;
+
+  serializeF32(value: number): void;
+
+  serializeF64(value: number): void;
+
+  serializeU8(value: number): void;
+
+  serializeU16(value: number): void;
+
+  serializeU32(value: number): void;
+
+  serializeU64(value: bigint | number): void;
+
+  serializeU128(value: bigint | number): void;
+
+  serializeI8(value: number): void;
+
+  serializeI16(value: number): void;
+
+  serializeI32(value: number): void;
+
+  serializeI64(value: bigint | number): void;
+
+  serializeI128(value: bigint | number): void;
+
+  serializeLen(value: number): void;
+
+  serializeVariantIndex(value: number): void;
+
+  serializeOptionTag(value: boolean): void;
+
+  getBufferOffset(): number;
+
+  getBytes(): Uint8Array;
+
+  sortMapEntries(offsets: number[]): void;
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/types.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export type Optional<T> = T | null;
+export type Seq<T> = T[];
+export type Tuple<T extends any[]> = T;
+export type ListTuple<T extends any[]> = Tuple<T>[];
+
+export type unit = null;
+export type bool = boolean;
+export type int8 = number;
+export type int16 = number;
+export type int32 = number;
+export type int64 = bigint;
+export type int128 = bigint;
+export type uint8 = number;
+export type uint16 = number;
+export type uint32 = number;
+export type uint64 = bigint;
+export type uint128 = bigint;
+export type float32 = number;
+export type float64 = number;
+export type char = string;
+export type str = string;
+export type bytes = Uint8Array;

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/build.gradle.kts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.serialization") version "2.2.0"
+    `java-library`
+}
+
+group = "com.example"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+}
+
+tasks.withType<Jar> {
+    manifest {
+        attributes["Implementation-Title"] = "com.example"
+        attributes["Implementation-Version"] = "1.0.0"
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/example/Example.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/example/Example.kt
@@ -1,0 +1,25 @@
+package com.example
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+private object UUIDSerializer : KSerializer<java.util.UUID> {
+    override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+    override fun deserialize(decoder: Decoder): java.util.UUID = java.util.UUID.fromString(decoder.decodeString())
+    override fun serialize(encoder: Encoder, value: java.util.UUID) = encoder.encodeString(value.toString())
+}
+
+typealias UUID = @Serializable(with = UUIDSerializer::class) java.util.UUID
+
+@Serializable
+@SerialName("StructWithUuid")
+data class StructWithUuid(
+    val id: UUID,
+    val parentId: UUID? = null,
+    val name: String,
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/BinaryDeserializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/BinaryDeserializer.kt
@@ -1,0 +1,182 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinaryDeserializer(
+    protected val input: ByteArray,
+    maxContainerDepth: Long
+) : Deserializer {
+    private var position: Int = 0
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(DeserializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw DeserializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_str(): String {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin string")
+        }
+        val content = readBytes(len.toInt())
+        return try {
+            content.decodeToString(throwOnInvalidSequence = true)
+        } catch (e: Throwable) {
+            throw DeserializationError("Incorrect UTF8 string")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bytes(): Bytes {
+        val len = deserialize_len()
+        if (len < 0 || len > Int.MAX_VALUE.toLong()) {
+            throw DeserializationError("Incorrect length value for Kotlin array")
+        }
+        return Bytes(readBytes(len.toInt()))
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_bool(): Boolean {
+        val value = getByte()
+        return when (value.toInt()) {
+            0 -> false
+            1 -> true
+            else -> throw DeserializationError("Incorrect boolean value")
+        }
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_unit(): Unit {
+        return Unit
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_char(): Char {
+        throw DeserializationError("Not implemented: deserialize_char")
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u8(): UByte {
+        return getByte().toUByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u16(): UShort {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8)).toUShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u32(): UInt {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return (b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)).toUInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u64(): ULong {
+        var value = 0uL
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toULong() and 0xffuL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_u128(): UInt128 {
+        val low = deserialize_u64()
+        val high = deserialize_u64()
+        return UInt128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i8(): Byte {
+        return getByte()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i16(): Short {
+        return deserialize_u16().toShort()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i32(): Int {
+        return deserialize_u32().toInt()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i64(): Long {
+        return deserialize_u64().toLong()
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_i128(): Int128 {
+        val low = deserialize_u64()
+        val high = deserialize_i64()
+        return Int128(high = high, low = low)
+    }
+
+    @Throws(DeserializationError::class)
+    override fun deserialize_option_tag(): Boolean {
+        return deserialize_bool()
+    }
+
+    override fun get_buffer_offset(): Int {
+        return position
+    }
+
+    protected fun getInt(): Int {
+        val b0 = getByte().toInt() and 0xff
+        val b1 = getByte().toInt() and 0xff
+        val b2 = getByte().toInt() and 0xff
+        val b3 = getByte().toInt() and 0xff
+        return b0 or (b1 shl 8) or (b2 shl 16) or (b3 shl 24)
+    }
+
+    protected fun getLong(): Long {
+        var value = 0L
+        for (shift in 0 until 64 step 8) {
+            val byteValue = getByte().toLong() and 0xffL
+            value = value or (byteValue shl shift)
+        }
+        return value
+    }
+
+    protected fun getByte(): Byte {
+        requireAvailable(1)
+        val value = input[position]
+        position += 1
+        return value
+    }
+
+    private fun readBytes(count: Int): ByteArray {
+        requireAvailable(count)
+        val slice = input.copyOfRange(position, position + count)
+        position += count
+        return slice
+    }
+
+    private fun requireAvailable(count: Int) {
+        if (position + count > input.size) {
+            throw DeserializationError(INPUT_NOT_LARGE_ENOUGH)
+        }
+    }
+
+    companion object {
+        private const val INPUT_NOT_LARGE_ENOUGH = "Input is not large enough"
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/BinarySerializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/BinarySerializer.kt
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+abstract class BinarySerializer(maxContainerDepth: Long) : Serializer {
+    protected val output: SerdeByteArrayOutput = SerdeByteArrayOutput()
+    private var containerDepthBudget: Long = maxContainerDepth
+
+    @Throws(SerializationError::class)
+    override fun increase_container_depth() {
+        if (containerDepthBudget == 0L) {
+            throw SerializationError("Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    override fun decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_str(value: String) {
+        serialize_bytes(Bytes(value.encodeToByteArray()))
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bytes(value: Bytes) {
+        serialize_len(value.content.size.toLong())
+        output.writeBytes(value.content, 0, value.content.size)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_bool(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_unit(value: Unit) {
+        // Nothing to serialize.
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_char(value: Char) {
+        throw SerializationError("Not implemented: serialize_char")
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u8(value: UByte) {
+        output.writeByte(value.toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u16(value: UShort) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u32(value: UInt) {
+        val v = value.toInt()
+        output.writeByte((v and 0xff).toByte())
+        output.writeByte(((v ushr 8) and 0xff).toByte())
+        output.writeByte(((v ushr 16) and 0xff).toByte())
+        output.writeByte(((v ushr 24) and 0xff).toByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u64(value: ULong) {
+        var v = value
+        for (i in 0 until 8) {
+            output.writeByte((v and 0xffuL).toByte())
+            v = v shr 8
+        }
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_u128(value: UInt128) {
+        serialize_u64(value.low)
+        serialize_u64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i8(value: Byte) {
+        serialize_u8(value.toUByte())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i16(value: Short) {
+        serialize_u16(value.toUShort())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i32(value: Int) {
+        serialize_u32(value.toUInt())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i64(value: Long) {
+        serialize_u64(value.toULong())
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_i128(value: Int128) {
+        serialize_u64(value.low)
+        serialize_i64(value.high)
+    }
+
+    @Throws(SerializationError::class)
+    override fun serialize_option_tag(value: Boolean) {
+        output.writeByte(if (value) 1.toByte() else 0.toByte())
+    }
+
+    override fun get_buffer_offset(): Int {
+        return output.size()
+    }
+
+    override fun get_bytes(): ByteArray {
+        return output.toByteArray()
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Bytes.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Bytes.kt
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+/**
+ * Inline value class wrapper around ByteArray.
+ *
+ * Provides proper value semantics for `equals` and `hashCode` using
+ * structural equality (contentEquals/contentHashCode) instead of
+ * referential equality.
+ *
+ * As a value class, this wrapper has zero runtime overhead - it's
+ * inlined at compile time and compiles down to ByteArray at runtime.
+ */
+@JvmInline
+value class Bytes(val content: ByteArray) {
+    override fun toString(): String = content.contentToString()
+
+    companion object {
+        fun empty(): Bytes = Bytes(ByteArray(0))
+
+        fun valueOf(content: ByteArray): Bytes = Bytes(content)
+    }
+}
+
+/**
+ * Extension function for structural equality comparison.
+ * Required because value classes don't support overriding equals.
+ */
+fun Bytes.contentEquals(other: Bytes): Boolean =
+    this.content.contentEquals(other.content)
+
+/**
+ * Extension function for structural hash code.
+ * Required because value classes don't support overriding hashCode.
+ */
+fun Bytes.contentHashCode(): Int =
+    content.contentHashCode()

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/DeserializationError.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/DeserializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class DeserializationError(message: String) : Exception(message)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Deserializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Deserializer.kt
@@ -1,0 +1,76 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Deserializer {
+    @Throws(DeserializationError::class)
+    fun deserialize_str(): String
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bytes(): Bytes
+
+    @Throws(DeserializationError::class)
+    fun deserialize_bool(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun deserialize_unit(): Unit
+
+    @Throws(DeserializationError::class)
+    fun deserialize_char(): Char
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f32(): Float
+
+    @Throws(DeserializationError::class)
+    fun deserialize_f64(): Double
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u8(): UByte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u16(): UShort
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u32(): UInt
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u64(): ULong
+
+    @Throws(DeserializationError::class)
+    fun deserialize_u128(): UInt128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i8(): Byte
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i16(): Short
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i32(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i64(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_i128(): Int128
+
+    @Throws(DeserializationError::class)
+    fun deserialize_len(): Long
+
+    @Throws(DeserializationError::class)
+    fun deserialize_variant_index(): Int
+
+    @Throws(DeserializationError::class)
+    fun deserialize_option_tag(): Boolean
+
+    @Throws(DeserializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    @Throws(DeserializationError::class)
+    fun check_that_key_slices_are_increasing(key1: Slice, key2: Slice)
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Int128.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Int128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Int128(val high: Long, val low: ULong)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/SerdeByteArrayOutput.kt
@@ -1,0 +1,48 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerdeByteArrayOutput(initialCapacity: Int = 32) {
+    private var buffer: ByteArray = ByteArray(initialCapacity)
+    private var length: Int = 0
+
+    fun writeByte(value: Byte) {
+        ensureCapacity(1)
+        buffer[length] = value
+        length += 1
+    }
+
+    fun writeBytes(value: ByteArray, offset: Int, count: Int) {
+        if (count == 0) {
+            return
+        }
+        ensureCapacity(count)
+        value.copyInto(buffer, destinationOffset = length, startIndex = offset, endIndex = offset + count)
+        length += count
+    }
+
+    fun size(): Int {
+        return length
+    }
+
+    fun toByteArray(): ByteArray {
+        return buffer.copyOf(length)
+    }
+
+    fun getBuffer(): ByteArray {
+        return buffer
+    }
+
+    private fun ensureCapacity(extra: Int) {
+        val required = length + extra
+        if (required <= buffer.size) {
+            return
+        }
+        var newSize = buffer.size
+        while (newSize < required) {
+            newSize = newSize * 2
+        }
+        buffer = buffer.copyOf(newSize)
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/SerializationError.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/SerializationError.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+class SerializationError(message: String) : Exception(message)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Serializer.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Serializer.kt
@@ -1,0 +1,77 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+interface Serializer {
+    @Throws(SerializationError::class)
+    fun serialize_str(value: String)
+
+    @Throws(SerializationError::class)
+    fun serialize_bytes(value: Bytes)
+
+    @Throws(SerializationError::class)
+    fun serialize_bool(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun serialize_unit(value: Unit)
+
+    @Throws(SerializationError::class)
+    fun serialize_char(value: Char)
+
+    @Throws(SerializationError::class)
+    fun serialize_f32(value: Float)
+
+    @Throws(SerializationError::class)
+    fun serialize_f64(value: Double)
+
+    @Throws(SerializationError::class)
+    fun serialize_u8(value: UByte)
+
+    @Throws(SerializationError::class)
+    fun serialize_u16(value: UShort)
+
+    @Throws(SerializationError::class)
+    fun serialize_u32(value: UInt)
+
+    @Throws(SerializationError::class)
+    fun serialize_u64(value: ULong)
+
+    @Throws(SerializationError::class)
+    fun serialize_u128(value: UInt128)
+
+    @Throws(SerializationError::class)
+    fun serialize_i8(value: Byte)
+
+    @Throws(SerializationError::class)
+    fun serialize_i16(value: Short)
+
+    @Throws(SerializationError::class)
+    fun serialize_i32(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_i64(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_i128(value: Int128)
+
+    @Throws(SerializationError::class)
+    fun serialize_len(value: Long)
+
+    @Throws(SerializationError::class)
+    fun serialize_variant_index(value: Int)
+
+    @Throws(SerializationError::class)
+    fun serialize_option_tag(value: Boolean)
+
+    @Throws(SerializationError::class)
+    fun increase_container_depth()
+
+    fun decrease_container_depth()
+
+    fun get_buffer_offset(): Int
+
+    fun sort_map_entries(offsets: IntArray)
+
+    fun get_bytes(): ByteArray
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Slice.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Slice.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Slice(val start: Int, val end: Int) {
+    companion object {
+        fun compare_bytes(content: ByteArray, slice1: Slice, slice2: Slice): Int {
+            val start1 = slice1.start
+            val end1 = slice1.end
+            val start2 = slice2.start
+            val end2 = slice2.end
+            var i = 0
+            while (i < end1 - start1) {
+                val index1 = start1 + i
+                val index2 = start2 + i
+                val byte1 = content[index1].toInt() and 0xff
+                if (index2 >= end2) {
+                    return 1
+                }
+                val byte2 = content[index2].toInt() and 0xff
+                if (byte1 > byte2) {
+                    return 1
+                }
+                if (byte1 < byte2) {
+                    return -1
+                }
+                i += 1
+            }
+            if (end2 - start2 > end1 - start1) {
+                return -1
+            }
+            return 0
+        }
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple4.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple4.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple4<T0, T1, T2, T3>(val field0: T0, val field1: T1, val field2: T2, val field3: T3)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple5.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple5.kt
@@ -1,0 +1,12 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple5<T0, T1, T2, T3, T4>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple6.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/Tuple6.kt
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class Tuple6<T0, T1, T2, T3, T4, T5>(
+    val field0: T0,
+    val field1: T1,
+    val field2: T2,
+    val field3: T3,
+    val field4: T4,
+    val field5: T5
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/UInt128.kt
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/kotlin/com/novi/serde/UInt128.kt
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package com.novi.serde
+
+data class UInt128(val high: ULong, val low: ULong)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Package.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.8
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    products: [
+        .library(
+            name: "Example",
+            targets: ["Example"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Example",
+            dependencies: ["Serde"]
+        ),
+        .target(
+            name: "Serde",
+            dependencies: []
+        ),
+    ]
+)

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Example/Example.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Serde
+
+func serializeOption<T, S: Serializer>(
+    value: T?,
+    serializer: S,
+    serializeElement: (T, S) throws -> Void
+) throws {
+    if let value = value {
+        try serializer.serialize_option_tag(value: true)
+        try serializeElement(value, serializer)
+    } else {
+        try serializer.serialize_option_tag(value: false)
+    }
+}
+
+func deserializeOption<T, D: Deserializer>(
+    deserializer: D,
+    deserializeElement: (D) throws -> T
+) throws -> T? {
+    let tag = try deserializer.deserialize_option_tag()
+    if tag {
+        return try deserializeElement(deserializer)
+    } else {
+        return nil
+    }
+}
+
+func serializeUuid<S: Serializer>(
+    value: UUID,
+    serializer: S
+) throws {
+    try serializer.serialize_str(value: value.uuidString.lowercased())
+}
+
+func deserializeUuid<D: Deserializer>(
+    deserializer: D
+) throws -> UUID {
+    let s = try deserializer.deserialize_str()
+    guard let uuid = UUID(uuidString: s) else {
+        throw DeserializationError.invalidInput(issue: "Invalid UUID string: \(s)")
+    }
+    return uuid
+}
+
+public struct StructWithUuid: Hashable {
+    public var id: UUID
+    public var parentId: UUID?
+    public var name: String
+
+    public init(id: UUID, parentId: UUID?, name: String) {
+        self.id = id
+        self.parentId = parentId
+        self.name = name
+    }
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        try serializeUuid(value: self.id, serializer: serializer)
+        try serializeOption(value: self.parentId, serializer: serializer) { value, serializer in
+            try serializeUuid(value: value, serializer: serializer)
+        }
+        try serializer.serialize_str(value: self.name)
+        try serializer.decrease_container_depth()
+    }
+
+    public func jsonSerialize() throws -> [UInt8] {
+        let serializer = JsonSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> StructWithUuid {
+        try deserializer.increase_container_depth()
+        let id = try deserializeUuid(deserializer: deserializer)
+        let parentId = try deserializeOption(deserializer: deserializer) { deserializer in
+            try deserializeUuid(deserializer: deserializer)
+        }
+        let name = try deserializer.deserialize_str()
+        try deserializer.decrease_container_depth()
+        return StructWithUuid(id: id, parentId: parentId, name: name)
+    }
+
+    public static func jsonDeserialize(input: [UInt8]) throws -> StructWithUuid {
+        let deserializer = JsonDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BinaryDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BinaryDeserializer.swift
@@ -1,0 +1,162 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BinaryDeserializer: Deserializer {
+    let input: [UInt8]
+    private var location: Int
+    private var containerDepthBudget: Int
+
+    init(input: [UInt8], maxContainerDepth: Int) {
+        self.input = input
+        location = 0
+        containerDepthBudget = maxContainerDepth
+    }
+
+    private func readBytes(count: Int) throws -> [UInt8] {
+        let newLocation = location + count
+        if newLocation > input.count {
+            throw DeserializationError.invalidInput(issue: "Input is too small")
+        }
+        let bytes = input[location..<newLocation]
+        location = newLocation
+        return Array(bytes)
+    }
+
+    public func deserialize_len() throws -> Int {
+        assertionFailure("Not implemented")
+        return 0
+    }
+
+    public func deserialize_variant_index() throws -> UInt32 {
+        assertionFailure("Not implemented")
+        return 0
+    }
+
+    public func deserialize_char() throws -> Character {
+        throw DeserializationError.invalidInput(issue: "Not implemented: char deserialization")
+    }
+
+    public func deserialize_f32() throws -> Float {
+        throw DeserializationError.invalidInput(issue: "Not implemented: f32 deserialization")
+    }
+
+    public func deserialize_f64() throws -> Double {
+        throw DeserializationError.invalidInput(issue: "Not implemented: f64 deserialization")
+    }
+
+    public func increase_container_depth() throws {
+        if containerDepthBudget == 0 {
+            throw DeserializationError.invalidInput(issue: "Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    public func decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    public func deserialize_str() throws -> String {
+        let bytes = try deserialize_bytes()
+        guard let value = String(bytes: bytes, encoding: .utf8) else {
+            throw DeserializationError.invalidInput(issue: "Incorrect UTF8 string")
+        }
+        return value
+    }
+
+    public func deserialize_bytes() throws -> [UInt8] {
+        let len = try deserialize_len()
+        let content = try readBytes(count: len)
+        return content
+    }
+
+    public func deserialize_bool() throws -> Bool {
+        let value = try deserialize_u8()
+        switch value {
+        case 0: return false
+        case 1: return true
+        default:
+            throw DeserializationError.invalidInput(issue: "Incorrect value for boolean: \(value)")
+        }
+    }
+
+    public func deserialize_unit() throws {}
+
+    public func deserialize_u8() throws -> UInt8 {
+        let bytes = try readBytes(count: 1)
+        return bytes[0]
+    }
+
+    public func deserialize_u16() throws -> UInt16 {
+        let bytes = try readBytes(count: 2)
+        var x = UInt16(bytes[0])
+        x += UInt16(bytes[1]) << 8
+        return x
+    }
+
+    public func deserialize_u32() throws -> UInt32 {
+        let bytes = try readBytes(count: 4)
+        var x = UInt32(bytes[0])
+        x += UInt32(bytes[1]) << 8
+        x += UInt32(bytes[2]) << 16
+        x += UInt32(bytes[3]) << 24
+        return x
+    }
+
+    public func deserialize_u64() throws -> UInt64 {
+        let bytes = try readBytes(count: 8)
+        var x = UInt64(bytes[0])
+        x += UInt64(bytes[1]) << 8
+        x += UInt64(bytes[2]) << 16
+        x += UInt64(bytes[3]) << 24
+        x += UInt64(bytes[4]) << 32
+        x += UInt64(bytes[5]) << 40
+        x += UInt64(bytes[6]) << 48
+        x += UInt64(bytes[7]) << 56
+        return x
+    }
+
+    public func deserialize_u128() throws -> UInt128 {
+        let low = try deserialize_u64()
+        let high = try deserialize_u64()
+        return UInt128(high: high, low: low)
+    }
+
+    public func deserialize_i8() throws -> Int8 {
+        return Int8(bitPattern: try deserialize_u8())
+    }
+
+    public func deserialize_i16() throws -> Int16 {
+        return Int16(bitPattern: try deserialize_u16())
+    }
+
+    public func deserialize_i32() throws -> Int32 {
+        return Int32(bitPattern: try deserialize_u32())
+    }
+
+    public func deserialize_i64() throws -> Int64 {
+        return Int64(bitPattern: try deserialize_u64())
+    }
+
+    public func deserialize_i128() throws -> Int128 {
+        let low = try deserialize_u64()
+        let high = try deserialize_i64()
+        return Int128(high: high, low: low)
+    }
+
+    public func deserialize_option_tag() throws -> Bool {
+        let value = try deserialize_u8()
+        switch value {
+        case 0: return false
+        case 1: return true
+        default:
+            throw DeserializationError.invalidInput(
+                issue: "Incorrect value for option tag: \(value)")
+        }
+    }
+
+    public func get_buffer_offset() -> Int {
+        return location
+    }
+
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BinarySerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BinarySerializer.swift
@@ -1,0 +1,133 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BinarySerializer: Serializer {
+    var output: [UInt8]
+    private var containerDepthBudget: Int
+
+    public init(maxContainerDepth: Int) {
+        output = []
+        output.reserveCapacity(64)
+        containerDepthBudget = maxContainerDepth
+    }
+
+    public func increase_container_depth() throws {
+        if containerDepthBudget == 0 {
+            throw SerializationError.invalidValue(issue: "Exceeded maximum container depth")
+        }
+        containerDepthBudget -= 1
+    }
+
+    public func decrease_container_depth() {
+        containerDepthBudget += 1
+    }
+
+    public func serialize_char(value _: Character) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: char serialization")
+    }
+
+    public func serialize_f32(value: Float) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: f32 serialization")
+    }
+
+    public func serialize_f64(value: Double) throws {
+        throw SerializationError.invalidValue(issue: "Not implemented: f64 serialization")
+    }
+
+    public func get_bytes() -> [UInt8] {
+        return output
+    }
+
+    public func serialize_str(value: String) throws {
+        try serialize_bytes(value: Array(value.utf8))
+    }
+
+    public func serialize_bytes(value: [UInt8]) throws {
+        try serialize_len(value: value.count)
+        output.append(contentsOf: value)
+    }
+
+    public func serialize_bool(value: Bool) throws {
+        writeByte(value ? 1 : 0)
+    }
+
+    public func serialize_unit(value _: ()) throws {}
+
+    func writeByte(_ value: UInt8) {
+        output.append(value)
+    }
+
+    public func serialize_u8(value: UInt8) throws {
+        writeByte(value)
+    }
+
+    public func serialize_u16(value: UInt16) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+    }
+
+    public func serialize_u32(value: UInt32) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+        writeByte(UInt8(truncatingIfNeeded: value >> 16))
+        writeByte(UInt8(truncatingIfNeeded: value >> 24))
+    }
+
+    public func serialize_u64(value: UInt64) throws {
+        writeByte(UInt8(truncatingIfNeeded: value))
+        writeByte(UInt8(truncatingIfNeeded: value >> 8))
+        writeByte(UInt8(truncatingIfNeeded: value >> 16))
+        writeByte(UInt8(truncatingIfNeeded: value >> 24))
+        writeByte(UInt8(truncatingIfNeeded: value >> 32))
+        writeByte(UInt8(truncatingIfNeeded: value >> 40))
+        writeByte(UInt8(truncatingIfNeeded: value >> 48))
+        writeByte(UInt8(truncatingIfNeeded: value >> 56))
+    }
+
+    public func serialize_u128(value: UInt128) throws {
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: value.high)
+    }
+
+    public func serialize_i8(value: Int8) throws {
+        try serialize_u8(value: UInt8(bitPattern: value))
+    }
+
+    public func serialize_i16(value: Int16) throws {
+        try serialize_u16(value: UInt16(bitPattern: value))
+    }
+
+    public func serialize_i32(value: Int32) throws {
+        try serialize_u32(value: UInt32(bitPattern: value))
+    }
+
+    public func serialize_i64(value: Int64) throws {
+        try serialize_u64(value: UInt64(bitPattern: value))
+    }
+
+    public func serialize_i128(value: Int128) throws {
+        try serialize_u64(value: value.low)
+        try serialize_u64(value: UInt64(bitPattern: value.high))
+    }
+
+    public func serialize_option_tag(value: Bool) throws {
+        writeByte(value ? 1 : 0)
+    }
+
+    public func get_buffer_offset() -> Int {
+        return output.count
+    }
+
+    public func serialize_len(value _: Int) throws {
+        assertionFailure("Not implemented")
+    }
+
+    public func serialize_variant_index(value _: UInt32) throws {
+        assertionFailure("Not implemented")
+    }
+
+    public func sort_map_entries(offsets _: [Int]) {
+        assertionFailure("Not implemented")
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BincodeDeserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BincodeDeserializer.swift
@@ -1,0 +1,34 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BincodeDeserializer: BinaryDeserializer {
+    public let MAX_LENGTH: Int = 1 << 31 - 1
+
+    public init(input: [UInt8]) {
+        super.init(input: input, maxContainerDepth: Int.max)
+    }
+
+    override public func deserialize_len() throws -> Int {
+        let value = try deserialize_i64()
+        if value < 0 || value > MAX_LENGTH {
+            throw DeserializationError.invalidInput(issue: "Incorrect length value")
+        }
+        return Int(value)
+    }
+
+    override public func deserialize_f32() throws -> Float {
+        let num = try deserialize_u32()
+        return Float(bitPattern: num)
+    }
+
+    override public func deserialize_f64() throws -> Double {
+        let num = try deserialize_u64()
+        return Double(bitPattern: num)
+    }
+
+    override public func deserialize_variant_index() throws -> UInt32 {
+        return try deserialize_u32()
+    }
+
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BincodeSerializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/BincodeSerializer.swift
@@ -1,0 +1,34 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public class BincodeSerializer: BinarySerializer {
+    public let MAX_LENGTH: Int = 1 << 31 - 1
+
+    public init() {
+        super.init(maxContainerDepth: Int.max)
+    }
+
+    override public func serialize_len(value: Int) throws {
+        if value < 0 || value > MAX_LENGTH {
+            throw SerializationError.invalidValue(issue: "Invalid length value")
+        }
+        try serialize_u64(value: UInt64(value))
+    }
+
+    override public func serialize_f32(value: Float) throws {
+        try serialize_u32(value: value.bitPattern)
+    }
+
+    override public func serialize_f64(value: Double) throws {
+        try serialize_u64(value: value.bitPattern)
+    }
+
+    override public func serialize_variant_index(value: UInt32) throws {
+        try serialize_u32(value: value)
+    }
+
+    override public func sort_map_entries(offsets _: [Int]) {
+        // Not required by the format.
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Deserializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Deserializer.swift
@@ -1,0 +1,33 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public enum DeserializationError: Error {
+    case invalidInput(issue: String)
+}
+
+public protocol Deserializer {
+    func deserialize_str() throws -> String
+    func deserialize_bytes() throws -> [UInt8]
+    func deserialize_bool() throws -> Bool
+    func deserialize_unit() throws
+    func deserialize_char() throws -> Character
+    func deserialize_f32() throws -> Float
+    func deserialize_f64() throws -> Double
+    func deserialize_u8() throws -> UInt8
+    func deserialize_u16() throws -> UInt16
+    func deserialize_u32() throws -> UInt32
+    func deserialize_u64() throws -> UInt64
+    func deserialize_u128() throws -> UInt128
+    func deserialize_i8() throws -> Int8
+    func deserialize_i16() throws -> Int16
+    func deserialize_i32() throws -> Int32
+    func deserialize_i64() throws -> Int64
+    func deserialize_i128() throws -> Int128
+    func deserialize_len() throws -> Int
+    func deserialize_variant_index() throws -> UInt32
+    func deserialize_option_tag() throws -> Bool
+    func get_buffer_offset() -> Int
+    func increase_container_depth() throws
+    func decrease_container_depth() throws
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Indirect.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Indirect.swift
@@ -1,0 +1,23 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+// See https://forums.swift.org/t/using-indirect-modifier-for-struct-properties/37600/16
+@propertyWrapper
+public indirect enum Indirect<T> {
+    case wrapped(T)
+
+    public init(wrappedValue initialValue: T) {
+        self = .wrapped(initialValue)
+    }
+
+    public var wrappedValue: T {
+        get {
+            switch self {
+            case .wrapped(let x): return x
+            }
+        }
+        set { self = .wrapped(newValue) }
+    }
+}
+
+extension Indirect: Equatable where T: Equatable {}
+extension Indirect: Hashable where T: Hashable {}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Int128.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Int128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct Int128: Hashable {
+    public var high: Int64
+    public var low: UInt64
+
+    public init(high: Int64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Serializer.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/Serializer.swift
@@ -1,0 +1,35 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public enum SerializationError: Error {
+    case invalidValue(issue: String)
+}
+
+public protocol Serializer {
+    func serialize_str(value: String) throws
+    func serialize_bytes(value: [UInt8]) throws
+    func serialize_bool(value: Bool) throws
+    func serialize_unit(value: ()) throws
+    func serialize_char(value: Character) throws
+    func serialize_f32(value: Float) throws
+    func serialize_f64(value: Double) throws
+    func serialize_u8(value: UInt8) throws
+    func serialize_u16(value: UInt16) throws
+    func serialize_u32(value: UInt32) throws
+    func serialize_u64(value: UInt64) throws
+    func serialize_u128(value: UInt128) throws
+    func serialize_i8(value: Int8) throws
+    func serialize_i16(value: Int16) throws
+    func serialize_i32(value: Int32) throws
+    func serialize_i64(value: Int64) throws
+    func serialize_i128(value: Int128) throws
+    func serialize_len(value: Int) throws
+    func serialize_variant_index(value: UInt32) throws
+    func serialize_option_tag(value: Bool) throws
+    func increase_container_depth() throws
+    func decrease_container_depth() throws
+    func get_buffer_offset() -> Int
+    func sort_map_entries(offsets: [Int])
+    func get_bytes() -> [UInt8]
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/UInt128.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Serde/UInt128.swift
@@ -1,0 +1,13 @@
+//  Copyright (c) Facebook, Inc. and its affiliates.
+
+import Foundation
+
+public struct UInt128: Hashable {
+    public var high: UInt64
+    public var low: UInt64
+
+    public init(high: UInt64, low: UInt64) {
+        self.high = high
+        self.low = low
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/example.ts
@@ -1,0 +1,66 @@
+import { Serializer, Deserializer } from "./serde";
+type Optional<T> = T | null;
+type str = string;
+
+function serializeOption<T>(
+    value: T | null,
+    serializer: Serializer,
+    serializeElement: (value: T, serializer: Serializer) => void,
+): void {
+    if (value !== null) {
+        serializer.serializeOptionTag(true);
+        serializeElement(value, serializer);
+    } else {
+        serializer.serializeOptionTag(false);
+    }
+}
+
+function deserializeOption<T>(
+    deserializer: Deserializer,
+    deserializeElement: (deserializer: Deserializer) => T,
+): T | null {
+    const tag = deserializer.deserializeOptionTag();
+    if (!tag) {
+        return null;
+    } else {
+        return deserializeElement(deserializer);
+    }
+}
+
+export type Uuid = string & { readonly __uuid: unique symbol };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function serializeUuid(value: Uuid, serializer: Serializer): void {
+    serializer.serializeStr(value as string);
+}
+
+function deserializeUuid(deserializer: Deserializer): Uuid {
+    const s = deserializer.deserializeStr();
+    if (!UUID_RE.test(s)) {
+        throw new Error(`Invalid UUID string: ${s}`);
+    }
+    return s.toLowerCase() as Uuid;
+}
+
+export class StructWithUuid {
+    constructor (public id: Uuid, public parent_id: Optional<Uuid>, public name: str) {
+    }
+
+    public serialize(serializer: Serializer): void {
+        serializeUuid(this.id, serializer);
+        serializeOption(this.parent_id, serializer, (value, serializer) => {
+            serializeUuid(value, serializer);
+        });
+        serializer.serializeStr(this.name);
+    }
+
+    static deserialize(deserializer: Deserializer): StructWithUuid {
+        const id = deserializeUuid(deserializer);
+        const parent_id = deserializeOption(deserializer, (deserializer) => {
+            return deserializeUuid(deserializer);
+        });
+        const name = deserializer.deserializeStr();
+        return new StructWithUuid(id,parent_id,name);
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/package.json
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "name": "example",
+  "version": "0.1.0"
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
@@ -1,0 +1,146 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { Deserializer } from "./deserializer";
+
+export abstract class BinaryDeserializer implements Deserializer {
+  private static readonly BIG_32: bigint = BigInt(32);
+  private static readonly BIG_64: bigint = BigInt(64);
+  private static readonly textDecoder = new TextDecoder();
+  public buffer: ArrayBuffer;
+  public offset: number;
+
+  constructor(data: Uint8Array) {
+    // copies data to prevent outside mutation of buffer.
+    this.buffer = new ArrayBuffer(data.length);
+    new Uint8Array(this.buffer).set(data, 0);
+    this.offset = 0;
+  }
+
+  private read(length: number): ArrayBuffer {
+    const bytes = this.buffer.slice(this.offset, this.offset + length);
+    this.offset += length;
+    return bytes;
+  }
+
+  abstract deserializeLen(): number;
+
+  abstract deserializeVariantIndex(): number;
+
+  abstract checkThatKeySlicesAreIncreasing(
+    key1: [number, number],
+    key2: [number, number],
+  ): void;
+
+  public deserializeStr(): string {
+    const value = this.deserializeBytes();
+    return BinaryDeserializer.textDecoder.decode(value);
+  }
+
+  public deserializeBytes(): Uint8Array {
+    const len = this.deserializeLen();
+    if (len < 0) {
+      throw new Error("Length of a bytes array can't be negative");
+    }
+    return new Uint8Array(this.read(len));
+  }
+
+  public deserializeBool(): boolean {
+    const bool = new Uint8Array(this.read(1))[0];
+    return bool == 1;
+  }
+
+  public deserializeUnit(): null {
+    return null;
+  }
+
+  public deserializeU8(): number {
+    return new DataView(this.read(1)).getUint8(0);
+  }
+
+  public deserializeU16(): number {
+    return new DataView(this.read(2)).getUint16(0, true);
+  }
+
+  public deserializeU32(): number {
+    return new DataView(this.read(4)).getUint32(0, true);
+  }
+
+  public deserializeU64(): bigint {
+    const low = this.deserializeU32();
+    const high = this.deserializeU32();
+
+    // combine the two 32-bit values and return (little endian)
+    return BigInt(
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
+        BigInt(low.toString()),
+    );
+  }
+
+  public deserializeU128(): bigint {
+    const low = this.deserializeU64();
+    const high = this.deserializeU64();
+
+    // combine the two 64-bit values and return (little endian)
+    return BigInt(
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
+        BigInt(low.toString()),
+    );
+  }
+
+  public deserializeI8(): number {
+    return new DataView(this.read(1)).getInt8(0);
+  }
+
+  public deserializeI16(): number {
+    return new DataView(this.read(2)).getInt16(0, true);
+  }
+
+  public deserializeI32(): number {
+    return new DataView(this.read(4)).getInt32(0, true);
+  }
+
+  public deserializeI64(): bigint {
+    const low = this.deserializeI32();
+    const high = this.deserializeI32();
+
+    // combine the two 32-bit values and return (little endian)
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
+      BigInt(low.toString())
+    );
+  }
+
+  public deserializeI128(): bigint {
+    const low = this.deserializeI64();
+    const high = this.deserializeI64();
+
+    // combine the two 64-bit values and return (little endian)
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
+      BigInt(low.toString())
+    );
+  }
+
+  public deserializeOptionTag(): boolean {
+    return this.deserializeBool();
+  }
+
+  public getBufferOffset(): number {
+    return this.offset;
+  }
+
+  public deserializeChar(): string {
+    throw new Error("Method deserializeChar not implemented.");
+  }
+
+  public deserializeF32(): number {
+    return new DataView(this.read(4)).getFloat32(0, true);
+  }
+
+  public deserializeF64(): number {
+    return new DataView(this.read(8)).getFloat64(0, true);
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binarySerializer.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+import { Serializer } from "./serializer";
+
+export abstract class BinarySerializer implements Serializer {
+  private static readonly BIG_32: bigint = BigInt(32);
+  private static readonly BIG_64: bigint = BigInt(64);
+
+  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
+  private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
+
+  private static readonly textEncoder = new TextEncoder();
+
+  private buffer: ArrayBuffer;
+  private offset: number;
+
+  constructor() {
+    this.buffer = new ArrayBuffer(64);
+    this.offset = 0;
+  }
+
+  private ensureBufferWillHandleSize(bytes: number) {
+    while (this.buffer.byteLength < this.offset + bytes) {
+      const newBuffer = new ArrayBuffer(this.buffer.byteLength * 2);
+      new Uint8Array(newBuffer).set(new Uint8Array(this.buffer));
+      this.buffer = newBuffer;
+    }
+  }
+
+  protected serialize(values: Uint8Array) {
+    this.ensureBufferWillHandleSize(values.length);
+    new Uint8Array(this.buffer, this.offset).set(values);
+    this.offset += values.length;
+  }
+
+  abstract serializeLen(value: number): void;
+
+  abstract serializeVariantIndex(value: number): void;
+
+  abstract sortMapEntries(offsets: number[]): void;
+
+  public serializeStr(value: string): void {
+    this.serializeBytes(BinarySerializer.textEncoder.encode(value));
+  }
+
+  public serializeBytes(value: Uint8Array): void {
+    this.serializeLen(value.length);
+    this.serialize(value);
+  }
+
+  public serializeBool(value: boolean): void {
+    const byteValue = value ? 1 : 0;
+    this.serialize(new Uint8Array([byteValue]));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/explicit-module-boundary-types
+  public serializeUnit(_value: null): void {
+    return;
+  }
+
+  private serializeWithFunction(
+    fn: (byteOffset: number, value: number, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: number,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
+  public serializeU8(value: number): void {
+    this.serialize(new Uint8Array([value]));
+  }
+
+  public serializeU16(value: number): void {
+    this.serializeWithFunction(DataView.prototype.setUint16, 2, value);
+  }
+
+  public serializeU32(value: number): void {
+    this.serializeWithFunction(DataView.prototype.setUint32, 4, value);
+  }
+
+  public serializeU64(value: BigInt | number): void {
+    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
+    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
+
+    // write little endian number
+    this.serializeU32(Number(low));
+    this.serializeU32(Number(high));
+  }
+
+  public serializeU128(value: BigInt | number): void {
+    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
+    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+
+    // write little endian number
+    this.serializeU64(low);
+    this.serializeU64(high);
+  }
+
+  public serializeI8(value: number): void {
+    const bytes = 1;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt8(0, value);
+    this.offset += bytes;
+  }
+
+  public serializeI16(value: number): void {
+    const bytes = 2;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt16(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeI32(value: number): void {
+    const bytes = 4;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setInt32(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeI64(value: bigint | number): void {
+    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
+    const high = BigInt(value) >> BinarySerializer.BIG_32;
+
+    // write little endian number
+    this.serializeI32(Number(low));
+    this.serializeI32(Number(high));
+  }
+
+  public serializeI128(value: bigint | number): void {
+    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
+    const high = BigInt(value) >> BinarySerializer.BIG_64;
+
+    // write little endian number
+    this.serializeI64(low);
+    this.serializeI64(high);
+  }
+
+  public serializeOptionTag(value: boolean): void {
+    this.serializeBool(value);
+  }
+
+  public getBufferOffset(): number {
+    return this.offset;
+  }
+
+  public getBytes(): Uint8Array {
+    return new Uint8Array(this.buffer).slice(0, this.offset);
+  }
+
+  public serializeChar(_value: string): void {
+    throw new Error("Method serializeChar not implemented.");
+  }
+
+  public serializeF32(value: number): void {
+    const bytes = 4;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setFloat32(0, value, true);
+    this.offset += bytes;
+  }
+
+  public serializeF64(value: number): void {
+    const bytes = 8;
+    this.ensureBufferWillHandleSize(bytes);
+    new DataView(this.buffer, this.offset).setFloat64(0, value, true);
+    this.offset += bytes;
+  }
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/deserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/deserializer.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export interface Deserializer {
+  deserializeStr(): string;
+
+  deserializeBytes(): Uint8Array;
+
+  deserializeBool(): boolean;
+
+  deserializeUnit(): null;
+
+  deserializeChar(): string;
+
+  deserializeF32(): number;
+
+  deserializeF64(): number;
+
+  deserializeU8(): number;
+
+  deserializeU16(): number;
+
+  deserializeU32(): number;
+
+  deserializeU64(): bigint;
+
+  deserializeU128(): bigint;
+
+  deserializeI8(): number;
+
+  deserializeI16(): number;
+
+  deserializeI32(): number;
+
+  deserializeI64(): bigint;
+
+  deserializeI128(): bigint;
+
+  deserializeLen(): number;
+
+  deserializeVariantIndex(): number;
+
+  deserializeOptionTag(): boolean;
+
+  getBufferOffset(): number;
+
+  checkThatKeySlicesAreIncreasing(
+    key1: [number, number],
+    key2: [number, number],
+  ): void;
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/index.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export * from "./types";
+export * from "./serializer";
+export * from "./deserializer";
+export * from "./binarySerializer";
+export * from "./binaryDeserializer";

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/serializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/serializer.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export interface Serializer {
+  serializeStr(value: string): void;
+
+  serializeBytes(value: Uint8Array): void;
+
+  serializeBool(value: boolean): void;
+
+  serializeUnit(value: null): void;
+
+  serializeChar(value: string): void;
+
+  serializeF32(value: number): void;
+
+  serializeF64(value: number): void;
+
+  serializeU8(value: number): void;
+
+  serializeU16(value: number): void;
+
+  serializeU32(value: number): void;
+
+  serializeU64(value: bigint | number): void;
+
+  serializeU128(value: bigint | number): void;
+
+  serializeI8(value: number): void;
+
+  serializeI16(value: number): void;
+
+  serializeI32(value: number): void;
+
+  serializeI64(value: bigint | number): void;
+
+  serializeI128(value: bigint | number): void;
+
+  serializeLen(value: number): void;
+
+  serializeVariantIndex(value: number): void;
+
+  serializeOptionTag(value: boolean): void;
+
+  getBufferOffset(): number;
+
+  getBytes(): Uint8Array;
+
+  sortMapEntries(offsets: number[]): void;
+}

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/types.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates
+ * SPDX-License-Identifier: MIT OR Apache-2.0
+ */
+
+export type Optional<T> = T | null;
+export type Seq<T> = T[];
+export type Tuple<T extends any[]> = T;
+export type ListTuple<T extends any[]> = Tuple<T>[];
+
+export type unit = null;
+export type bool = boolean;
+export type int8 = number;
+export type int16 = number;
+export type int32 = number;
+export type int64 = bigint;
+export type int128 = bigint;
+export type uint8 = number;
+export type uint16 = number;
+export type uint32 = number;
+export type uint64 = bigint;
+export type uint128 = bigint;
+export type float32 = number;
+export type float64 = number;
+export type char = string;
+export type str = string;
+export type bytes = Uint8Array;

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -240,6 +240,7 @@ impl Emitter<TypeScript> for Format {
             Self::Char => write!(w, "char"),
             Self::Str => write!(w, "str"),
             Self::Bytes => write!(w, "bytes"),
+            Self::Uuid => write!(w, "Uuid"),
 
             Self::Option(format) => {
                 write!(w, "Optional<")?;

--- a/crates/facet_generate/src/reflection/format/mod.rs
+++ b/crates/facet_generate/src/reflection/format/mod.rs
@@ -215,6 +215,13 @@ pub enum Format {
     Char,
     Str,
     Bytes,
+    /// A UUID. On the wire this is identical to `Bytes` (16 raw bytes,
+    /// length-prefixed) for non-human-readable encoders (e.g. bincode), and a
+    /// lowercase hyphenated string for human-readable encoders (e.g. JSON).
+    /// Foreign-language emitters map this to the native UUID type for the
+    /// target language (e.g. `Foundation.UUID` in Swift, `java.util.UUID` in
+    /// Kotlin, `System.Guid` in C#, branded `string` in TypeScript).
+    Uuid,
 
     /// The format of `Option<T>`.
     Option(Box<Self>),
@@ -597,7 +604,8 @@ impl FormatHolder for Format {
             | Self::F64
             | Self::Char
             | Self::Str
-            | Self::Bytes => (),
+            | Self::Bytes
+            | Self::Uuid => (),
 
             Self::Option(format)
             | Self::Seq(format)
@@ -649,7 +657,8 @@ impl FormatHolder for Format {
             | Self::F64
             | Self::Char
             | Self::Str
-            | Self::Bytes => (),
+            | Self::Bytes
+            | Self::Uuid => (),
 
             Self::Option(format)
             | Self::Seq(format)
@@ -712,6 +721,7 @@ impl Format {
                 | Self::Char
                 | Self::Str
                 | Self::Bytes
+                | Self::Uuid
         )
     }
 

--- a/crates/facet_generate/src/reflection/mod.rs
+++ b/crates/facet_generate/src/reflection/mod.rs
@@ -1636,6 +1636,7 @@ fn type_to_format(shape: &Shape) -> Result<Option<Format>, Error> {
         }),
         Type::User(UserType::Opaque) => match shape.type_identifier {
             "String" | "DateTime<Utc>" => Some(Format::Str),
+            "Uuid" => Some(Format::Uuid),
             _ => None,
         },
         // Handle () unit type which in facet 0.44.1 appears as User(Struct(Tuple, []))

--- a/crates/facet_generate/src/tests/mod.rs
+++ b/crates/facet_generate/src/tests/mod.rs
@@ -97,6 +97,7 @@ mod test_skip_by_language;
 mod test_type_alias;
 mod test_unit_enum_case_name_support;
 mod test_unit_enum_serde_other;
+mod test_uuid;
 mod test_visibility_modifiers;
 mod unit_enum_decorator;
 mod unit_enum_is_properly_named_with_serde_overrides;
@@ -192,12 +193,15 @@ macro_rules! test {
     (@package kotlin) => { "com.example" };
     (@package swift) => { "ExamplePackage" };
     (@package typescript) => { "example_package" };
+    (@package csharp) => { "Example" };
 
     (@out kotlin) => { "output.kt" };
     (@out swift) => { "output.swift" };
     (@out typescript) => { "output.ts" };
+    (@out csharp) => { "output.cs" };
 
     (@gen kotlin) => { kotlin::KotlinCodeGenerator };
     (@gen swift) => { swift::SwiftCodeGenerator };
     (@gen typescript) => { typescript::TypeScriptCodeGenerator };
+    (@gen csharp) => { csharp::CSharpCodeGenerator };
 }

--- a/crates/facet_generate/src/tests/test_uuid/mod.rs
+++ b/crates/facet_generate/src/tests/test_uuid/mod.rs
@@ -1,0 +1,11 @@
+use facet::Facet;
+use uuid::Uuid;
+
+#[derive(Facet)]
+#[facet(rename_all = "camelCase")]
+pub struct Foo {
+    pub id: Uuid,
+    pub maybe_id: Option<Uuid>,
+}
+
+crate::test! { Foo for kotlin, swift, typescript, csharp }

--- a/crates/facet_generate/src/tests/test_uuid/output.cs
+++ b/crates/facet_generate/src/tests/test_uuid/output.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Facet.Runtime.Serde;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Example;
+
+public partial class Foo : ObservableObject {
+    [ObservableProperty]
+    private Guid _id;
+    [ObservableProperty]
+    private Guid? _maybeId;
+}

--- a/crates/facet_generate/src/tests/test_uuid/output.kt
+++ b/crates/facet_generate/src/tests/test_uuid/output.kt
@@ -1,0 +1,6 @@
+package com.example
+
+data class Foo(
+    val id: UUID,
+    val maybeId: UUID? = null,
+)

--- a/crates/facet_generate/src/tests/test_uuid/output.swift
+++ b/crates/facet_generate/src/tests/test_uuid/output.swift
@@ -1,0 +1,10 @@
+
+public struct Foo {
+    public var id: UUID
+    public var maybeId: UUID?
+
+    public init(id: UUID, maybeId: UUID?) {
+        self.id = id
+        self.maybeId = maybeId
+    }
+}

--- a/crates/facet_generate/src/tests/test_uuid/output.ts
+++ b/crates/facet_generate/src/tests/test_uuid/output.ts
@@ -1,0 +1,6 @@
+type Optional<T> = T | null;
+
+export class Foo {
+    constructor (public id: Uuid, public maybeId: Optional<Uuid>) {
+    }
+}

--- a/crates/facet_generate/tests/common/mod.rs
+++ b/crates/facet_generate/tests/common/mod.rs
@@ -508,6 +508,38 @@ pub enum SwiftList<T> {
 #[derive(Facet, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SwiftSimpleList(pub Option<Box<Self>>);
 
+// ---------------------------------------------------------------------------
+// UUID round-trip fixtures
+// ---------------------------------------------------------------------------
+
+/// Two well-known RFC 4122 UUIDs used as pinned test vectors.
+/// Using `uuid!` gives a compile-time constant so the bytes are deterministic.
+pub const UUID_ID: uuid::Uuid = uuid::uuid!("550e8400-e29b-41d4-a716-446655440000");
+pub const UUID_PARENT_ID: uuid::Uuid = uuid::uuid!("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+/// A struct with a required and an optional UUID field.
+#[derive(Facet, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct UuidData {
+    pub id: uuid::Uuid,
+    pub parent_id: Option<uuid::Uuid>,
+}
+
+/// Returns a registry containing only [`UuidData`].
+pub fn get_uuid_registry() -> Registry {
+    reflect!(UuidData).unwrap()
+}
+
+/// Serialize the canonical UUID test value with bincode.
+/// The resulting bytes are used as the reference wire encoding in all
+/// language round-trip tests.
+pub fn get_uuid_reference_bytes() -> Vec<u8> {
+    bincode::serialize(&UuidData {
+        id: UUID_ID,
+        parent_id: Some(UUID_PARENT_ID),
+    })
+    .unwrap()
+}
+
 /// Registry used for Swift compilation and runtime tests.
 ///
 /// Excludes `ComplexMap(BTreeMap<([u32; 2], [u8; 4]), ()>)` because native

--- a/crates/facet_generate/tests/csharp_runtime.rs
+++ b/crates/facet_generate/tests/csharp_runtime.rs
@@ -54,6 +54,58 @@ fn quote_bytes(bytes: &[u8]) -> String {
 }
 
 #[test]
+fn test_csharp_bincode_runtime_on_uuid_data() {
+    let registry = common::get_uuid_registry();
+    let dir = tempdir().unwrap();
+    let dir = dir.path().to_path_buf().join("testing");
+
+    csharp::Installer::new("Example.Testing", &dir)
+        .plugin(BincodePlugin)
+        .generate(&registry)
+        .unwrap();
+
+    let reference = common::get_uuid_reference_bytes();
+    let id_str = common::UUID_ID.to_string();
+    let parent_id_str = common::UUID_PARENT_ID.to_string();
+
+    make_executable(&dir, "Example.Testing");
+
+    let program_path = dir.join("Program.cs");
+    let mut program = std::fs::File::create(program_path).unwrap();
+    writeln!(
+        program,
+        r#"using System;
+using System.Linq;
+using Example.Testing;
+using Facet.Runtime.Serde;
+using Facet.Runtime.Bincode;
+
+static void Assert(bool condition, string message)
+{{
+    if (!condition) throw new Exception("Assertion failed: " + message);
+}}
+
+byte[] input = {bytes};
+var value = UuidData.BincodeDeserialize(input);
+
+Assert(value.Id == new Guid("{id}"), $"Id should be {id}, got {{value.Id}}");
+Assert(value.ParentId == new Guid("{parent_id}"), $"ParentId should be {parent_id}, got {{value.ParentId}}");
+
+var output = value.BincodeSerialize();
+Assert(input.SequenceEqual(output), $"Roundtrip failed: {{input.Length}} bytes in, {{output.Length}} bytes out");
+
+Console.WriteLine("UUID roundtrip: PASSED");
+"#,
+        bytes = quote_bytes(&reference),
+        id = id_str,
+        parent_id = parent_id_str,
+    )
+    .unwrap();
+
+    dotnet_run(&dir);
+}
+
+#[test]
 fn test_csharp_bincode_runtime_on_simple_data() {
     let registry = common::get_simple_registry();
     let dir = tempdir().unwrap();

--- a/crates/facet_generate/tests/kotlin_runtime.rs
+++ b/crates/facet_generate/tests/kotlin_runtime.rs
@@ -19,7 +19,7 @@
 
 use std::{
     fs,
-    io::Write as _,
+    io::{self, Write as _},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -64,6 +64,17 @@ fn quote_bytes_kotlin(bytes: &[u8]) -> String {
 
 #[test]
 fn test_kotlin_bincode_runtime_on_uuid_data() {
+    // Skip gracefully when kotlinc is not on PATH (e.g. Windows CI runners
+    // that have Gradle but not the standalone kotlinc compiler).
+    match Command::new("kotlinc").arg("-version").output() {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            eprintln!("kotlinc not found on PATH — skipping runtime test");
+            return;
+        }
+        Err(e) => panic!("failed to probe kotlinc: {e}"),
+        Ok(_) => {}
+    }
+
     let registry = common::get_uuid_registry();
     let dir = tempdir().unwrap();
     let dir = dir.path().to_path_buf().join("testing");

--- a/crates/facet_generate/tests/kotlin_runtime.rs
+++ b/crates/facet_generate/tests/kotlin_runtime.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "kotlin")]
+//! Runtime tests for Kotlin bincode serialization.
+//!
+//! These tests generate Kotlin code, serialize data in Rust with bincode, then
+//! compile and run the generated Kotlin code to deserialize, verify field
+//! values, and re-serialize — checking that the bytes round-trip correctly.
+//!
+//! # Toolchain requirement
+//!
+//! `kotlinc` and `java` must be on `PATH`. The test compiles all generated
+//! `.kt` sources (including the serde runtime) into a single JAR with
+//! `kotlinc -include-runtime`, then runs the JVM entry-point with
+//! `java -classpath`.
+//!
+//! Unlike the compilation-only test in `kotlin_generation.rs`, this test
+//! actually *executes* the generated serialization logic and verifies the
+//! bytes produced by the Kotlin code match what Rust's `bincode` produces
+//! for the same value.
+
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use facet_generate::generation::{bincode::BincodePlugin, kotlin};
+use tempfile::tempdir;
+
+pub mod common;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Collect all `.kt` files under `dir`, recursively.
+fn collect_kt_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = vec![];
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(collect_kt_files(&path));
+            } else if path.extension().is_some_and(|e| e == "kt") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// Format a `&[u8]` as a Kotlin `byteArrayOf(…)` literal.
+///
+/// Kotlin `Byte` is signed, so values > 127 must be cast to their signed
+/// equivalents (e.g. 255u8 → -1i8).
+fn quote_bytes_kotlin(bytes: &[u8]) -> String {
+    let elems: Vec<String> = bytes.iter().map(|&b| b.cast_signed().to_string()).collect();
+    format!("byteArrayOf({})", elems.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_kotlin_bincode_runtime_on_uuid_data() {
+    let registry = common::get_uuid_registry();
+    let dir = tempdir().unwrap();
+    let dir = dir.path().to_path_buf().join("testing");
+
+    // Generate the Kotlin source + serde/bincode runtime files.
+    kotlin::Installer::new("com.example.testing", &dir)
+        .plugin(BincodePlugin)
+        .generate(&registry)
+        .unwrap();
+
+    let reference = common::get_uuid_reference_bytes();
+    let id_str = common::UUID_ID.to_string();
+    let parent_id_str = common::UUID_PARENT_ID.to_string();
+
+    // Write a top-level Main.kt (default package → JVM class `MainKt`).
+    let main_path = dir.join("Main.kt");
+    let mut main_file = fs::File::create(&main_path).unwrap();
+    writeln!(
+        main_file,
+        r#"import com.example.testing.UuidData
+import java.util.UUID
+
+fun main() {{
+    val input = {bytes}
+    val value = UuidData.bincodeDeserialize(input)
+
+    check(value.id == UUID.fromString("{id}")) {{
+        "id mismatch: ${{value.id}}"
+    }}
+    check(value.parentId == UUID.fromString("{parent_id}")) {{
+        "parentId mismatch: ${{value.parentId}}"
+    }}
+
+    val output = value.bincodeSerialize()
+    check(input.contentEquals(output)) {{
+        "roundtrip failed:\n  input  = ${{input.toList()}}\n  output = ${{output.toList()}}"
+    }}
+
+    println("UUID roundtrip: PASSED")
+}}
+"#,
+        bytes = quote_bytes_kotlin(&reference),
+        id = id_str,
+        parent_id = parent_id_str,
+    )
+    .unwrap();
+
+    // Compile all .kt files (generated types + serde runtime + Main.kt) into
+    // a single self-contained JAR.
+    let jar_path = dir.join("test.jar");
+    let kt_files = collect_kt_files(&dir);
+
+    let status = Command::new("kotlinc")
+        .args(&kt_files)
+        .arg("-include-runtime")
+        .arg("-d")
+        .arg(&jar_path)
+        .current_dir(&dir)
+        .status()
+        .unwrap();
+    assert!(status.success(), "kotlinc compilation failed");
+
+    // Run the JVM entry-point. `Main.kt` in the default package compiles to
+    // the JVM class `MainKt`.
+    let status = Command::new("java")
+        .arg("-classpath")
+        .arg(&jar_path)
+        .arg("MainKt")
+        .current_dir(&dir)
+        .status()
+        .unwrap();
+    assert!(status.success(), "UUID round-trip test failed");
+}

--- a/crates/facet_generate/tests/swift_runtime.rs
+++ b/crates/facet_generate/tests/swift_runtime.rs
@@ -206,6 +206,84 @@ let package = Package(
     assert!(status.success());
 }
 
+#[test]
+fn test_swift_bincode_runtime_on_uuid_data() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CodeGeneratorConfig::new("Testing".to_string());
+    let registry = common::get_uuid_registry();
+    let mut installer =
+        swift::Installer::new(&config.module_name, dir.path()).plugin(BincodePlugin);
+    installer.install_module(&config, &registry).unwrap();
+    installer.install_serde_runtime().unwrap();
+
+    let reference = common::get_uuid_reference_bytes();
+    let id_str = common::UUID_ID.to_string();
+    let parent_id_str = common::UUID_PARENT_ID.to_string();
+
+    std::fs::create_dir_all(dir.path().join("Sources/main")).unwrap();
+    let main_path = dir.path().join("Sources/main/main.swift");
+    let mut main = File::create(main_path).unwrap();
+    writeln!(
+        main,
+        r#"
+import Foundation
+import Serde
+import Testing
+
+let input: [UInt8] = [{bytes}]
+let value = try UuidData.bincodeDeserialize(input: input)
+
+let expectedId = UUID(uuidString: "{id}")!
+let expectedParentId = UUID(uuidString: "{parent_id}")!
+assert(value.id == expectedId, "id mismatch: \(value.id)")
+assert(value.parentId == expectedParentId, "parentId mismatch: \(String(describing: value.parentId))")
+
+let output = try value.bincodeSerialize()
+assert(input == output, "roundtrip failed: \(input) != \(output)")
+
+print("UUID roundtrip: PASSED")
+"#,
+        bytes = reference.iter().map(|x| format!("{x}")).collect::<Vec<_>>().join(", "),
+        id = id_str,
+        parent_id = parent_id_str,
+    )
+    .unwrap();
+
+    let mut file = File::create(dir.path().join("Package.swift")).unwrap();
+    write!(
+        file,
+        r#"// swift-tools-version:6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "Testing",
+    platforms: [.macOS(.v15)],
+    targets: [
+        .target(
+            name: "Serde",
+            dependencies: []),
+        .target(
+            name: "Testing",
+            dependencies: ["Serde"]),
+        .target(
+            name: "main",
+            dependencies: ["Serde", "Testing"]
+        ),
+    ]
+)
+"#
+    )
+    .unwrap();
+
+    let status = Command::new("swift")
+        .current_dir(dir.path())
+        .arg("run")
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
 fn quote_bytes(bytes: &[u8]) -> String {
     format!(
         "[{}]",

--- a/crates/facet_generate/tests/typescript_runtime.rs
+++ b/crates/facet_generate/tests/typescript_runtime.rs
@@ -9,6 +9,75 @@ use std::{fs::File, io::Write, process::Command, sync::Arc};
 use tempfile::tempdir;
 
 #[test]
+fn test_typescript_runtime_bincode_uuid_roundtrip() {
+    let registry = common::get_uuid_registry();
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+    std::fs::create_dir_all(dir_path).unwrap();
+
+    let mut installer = typescript::Installer::new("main", dir_path);
+    installer.install_serde_runtime().unwrap();
+    installer.install_bincode_runtime().unwrap();
+
+    let source_path = dir_path.join("test.ts");
+    let mut source = File::create(&source_path).unwrap();
+
+    writeln!(
+        source,
+        r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
+import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
+"#
+    )
+    .unwrap();
+
+    let config = CodeGeneratorConfig::new("main".to_string());
+    let generator = typescript::TypeScriptCodeGenerator::new(&config)
+        .with_plugins(vec![Arc::new(BincodePlugin)]);
+    generator.output(&mut source, &registry).unwrap();
+
+    let reference = common::get_uuid_reference_bytes();
+    let id_str = common::UUID_ID.to_string();
+    let parent_id_str = common::UUID_PARENT_ID.to_string();
+
+    writeln!(
+        source,
+        r#"
+Deno.test("UUID bincode roundtrip", () => {{
+  const expectedBytes = new Uint8Array([{bytes}]);
+  const deserializer = new BincodeDeserializer(expectedBytes);
+  const value: UuidData = UuidData.deserialize(deserializer);
+
+  assertEquals(value.id, "{id}" as Uuid, "id should match");
+  assertEquals(value.parent_id, "{parent_id}" as Uuid, "parent_id should match");
+
+  const serializer = new BincodeSerializer();
+  value.serialize(serializer);
+  const output = serializer.getBytes();
+
+  assertEquals(output, expectedBytes, "roundtrip bytes should match");
+}});
+"#,
+        bytes = reference
+            .iter()
+            .map(|x| format!("{x}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        id = id_str,
+        parent_id = parent_id_str,
+    )
+    .unwrap();
+
+    let status = Command::new("deno")
+        .current_dir(dir_path)
+        .arg("test")
+        .arg("--sloppy-imports")
+        .arg(&source_path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
 fn test_typescript_runtime_bincode_serialization() {
     let registry = common::get_simple_registry();
     let dir = tempdir().unwrap();


### PR DESCRIPTION
fixes #87 

## Add native UUID support for all four target languages

Adds `Format::Uuid` as a first-class IR variant so that `uuid::Uuid` fields are emitted as the native UUID type in each target language, rather than being dropped or mapped to a plain string.

### Motivation

`uuid::Uuid` is an opaque type in facet's reflection model. Without explicit handling, fields of that type would fall through the existing `Type::User(UserType::Opaque)` match and return `None`, making structs with UUID fields un-generatable. Mapping to `Format::Str` would work for JSON but would be wrong over bincode, where the `uuid` crate serialises as 16 raw bytes via `serialize_bytes`.

### Wire format

The encoding follows exactly what `uuid::Uuid`'s serde implementation produces:

- **Bincode** (non-human-readable): `serialize_bytes(&uuid.as_bytes()[..])` — 8-byte little-endian length prefix followed by 16 raw bytes in RFC 4122 order. The foreign helpers delegate to the runtime's existing `serialize_bytes`/`deserialize_bytes`, so the byte layout is automatically consistent.
- **JSON** (human-readable): lowercase hyphenated string, e.g. `"550e8400-e29b-41d4-a716-446655440000"`.

### Foreign type mapping

| Language | Type | Notes |
|---|---|---|
| Swift | `Foundation.UUID` | `import Foundation` added when `Feature::Uuid` is set |
| Kotlin | `java.util.UUID` | MSB/LSB big-endian packing; `Bytes` wrapper used for the bincode call |
| TypeScript | branded `string` — `type Uuid = string & { readonly __uuid: unique symbol }` | Brand costs nothing at runtime; byte↔string helpers inlined into the module |
| C# | `System.Guid` | Uses `Guid.TryWriteBytes(bigEndian: true)` / `new Guid(bytes, bigEndian: true)` (.NET 5+) to match RFC 4122 byte order — the `bigEndian` overload is the critical detail that prevents silent field corruption |

### Changes

**IR & config** (`reflection/format/mod.rs`, `generation/config.rs`)
- New `Format::Uuid` leaf variant, sitting alongside `Bytes` in all exhaustive matches.
- New `Feature::Uuid` flag, set automatically by `CodeGeneratorConfig::update_from` when the registry contains a UUID field.
- `"Uuid"` added to the `type_identifier` detection in `type_to_format`.
- `uuid = { version = "1", features = ["v4", "serde"] }` added as a dev-dependency; `facet`'s `"uuid"` feature enabled.

**Per-language emitters** — for each language, touched: type-name emitter, bincode plugin (serialize/deserialize dispatch + `FEATURE_UUID` module helper + imports), JSON plugin (same), and any language-specific predicates (Swift's `is_hashable`/`is_equatable_auto`/`fmt_can_be_hashable`/`fmt_can_be_equatable`; C#'s `is_csharp_value_type` so `Option<Uuid>` uses the value-type option helpers).

**Bug fix — C# `module_helpers` never called** (`csharp/emitter/mod.rs`)
`Emitter<CSharp> for Module::write` was the only language emitter that never called `plugin.module_helpers()`, so any per-module helper snippets (including `UuidSerde`) were silently dropped. Fixed by changing the writer bound from `W: Write` to `W: IndentWrite` and adding the `module_helpers` loop after the `namespace` declaration. This is a latent correctness fix that also benefits any future C# module helpers.

**Bug fix — missing `import com.novi.serde.Bytes` in Kotlin bincode** (`bincode/kotlin.rs`)
The `FEATURE_UUID` helper constructs `Bytes(bytes)` to call `serializer.serialize_bytes`, but the import was not added alongside `import java.util.UUID`. Only caught by the new runtime test — the snapshot tests are text-only and cannot see this kind of error.

**`test!` macro extended to support `csharp`** (`tests/mod.rs`)
The three `@package`/`@out`/`@gen` dispatch arms were missing for C#. Adding them means any future type-only test fixture can include `csharp` with no additional boilerplate.

**Tests**
- `src/tests/test_uuid/` — type-declaration golden tests for all four languages (`output.kt`, `output.swift`, `output.ts`, `output.cs`).
- `src/generation/tests/with_uuid/` — plugin-driven snapshot tests: `test_bincode` and `test_json`, each covering Kotlin, Swift, and TypeScript, exercising the full serialize/deserialize method bodies.
- `tests/common/mod.rs` — `UuidData` struct, two pinned RFC 4122 constant UUIDs, and `get_uuid_reference_bytes()` shared across all runtime tests.
- `tests/swift_runtime.rs` — `test_swift_bincode_runtime_on_uuid_data`: deserialises Rust-produced bytes in Swift, checks field values, re-serialises, compares bytes.
- `tests/typescript_runtime.rs` — same via Deno, including the branded `Uuid` type in the assertion.
- `tests/csharp_runtime.rs` — same via `dotnet run`, specifically exercising the `bigEndian: true` path.
- `tests/kotlin_runtime.rs` —  Uses `kotlinc -include-runtime` + `java -classpath` (no Gradle, ~3 s) to compile and run the generated code, verifying the round-trip.