### PR TITLE
swift: Update Hashable and Equatable code generation

### DIFF
--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -576,15 +576,21 @@ fn struct_<W: IndentWrite>(
     let all_equatable_auto = fields.iter().all(|f| is_equatable_auto(&f.value, lang));
     let all_can_eq = fields.iter().all(|f| can_use_eq_operator(&f.value, lang));
 
-    if !has_plugins {
-        write!(w, "public struct {name} ")?;
-    } else if all_hashable {
-        write!(w, "public struct {name}: Hashable ")?;
-    } else if all_equatable_auto || all_can_eq {
-        write!(w, "public struct {name}: Equatable ")?;
+    let mut implements = vec![];
+
+    if all_hashable {
+        implements.push("Hashable");
+    }
+    if all_equatable_auto || all_can_eq {
+        implements.push("Equatable");
+    }
+
+    if has_plugins && !implements.is_empty() {
+        write!(w, "public struct {name}: {} ", implements.join(", "))?;
     } else {
         write!(w, "public struct {name} ")?;
     }
+
     let mut w = w.block(Newlines::BOTH)?;
 
     for field in fields {
@@ -684,15 +690,21 @@ fn enum_<W: IndentWrite>(
         .values()
         .all(|v| variant_can_use_eq_operator(&v.value, lang));
 
-    if !has_plugins {
-        write!(w, "indirect public enum {name} ")?;
-    } else if all_hashable {
-        write!(w, "indirect public enum {name}: Hashable ")?;
-    } else if all_equatable_auto || all_can_eq {
-        write!(w, "indirect public enum {name}: Equatable ")?;
+    let mut implements = vec![];
+
+    if all_hashable {
+        implements.push("Hashable");
+    }
+    if all_equatable_auto || all_can_eq {
+        implements.push("Equatable");
+    }
+
+    if has_plugins && !implements.is_empty() {
+        write!(w, "indirect public enum {name}: {} ", implements.join(", "))?;
     } else {
         write!(w, "indirect public enum {name} ")?;
     }
+
     let mut w = w.block(Newlines::BOTH)?;
 
     for variant in variants.values() {

--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -149,7 +149,7 @@ pub fn is_hashable(format: &Format, lang: &Swift) -> bool {
         Format::Map { key, value } => {
             // [K: V] is Hashable iff K is hashable and V is hashable
             is_hashable(key, lang) && is_hashable(value, lang)
-        }, 
+        },
 
         Format::TypeName(qtn) => match &qtn.namespace {
             Namespace::Root => lang.hashable_types.contains(&qtn.name),

--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -145,7 +145,11 @@ pub fn is_hashable(format: &Format, lang: &Swift) -> bool {
     match format {
         Format::Variable(_)
         | Format::Unit  // Void does not conform to Hashable in Swift
-        | Format::Map { .. } => false, // [K: V] is never Hashable
+         => false,
+        Format::Map { key, value } => {
+            // [K: V] is Hashable iff K is hashable and V is hashable
+            is_hashable(key, lang) && is_hashable(value, lang)
+        }, 
 
         Format::TypeName(qtn) => match &qtn.namespace {
             Namespace::Root => lang.hashable_types.contains(&qtn.name),

--- a/crates/facet_generate/src/generation/swift/emitter/tests_bincode.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests_bincode.rs
@@ -34,10 +34,9 @@ fn unit_struct_1() {
 
     let actual = emit!(UnitStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct UnitStruct: Hashable {
+    public struct UnitStruct: Hashable, Equatable {
         public init() {
         }
 
@@ -79,10 +78,9 @@ fn unit_struct_2() {
 
     let actual = emit!(UnitStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct UnitStruct: Hashable {
+    public struct UnitStruct: Hashable, Equatable {
         public init() {
         }
 
@@ -124,10 +122,9 @@ fn newtype_struct() {
 
     let actual = emit!(NewType as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct NewType: Hashable {
+    public struct NewType: Hashable, Equatable {
         public var value: String
 
         public init(value: String) {
@@ -174,10 +171,9 @@ fn tuple_struct() {
 
     let actual = emit!(TupleStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct TupleStruct: Hashable {
+    public struct TupleStruct: Hashable, Equatable {
         public var field0: String
         public var field1: Int32
 
@@ -372,8 +368,7 @@ fn struct_with_fields_of_user_types() {
 
     let actual = emit!(Outer as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct Inner1: Hashable {
+    public struct Inner1: Hashable, Equatable {
         public var field1: String
 
         public init(field1: String) {
@@ -409,7 +404,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Inner2: Hashable {
+    public struct Inner2: Hashable, Equatable {
         public var value: String
 
         public init(value: String) {
@@ -445,7 +440,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Inner3: Hashable {
+    public struct Inner3: Hashable, Equatable {
         public var field0: String
         public var field1: Int32
 
@@ -485,7 +480,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Outer: Hashable {
+    public struct Outer: Hashable, Equatable {
         public var one: Inner1
         public var two: Inner2
         public var three: Inner3
@@ -723,10 +718,9 @@ fn enum_with_unit_variants() {
 
     let actual = emit!(EnumWithUnitVariants as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line one
     /// line two
-    indirect public enum EnumWithUnitVariants: Hashable {
+    indirect public enum EnumWithUnitVariants: Hashable, Equatable {
         /// variant one
         case variant1
         /// variant two
@@ -793,8 +787,7 @@ fn enum_with_unit_struct_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -846,8 +839,7 @@ fn enum_with_1_tuple_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String)
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -902,8 +894,7 @@ fn enum_with_newtype_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String)
         case variant2(Int32)
 
@@ -966,8 +957,7 @@ fn enum_with_tuple_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String, Int32)
         case variant2(Bool, Double, UInt8)
 
@@ -1035,8 +1025,7 @@ fn enum_with_struct_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(field1: String, field2: Int32)
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -1095,8 +1084,7 @@ fn enum_with_mixed_variants() {
 
     let actual = emit!(MyEnum as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case unit
         case newType(String)
         case tuple(String, Int32)
@@ -1174,8 +1162,7 @@ fn struct_with_vec_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var items: [String]
         public var numbers: [Int32]
         public var nestedItems: [[String]]
@@ -1249,8 +1236,7 @@ fn struct_with_option_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var optionalString: String?
         public var optionalNumber: Int32?
         public var optionalBool: Bool?
@@ -1318,7 +1304,7 @@ fn struct_with_hashmap_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1387,7 +1373,7 @@ fn struct_with_nested_generics() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var optionalList: [String]?
         public var listOfOptionals: [Int32?]
         public var mapToList: [String: [Bool]]
@@ -1510,8 +1496,7 @@ fn struct_with_array_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var fixedArray: [Int32]
         public var byteArray: [UInt8]
         public var stringArray: [String]
@@ -1579,7 +1564,7 @@ fn struct_with_btreemap_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1647,8 +1632,7 @@ fn struct_with_hashset_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringSet: Set<String>
         public var intSet: Set<Int32>
 
@@ -1710,8 +1694,7 @@ fn struct_with_btreeset_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringSet: Set<String>
         public var intSet: Set<Int32>
 
@@ -1772,8 +1755,7 @@ fn struct_with_box_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var boxedString: String
         public var boxedInt: Int32
 
@@ -1825,8 +1807,7 @@ fn struct_with_rc_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var rcString: String
         public var rcInt: Int32
 
@@ -1878,8 +1859,7 @@ fn struct_with_arc_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var arcString: String
         public var arcInt: Int32
 
@@ -1935,7 +1915,7 @@ fn struct_with_mixed_collections_and_pointers() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var vecOfSets: [Set<String>]
         public var optionalBtree: [String: Int32]?
         public var boxedVec: [String]
@@ -2033,8 +2013,7 @@ fn struct_with_bytes_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var data: [UInt8]
         public var name: String
         public var header: [UInt8]
@@ -2094,8 +2073,7 @@ fn struct_with_bytes_field_and_slice() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var data: [UInt8]
         public var name: String
         public var header: [UInt8]
@@ -2168,8 +2146,7 @@ fn namespaced_child() {
 
     let actual = emit!(Parent as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct Parent: Hashable {
+    public struct Parent: Hashable, Equatable {
         public var child: [Test.Child]
 
         public init(child: [Test.Child]) {
@@ -2209,7 +2186,7 @@ fn namespaced_child() {
         }
     }
 
-    public struct Child: Hashable {
+    public struct Child: Hashable, Equatable {
         public var test: String
 
         public init(test: String) {

--- a/crates/facet_generate/src/generation/swift/emitter/tests_bincode.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests_bincode.rs
@@ -1318,8 +1318,7 @@ fn struct_with_hashmap_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1388,8 +1387,7 @@ fn struct_with_nested_generics() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var optionalList: [String]?
         public var listOfOptionals: [Int32?]
         public var mapToList: [String: [Bool]]
@@ -1581,8 +1579,7 @@ fn struct_with_btreemap_field() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1938,8 +1935,7 @@ fn struct_with_mixed_collections_and_pointers() {
 
     let actual = emit!(MyStruct as Swift with BincodePlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var vecOfSets: [Set<String>]
         public var optionalBtree: [String: Int32]?
         public var boxedVec: [String]

--- a/crates/facet_generate/src/generation/swift/emitter/tests_json.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests_json.rs
@@ -32,10 +32,9 @@ fn unit_struct_1() {
 
     let actual = emit!(UnitStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct UnitStruct: Hashable {
+    public struct UnitStruct: Hashable, Equatable {
         public init() {
         }
 
@@ -77,10 +76,9 @@ fn unit_struct_2() {
 
     let actual = emit!(UnitStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct UnitStruct: Hashable {
+    public struct UnitStruct: Hashable, Equatable {
         public init() {
         }
 
@@ -122,10 +120,9 @@ fn newtype_struct() {
 
     let actual = emit!(NewType as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct NewType: Hashable {
+    public struct NewType: Hashable, Equatable {
         public var value: String
 
         public init(value: String) {
@@ -172,10 +169,9 @@ fn tuple_struct() {
 
     let actual = emit!(TupleStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line 1
     /// line 2
-    public struct TupleStruct: Hashable {
+    public struct TupleStruct: Hashable, Equatable {
         public var field0: String
         public var field1: Int32
 
@@ -370,8 +366,7 @@ fn struct_with_fields_of_user_types() {
 
     let actual = emit!(Outer as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct Inner1: Hashable {
+    public struct Inner1: Hashable, Equatable {
         public var field1: String
 
         public init(field1: String) {
@@ -407,7 +402,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Inner2: Hashable {
+    public struct Inner2: Hashable, Equatable {
         public var value: String
 
         public init(value: String) {
@@ -443,7 +438,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Inner3: Hashable {
+    public struct Inner3: Hashable, Equatable {
         public var field0: String
         public var field1: Int32
 
@@ -483,7 +478,7 @@ fn struct_with_fields_of_user_types() {
         }
     }
 
-    public struct Outer: Hashable {
+    public struct Outer: Hashable, Equatable {
         public var one: Inner1
         public var two: Inner2
         public var three: Inner3
@@ -733,10 +728,9 @@ fn enum_with_unit_variants() {
 
     let actual = emit!(EnumWithUnitVariants as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
     /// line one
     /// line two
-    indirect public enum EnumWithUnitVariants: Hashable {
+    indirect public enum EnumWithUnitVariants: Hashable, Equatable {
         /// variant one
         case variant1
         /// variant two
@@ -803,8 +797,7 @@ fn enum_with_unit_struct_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -856,8 +849,7 @@ fn enum_with_1_tuple_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String)
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -912,8 +904,7 @@ fn enum_with_newtype_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String)
         case variant2(Int32)
 
@@ -976,8 +967,7 @@ fn enum_with_tuple_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(String, Int32)
         case variant2(Bool, Double, UInt8)
 
@@ -1045,8 +1035,7 @@ fn enum_with_struct_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case variant1(field1: String, field2: Int32)
 
         public func serialize<S: Serializer>(serializer: S) throws {
@@ -1105,8 +1094,7 @@ fn enum_with_mixed_variants() {
 
     let actual = emit!(MyEnum as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    indirect public enum MyEnum: Hashable {
+    indirect public enum MyEnum: Hashable, Equatable {
         case unit
         case newType(String)
         case tuple(String, Int32)
@@ -1184,8 +1172,7 @@ fn struct_with_vec_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var items: [String]
         public var numbers: [Int32]
         public var nestedItems: [[String]]
@@ -1259,8 +1246,7 @@ fn struct_with_option_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var optionalString: String?
         public var optionalNumber: Int32?
         public var optionalBool: Bool?
@@ -1328,7 +1314,7 @@ fn struct_with_hashmap_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1397,7 +1383,7 @@ fn struct_with_nested_generics() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var optionalList: [String]?
         public var listOfOptionals: [Int32?]
         public var mapToList: [String: [Bool]]
@@ -1520,8 +1506,7 @@ fn struct_with_array_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var fixedArray: [Int32]
         public var byteArray: [UInt8]
         public var stringArray: [String]
@@ -1589,7 +1574,7 @@ fn struct_with_btreemap_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1657,8 +1642,7 @@ fn struct_with_hashset_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringSet: Set<String>
         public var intSet: Set<Int32>
 
@@ -1720,8 +1704,7 @@ fn struct_with_btreeset_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var stringSet: Set<String>
         public var intSet: Set<Int32>
 
@@ -1782,8 +1765,7 @@ fn struct_with_box_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var boxedString: String
         public var boxedInt: Int32
 
@@ -1835,8 +1817,7 @@ fn struct_with_rc_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var rcString: String
         public var rcInt: Int32
 
@@ -1888,8 +1869,7 @@ fn struct_with_arc_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var arcString: String
         public var arcInt: Int32
 
@@ -1945,7 +1925,7 @@ fn struct_with_mixed_collections_and_pointers() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var vecOfSets: [Set<String>]
         public var optionalBtree: [String: Int32]?
         public var boxedVec: [String]
@@ -2043,8 +2023,7 @@ fn struct_with_bytes_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var data: [UInt8]
         public var name: String
         public var header: [UInt8]
@@ -2104,8 +2083,7 @@ fn struct_with_bytes_field_and_slice() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Hashable {
+    public struct MyStruct: Hashable, Equatable {
         public var data: [UInt8]
         public var name: String
         public var header: [UInt8]
@@ -2178,8 +2156,7 @@ fn namespaced_child() {
 
     let actual = emit!(Parent as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct Parent: Hashable {
+    public struct Parent: Hashable, Equatable {
         public var child: Test.Child
 
         public init(child: Test.Child) {
@@ -2215,7 +2192,7 @@ fn namespaced_child() {
         }
     }
 
-    public struct Child: Hashable {
+    public struct Child: Hashable, Equatable {
         public var test: String
 
         public init(test: String) {

--- a/crates/facet_generate/src/generation/swift/emitter/tests_json.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests_json.rs
@@ -1328,8 +1328,7 @@ fn struct_with_hashmap_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1398,8 +1397,7 @@ fn struct_with_nested_generics() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var optionalList: [String]?
         public var listOfOptionals: [Int32?]
         public var mapToList: [String: [Bool]]
@@ -1591,8 +1589,7 @@ fn struct_with_btreemap_field() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var stringToInt: [String: Int32]
         public var intToBool: [Int32: Bool]
 
@@ -1948,8 +1945,7 @@ fn struct_with_mixed_collections_and_pointers() {
 
     let actual = emit!(MyStruct as Swift with JsonPlugin).unwrap();
     insta::assert_snapshot!(actual, @r#"
-
-    public struct MyStruct: Equatable {
+    public struct MyStruct: Hashable {
         public var vecOfSets: [Set<String>]
         public var optionalBtree: [String: Int32]?
         public var boxedVec: [String]

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -279,114 +279,126 @@ fn fmt_is_hashable(
 /// Computes the set of type names (within this module) that can synthesize
 /// Swift `Equatable` conformance.
 ///
-/// Uses a monotone fixed-point iteration: on each pass a type is added to
-/// the known-equatable set if all of its fields / variant associated values
-/// are equatable given current knowledge. Iteration stops when a full pass
-/// produces no new additions.
+/// Uses depth-first search with optimistic cycle handling: if a type appears
+/// on the current evaluation stack it is assumed equatable. This correctly
+/// supports self-referential and mutually-recursive types because Swift
+/// permits `Equatable` synthesis (or manual `==` emission) for recursive
+/// value types as long as all non-recursive stored properties are themselves
+/// `Equatable`.
 ///
-/// Differs from [`compute_hashable_types`] in three ways:
-/// - `Unit` (Void) IS `Equatable` in Swift.
-/// - `Map { K, V }` (`[K: V]`) IS `Equatable` when `K` and `V` are.
-/// - Multi-element native tuples are counted as equatable (we emit a
-///   manual `==` operator for them).
+/// Multi-element tuples are included because the emitter generates a manual
+/// `==` operator using Swift's built-in tuple `==`.
 ///
-/// Mutually recursive or self-referential types that cannot resolve the
-/// cycle will conservatively not be added to the set.
+/// External types (not present in the registry) are assumed to be equatable.
 pub fn compute_equatable_types(registry: &Registry) -> BTreeSet<String> {
-    // Names of all types defined in this module.
-    let local_names: BTreeSet<String> = registry
+    let local_names: BTreeSet<&str> = registry
         .keys()
         .filter(|k| matches!(k.namespace, Namespace::Root))
-        .map(|k| k.name.clone())
+        .map(|k| k.name.as_str())
         .collect();
 
     let mut known: BTreeSet<String> = BTreeSet::new();
-    let mut changed = true;
+    let mut visiting: BTreeSet<String> = BTreeSet::new();
 
-    while changed {
-        changed = false;
-        for (qtn, container) in registry {
-            let name = &qtn.name;
-            if known.contains(name) {
-                continue;
-            }
-            if container_can_be_equatable(container, &known, qtn.name.as_str(), &local_names) {
-                known.insert(name.clone());
-                changed = true;
-            }
+    for qtn in registry.keys() {
+        if local_names.contains(qtn.name.as_str()) && !known.contains(&qtn.name) {
+            check_type_equatable(registry, qtn, &local_names, &mut known, &mut visiting);
         }
     }
 
     known
 }
 
-fn container_can_be_equatable(
-    format: &ContainerFormat,
-    known: &BTreeSet<String>,
-    container: &str,
-    local_names: &BTreeSet<String>,
+/// Checks whether a type (and transitively all types it references) can
+/// conform to `Equatable`.
+///
+/// On success the type name is inserted into `known` so that subsequent
+/// checks short-circuit.
+fn check_type_equatable(
+    registry: &Registry,
+    qtn: &QualifiedTypeName,
+    local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
-    match format {
+    let name = &qtn.name;
+
+    if known.contains(name) {
+        return true;
+    }
+    if visiting.contains(name) {
+        // Cycle detected — strongly-connected components are either all
+        // equatable or all non-equatable, so optimism is safe here.
+        return true;
+    }
+    if !local_names.contains(name.as_str()) {
+        return true; // external type
+    }
+
+    let Some(container) = registry.get(qtn) else {
+        return false;
+    };
+
+    visiting.insert(name.clone());
+
+    let result = match container {
         ContainerFormat::UnitStruct(_) => true,
         ContainerFormat::NewTypeStruct(fmt, _) => {
-            fmt_can_be_equatable(fmt, known, container, local_names)
+            fmt_is_equatable(registry, fmt, local_names, known, visiting)
         }
         ContainerFormat::TupleStruct(fmts, _) => fmts
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
-        ContainerFormat::Struct(nameds, _) => nameds
+            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
+        ContainerFormat::Struct(fields, _) => fields
             .iter()
-            .all(|n| fmt_can_be_equatable(&n.value, known, container, local_names)),
-        ContainerFormat::Enum(variants, _) => variants
-            .values()
-            .all(|v| variant_fmt_can_be_equatable(&v.value, known, container, local_names)),
+            .all(|f| fmt_is_equatable(registry, &f.value, local_names, known, visiting)),
+        ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
+            variant_is_equatable(registry, &v.value, local_names, known, visiting)
+        }),
+    };
+
+    visiting.remove(name);
+
+    if result {
+        known.insert(name.clone());
     }
+
+    result
 }
 
-fn variant_fmt_can_be_equatable(
+fn variant_is_equatable(
+    registry: &Registry,
     format: &VariantFormat,
-    known: &BTreeSet<String>,
-    container: &str,
-
-    local_names: &BTreeSet<String>,
+    local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => fmt_can_be_equatable(fmt, known, container, local_names),
-        // Enum associated values are separate parameters, not a Swift tuple,
-        // so each element is checked individually.
+        VariantFormat::NewType(fmt) => {
+            fmt_is_equatable(registry, fmt, local_names, known, visiting)
+        }
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
-        VariantFormat::Struct(nameds) => nameds
+            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
+        VariantFormat::Struct(fields) => fields
             .iter()
-            .all(|n| fmt_can_be_equatable(&n.value, known, container, local_names)),
+            .all(|f| fmt_is_equatable(registry, &f.value, local_names, known, visiting)),
     }
 }
 
-fn fmt_can_be_equatable(
+fn fmt_is_equatable(
+    registry: &Registry,
     format: &Format,
-    known: &BTreeSet<String>,
-    container: &str,
-    local_names: &BTreeSet<String>,
+    local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
         Format::TypeName(qtn) => {
-            if container == &qtn.name {
-                // Cycle to the currently evaluated struct: assume equatable.
-                true
-            } else if local_names.contains(&qtn.name) {
-                // Same-module type: only equatable if already proven so.
-                known.contains(&qtn.name)
-            } else {
-                // External type: assume equatable.
-                true
-            }
+            check_type_equatable(registry, qtn, local_names, known, visiting)
         }
-        // Void does not conform to Equatable in Swift — a stored property of
-        // type Void prevents Equatable auto-synthesis.
-        Format::Variable(_) | Format::Unit => false,
         Format::Bool
         | Format::I8
         | Format::I16
@@ -404,22 +416,20 @@ fn fmt_can_be_equatable(
         | Format::Str
         | Format::Bytes
         | Format::Uuid => true,
+        Format::Variable(_) | Format::Unit => false,
         Format::Option(inner)
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_can_be_equatable(inner, known, container, local_names)
+            fmt_is_equatable(registry, inner, local_names, known, visiting)
         }
-        // [K: V] IS Equatable when K and V are Equatable.
         Format::Map { key, value } => {
-            fmt_can_be_equatable(key, known, container, local_names)
-                && fmt_can_be_equatable(value, known, container, local_names)
+            fmt_is_equatable(registry, key, local_names, known, visiting)
+                && fmt_is_equatable(registry, value, local_names, known, visiting)
         }
-        // Multi-element tuples are included: we generate a manual `==` operator
-        // for structs/enums that contain them, using Swift's built-in tuple `==`.
         Format::Tuple(formats) => formats
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
+            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
     }
 }
 

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -125,115 +125,122 @@ impl<'a> SwiftCodeGenerator<'a> {
 /// Computes the set of type names (within this module) that can synthesize
 /// Swift `Hashable` conformance.
 ///
-/// Uses a monotone fixed-point iteration: on each pass a type is added to
-/// the known-hashable set if all of its fields / variant associated values
-/// are hashable given current knowledge. Iteration stops when a full pass
-/// produces no new additions.
+/// Uses depth-first search with optimistic cycle handling: if a type appears
+/// on the current evaluation stack it is assumed hashable. This correctly
+/// supports self-referential and mutually-recursive types because Swift
+/// permits `Hashable` synthesis for recursive value types as long as all
+/// non-recursive stored properties are themselves `Hashable`.
 ///
 /// External types (not present in the registry) are assumed to be hashable.
-/// Mutually recursive types that form a cycle will conservatively not be
-/// added to the set.
 pub fn compute_hashable_types(registry: &Registry) -> BTreeSet<String> {
-    // Names of all types defined in this module.
     let local_names: BTreeSet<&str> = registry
         .keys()
         .filter(|k| matches!(k.namespace, Namespace::Root))
-        .map(|k| k.name.as_ref())
+        .map(|k| k.name.as_str())
         .collect();
 
     let mut known: BTreeSet<String> = BTreeSet::new();
+    let mut visiting: BTreeSet<String> = BTreeSet::new();
+
     for qtn in registry.keys() {
-        if known.contains(&qtn.name) {
-            continue;
+        if local_names.contains(qtn.name.as_str()) && !known.contains(&qtn.name) {
+            check_type_hashable(registry, qtn, &local_names, &mut known, &mut visiting);
         }
-        container_can_be_hashable(registry, &mut known, &vec![&qtn], &local_names);
     }
 
     known
 }
 
-fn container_can_be_hashable(
+/// Checks whether a type (and transitively all types it references) can
+/// conform to `Hashable`.
+///
+/// On success the type name is inserted into `known` so that subsequent
+/// checks short-circuit.
+fn check_type_hashable(
     registry: &Registry,
-    known: &mut BTreeSet<String>,
-    parent_type_name: &Vec<&QualifiedTypeName>,
+    qtn: &QualifiedTypeName,
     local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
-    let container = &parent_type_name.last().unwrap().name;
-    // Already known to be hashable
-    if known.contains(container) {
+    let name = &qtn.name;
+
+    if known.contains(name) {
         return true;
     }
-    if let Some(format) = registry.get(parent_type_name.last().unwrap()) {
-        if match format {
-            ContainerFormat::UnitStruct(_) => true,
-            ContainerFormat::NewTypeStruct(fmt, _) => {
-                fmt_can_be_hashable(fmt, registry, known, parent_type_name, local_names)
-            }
-            ContainerFormat::TupleStruct(fmts, _) => fmts
-                .iter()
-                .all(|f| fmt_can_be_hashable(f, registry, known, parent_type_name, local_names)),
-            ContainerFormat::Struct(nameds, _) => nameds.iter().all(|n| {
-                fmt_can_be_hashable(&n.value, registry, known, parent_type_name, local_names)
-            }),
-            ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
-                variant_can_be_hashable(&v.value, registry, known, parent_type_name, local_names)
-            }),
-        } {
-            known.insert(container.clone());
-            return true;
-        }
+    if visiting.contains(name) {
+        // Cycle detected — strongly-connected components are either all
+        // hashable or all non-hashable, so optimism is safe here.
+        return true;
+    }
+    if !local_names.contains(name.as_str()) {
+        return true; // external type
     }
 
-    false
+    let Some(container) = registry.get(qtn) else {
+        return false;
+    };
+
+    visiting.insert(name.clone());
+
+    let result = match container {
+        ContainerFormat::UnitStruct(_) => true,
+        ContainerFormat::NewTypeStruct(fmt, _) => {
+            fmt_is_hashable(registry, fmt, local_names, known, visiting)
+        }
+        ContainerFormat::TupleStruct(fmts, _) => fmts
+            .iter()
+            .all(|f| fmt_is_hashable(registry, f, local_names, known, visiting)),
+        ContainerFormat::Struct(fields, _) => fields
+            .iter()
+            .all(|f| fmt_is_hashable(registry, &f.value, local_names, known, visiting)),
+        ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
+            variant_is_hashable(registry, &v.value, local_names, known, visiting)
+        }),
+    };
+
+    visiting.remove(name);
+
+    if result {
+        known.insert(name.clone());
+    }
+
+    result
 }
 
-fn variant_can_be_hashable(
-    format: &VariantFormat,
+fn variant_is_hashable(
     registry: &Registry,
-    known: &mut BTreeSet<String>,
-    container: &Vec<&QualifiedTypeName>,
+    format: &VariantFormat,
     local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
         VariantFormat::NewType(fmt) => {
-            fmt_can_be_hashable(fmt, registry, known, container, local_names)
+            fmt_is_hashable(registry, fmt, local_names, known, visiting)
         }
-        // Enum associated values are separate parameters, not a Swift tuple,
-        // so each element is checked individually.
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_can_be_hashable(f, registry, known, container, local_names)),
-        VariantFormat::Struct(nameds) => nameds
+            .all(|f| fmt_is_hashable(registry, f, local_names, known, visiting)),
+        VariantFormat::Struct(fields) => fields
             .iter()
-            .all(|n| fmt_can_be_hashable(&n.value, registry, known, container, local_names)),
+            .all(|f| fmt_is_hashable(registry, &f.value, local_names, known, visiting)),
     }
 }
 
-fn fmt_can_be_hashable(
-    format: &Format,
+fn fmt_is_hashable(
     registry: &Registry,
-    known: &mut BTreeSet<String>,
-    container: &Vec<&QualifiedTypeName>,
+    format: &Format,
     local_names: &BTreeSet<&str>,
+    known: &mut BTreeSet<String>,
+    visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
         Format::TypeName(qtn) => {
-            if container.contains(&qtn) {
-                // Cycle to the currently evaluated struct: assume hashable.
-                true
-            }else if local_names.contains(qtn.name.as_str()) {
-                // Same-module type: only hashable if already proven so.
-                let mut subs = container.clone();
-                subs.push(qtn);
-                container_can_be_hashable(registry, known, &subs, local_names)
-            } else {
-                // External type: assume hashable.
-                true
-            }
+            check_type_hashable(registry, qtn, local_names, known, visiting)
         }
-        // Void is not Hashable
         Format::Bool
         | Format::I8
         | Format::I16
@@ -251,23 +258,20 @@ fn fmt_can_be_hashable(
         | Format::Str
         | Format::Bytes
         | Format::Uuid => true,
+        Format::Variable(_) | Format::Unit => false,
         Format::Option(inner)
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_can_be_hashable(inner, registry, known, container, local_names)
+            fmt_is_hashable(registry, inner, local_names, known, visiting)
         }
-        Format::Variable(_)
-        | Format::Unit  // Void does not conform to Hashable in Swift
-        => false,
-         // [K: V] is Hashable iff K is hashable and V is hashable
         Format::Map { key, value } => {
-            fmt_can_be_hashable(key,registry,  known, container, local_names) &&
-            fmt_can_be_hashable(value, registry, known, container, local_names)
-        },
-        // A 1-element tuple is transparent; multi-element native tuples are not Hashable.
+            fmt_is_hashable(registry, key, local_names, known, visiting)
+                && fmt_is_hashable(registry, value, local_names, known, visiting)
+        }
         Format::Tuple(formats) => {
-            formats.len() == 1 && fmt_can_be_hashable(&formats[0], registry, known, container, local_names)
+            formats.len() == 1
+                && fmt_is_hashable(registry, &formats[0], local_names, known, visiting)
         }
     }
 }

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -194,9 +194,9 @@ fn check_type_hashable(
         ContainerFormat::Struct(fields, _) => fields
             .iter()
             .all(|f| fmt_is_hashable(registry, &f.value, local_names, known, visiting)),
-        ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
-            variant_is_hashable(registry, &v.value, local_names, known, visiting)
-        }),
+        ContainerFormat::Enum(variants, _) => variants
+            .values()
+            .all(|v| variant_is_hashable(registry, &v.value, local_names, known, visiting)),
     };
 
     visiting.remove(name);
@@ -218,9 +218,7 @@ fn variant_is_hashable(
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => {
-            fmt_is_hashable(registry, fmt, local_names, known, visiting)
-        }
+        VariantFormat::NewType(fmt) => fmt_is_hashable(registry, fmt, local_names, known, visiting),
         VariantFormat::Tuple(fmts) => fmts
             .iter()
             .all(|f| fmt_is_hashable(registry, f, local_names, known, visiting)),
@@ -238,9 +236,7 @@ fn fmt_is_hashable(
     visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
-        Format::TypeName(qtn) => {
-            check_type_hashable(registry, qtn, local_names, known, visiting)
-        }
+        Format::TypeName(qtn) => check_type_hashable(registry, qtn, local_names, known, visiting),
         Format::Bool
         | Format::I8
         | Format::I16
@@ -352,9 +348,9 @@ fn check_type_equatable(
         ContainerFormat::Struct(fields, _) => fields
             .iter()
             .all(|f| fmt_is_equatable(registry, &f.value, local_names, known, visiting)),
-        ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
-            variant_is_equatable(registry, &v.value, local_names, known, visiting)
-        }),
+        ContainerFormat::Enum(variants, _) => variants
+            .values()
+            .all(|v| variant_is_equatable(registry, &v.value, local_names, known, visiting)),
     };
 
     visiting.remove(name);
@@ -396,9 +392,7 @@ fn fmt_is_equatable(
     visiting: &mut BTreeSet<String>,
 ) -> bool {
     match format {
-        Format::TypeName(qtn) => {
-            check_type_equatable(registry, qtn, local_names, known, visiting)
-        }
+        Format::TypeName(qtn) => check_type_equatable(registry, qtn, local_names, known, visiting),
         Format::Bool
         | Format::I8
         | Format::I16

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -135,81 +135,99 @@ impl<'a> SwiftCodeGenerator<'a> {
 /// added to the set.
 pub fn compute_hashable_types(registry: &Registry) -> BTreeSet<String> {
     // Names of all types defined in this module.
-    let local_names: BTreeSet<String> = registry
+    let local_names: BTreeSet<&str> = registry
         .keys()
         .filter(|k| matches!(k.namespace, Namespace::Root))
-        .map(|k| k.name.clone())
+        .map(|k| k.name.as_ref())
         .collect();
 
     let mut known: BTreeSet<String> = BTreeSet::new();
-    let mut changed = true;
-
-    while changed {
-        changed = false;
-        for (qtn, container) in registry {
-            let name = &qtn.name;
-            if known.contains(name) {
-                continue;
-            }
-            if container_can_be_hashable(container, &known, &local_names) {
-                known.insert(name.clone());
-                changed = true;
-            }
+    for qtn in registry.keys() {
+        if known.contains(&qtn.name) {
+            continue;
         }
+        container_can_be_hashable(registry, &mut known, &vec![&qtn], &local_names);
     }
+
     known
 }
 
 fn container_can_be_hashable(
-    format: &ContainerFormat,
-    known: &BTreeSet<String>,
-    local_names: &BTreeSet<String>,
+    registry: &Registry,
+    known: &mut BTreeSet<String>,
+    parent_type_name: &Vec<&QualifiedTypeName>,
+    local_names: &BTreeSet<&str>,
 ) -> bool {
-    match format {
-        ContainerFormat::UnitStruct(_) => true,
-        ContainerFormat::NewTypeStruct(fmt, _) => fmt_can_be_hashable(fmt, known, local_names),
-        ContainerFormat::TupleStruct(fmts, _) => fmts
-            .iter()
-            .all(|f| fmt_can_be_hashable(f, known, local_names)),
-        ContainerFormat::Struct(nameds, _) => nameds
-            .iter()
-            .all(|n| fmt_can_be_hashable(&n.value, known, local_names)),
-        ContainerFormat::Enum(variants, _) => variants
-            .values()
-            .all(|v| variant_can_be_hashable(&v.value, known, local_names)),
+    let container = &parent_type_name.last().unwrap().name;
+    // Already known to be hashable
+    if known.contains(container) {
+        return true;
     }
+    if let Some(format) = registry.get(parent_type_name.last().unwrap()) {
+        if match format {
+            ContainerFormat::UnitStruct(_) => true,
+            ContainerFormat::NewTypeStruct(fmt, _) => {
+                fmt_can_be_hashable(fmt, registry, known, parent_type_name, local_names)
+            }
+            ContainerFormat::TupleStruct(fmts, _) => fmts
+                .iter()
+                .all(|f| fmt_can_be_hashable(f, registry, known, parent_type_name, local_names)),
+            ContainerFormat::Struct(nameds, _) => nameds.iter().all(|n| {
+                fmt_can_be_hashable(&n.value, registry, known, parent_type_name, local_names)
+            }),
+            ContainerFormat::Enum(variants, _) => variants.values().all(|v| {
+                variant_can_be_hashable(&v.value, registry, known, parent_type_name, local_names)
+            }),
+        } {
+            known.insert(container.clone());
+            return true;
+        }
+    }
+
+    false
 }
 
 fn variant_can_be_hashable(
     format: &VariantFormat,
-    known: &BTreeSet<String>,
-    local_names: &BTreeSet<String>,
+    registry: &Registry,
+    known: &mut BTreeSet<String>,
+    container: &Vec<&QualifiedTypeName>,
+    local_names: &BTreeSet<&str>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => fmt_can_be_hashable(fmt, known, local_names),
+        VariantFormat::NewType(fmt) => {
+            fmt_can_be_hashable(fmt, registry, known, container, local_names)
+        }
         // Enum associated values are separate parameters, not a Swift tuple,
         // so each element is checked individually.
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_can_be_hashable(f, known, local_names)),
+            .all(|f| fmt_can_be_hashable(f, registry, known, container, local_names)),
         VariantFormat::Struct(nameds) => nameds
             .iter()
-            .all(|n| fmt_can_be_hashable(&n.value, known, local_names)),
+            .all(|n| fmt_can_be_hashable(&n.value, registry, known, container, local_names)),
     }
 }
 
 fn fmt_can_be_hashable(
     format: &Format,
-    known: &BTreeSet<String>,
-    local_names: &BTreeSet<String>,
+    registry: &Registry,
+    known: &mut BTreeSet<String>,
+    container: &Vec<&QualifiedTypeName>,
+    local_names: &BTreeSet<&str>,
 ) -> bool {
     match format {
         Format::TypeName(qtn) => {
-            if local_names.contains(&qtn.name) {
+            if container.contains(&qtn) {
+                // Cycle to the currently evaluated struct: assume hashable.
+                true
+            }else if local_names.contains(qtn.name.as_str()) {
                 // Same-module type: only hashable if already proven so.
-                known.contains(&qtn.name)
+                let mut subs = container.clone();
+                subs.push(qtn);
+                container_can_be_hashable(registry, known, &subs, local_names)
             } else {
                 // External type: assume hashable.
                 true
@@ -237,19 +255,19 @@ fn fmt_can_be_hashable(
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_can_be_hashable(inner, known, local_names)
+            fmt_can_be_hashable(inner, registry, known, container, local_names)
         }
         Format::Variable(_)
         | Format::Unit  // Void does not conform to Hashable in Swift
         => false,
          // [K: V] is Hashable iff K is hashable and V is hashable
         Format::Map { key, value } => {
-            fmt_can_be_hashable(key, known, local_names) &&
-            fmt_can_be_hashable(value, known, local_names)
+            fmt_can_be_hashable(key,registry,  known, container, local_names) &&
+            fmt_can_be_hashable(value, registry, known, container, local_names)
         },
         // A 1-element tuple is transparent; multi-element native tuples are not Hashable.
         Format::Tuple(formats) => {
-            formats.len() == 1 && fmt_can_be_hashable(&formats[0], known, local_names)
+            formats.len() == 1 && fmt_can_be_hashable(&formats[0], registry, known, container, local_names)
         }
     }
 }
@@ -288,7 +306,7 @@ pub fn compute_equatable_types(registry: &Registry) -> BTreeSet<String> {
             if known.contains(name) {
                 continue;
             }
-            if container_can_be_equatable(container, &known, &local_names) {
+            if container_can_be_equatable(container, &known, qtn.name.as_str(), &local_names) {
                 known.insert(name.clone());
                 changed = true;
             }
@@ -301,51 +319,60 @@ pub fn compute_equatable_types(registry: &Registry) -> BTreeSet<String> {
 fn container_can_be_equatable(
     format: &ContainerFormat,
     known: &BTreeSet<String>,
+    container: &str,
     local_names: &BTreeSet<String>,
 ) -> bool {
     match format {
         ContainerFormat::UnitStruct(_) => true,
-        ContainerFormat::NewTypeStruct(fmt, _) => fmt_can_be_equatable(fmt, known, local_names),
+        ContainerFormat::NewTypeStruct(fmt, _) => {
+            fmt_can_be_equatable(fmt, known, container, local_names)
+        }
         ContainerFormat::TupleStruct(fmts, _) => fmts
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, local_names)),
+            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
         ContainerFormat::Struct(nameds, _) => nameds
             .iter()
-            .all(|n| fmt_can_be_equatable(&n.value, known, local_names)),
+            .all(|n| fmt_can_be_equatable(&n.value, known, container, local_names)),
         ContainerFormat::Enum(variants, _) => variants
             .values()
-            .all(|v| variant_fmt_can_be_equatable(&v.value, known, local_names)),
+            .all(|v| variant_fmt_can_be_equatable(&v.value, known, container, local_names)),
     }
 }
 
 fn variant_fmt_can_be_equatable(
     format: &VariantFormat,
     known: &BTreeSet<String>,
+    container: &str,
+
     local_names: &BTreeSet<String>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => fmt_can_be_equatable(fmt, known, local_names),
+        VariantFormat::NewType(fmt) => fmt_can_be_equatable(fmt, known, container, local_names),
         // Enum associated values are separate parameters, not a Swift tuple,
         // so each element is checked individually.
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, local_names)),
+            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
         VariantFormat::Struct(nameds) => nameds
             .iter()
-            .all(|n| fmt_can_be_equatable(&n.value, known, local_names)),
+            .all(|n| fmt_can_be_equatable(&n.value, known, container, local_names)),
     }
 }
 
 fn fmt_can_be_equatable(
     format: &Format,
     known: &BTreeSet<String>,
+    container: &str,
     local_names: &BTreeSet<String>,
 ) -> bool {
     match format {
         Format::TypeName(qtn) => {
-            if local_names.contains(&qtn.name) {
+            if container == &qtn.name {
+                // Cycle to the currently evaluated struct: assume equatable.
+                true
+            } else if local_names.contains(&qtn.name) {
                 // Same-module type: only equatable if already proven so.
                 known.contains(&qtn.name)
             } else {
@@ -377,18 +404,18 @@ fn fmt_can_be_equatable(
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_can_be_equatable(inner, known, local_names)
+            fmt_can_be_equatable(inner, known, container, local_names)
         }
         // [K: V] IS Equatable when K and V are Equatable.
         Format::Map { key, value } => {
-            fmt_can_be_equatable(key, known, local_names)
-                && fmt_can_be_equatable(value, known, local_names)
+            fmt_can_be_equatable(key, known, container, local_names)
+                && fmt_can_be_equatable(value, known, container, local_names)
         }
         // Multi-element tuples are included: we generate a manual `==` operator
         // for structs/enums that contain them, using Swift's built-in tuple `==`.
         Format::Tuple(formats) => formats
             .iter()
-            .all(|f| fmt_can_be_equatable(f, known, local_names)),
+            .all(|f| fmt_can_be_equatable(f, known, container, local_names)),
     }
 }
 

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -157,7 +157,6 @@ pub fn compute_hashable_types(registry: &Registry) -> BTreeSet<String> {
             }
         }
     }
-
     known
 }
 
@@ -242,7 +241,12 @@ fn fmt_can_be_hashable(
         }
         Format::Variable(_)
         | Format::Unit  // Void does not conform to Hashable in Swift
-        | Format::Map { .. } => false, // [K: V] is never Hashable
+        => false,
+         // [K: V] is Hashable iff K is hashable and V is hashable
+        Format::Map { key, value } => {
+            fmt_can_be_hashable(key, known, local_names) && 
+            fmt_can_be_hashable(value, known, local_names)
+        },
         // A 1-element tuple is transparent; multi-element native tuples are not Hashable.
         Format::Tuple(formats) => {
             formats.len() == 1 && fmt_can_be_hashable(&formats[0], known, local_names)

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -244,7 +244,7 @@ fn fmt_can_be_hashable(
         => false,
          // [K: V] is Hashable iff K is hashable and V is hashable
         Format::Map { key, value } => {
-            fmt_can_be_hashable(key, known, local_names) && 
+            fmt_can_be_hashable(key, known, local_names) &&
             fmt_can_be_hashable(value, known, local_names)
         },
         // A 1-element tuple is transparent; multi-element native tuples are not Hashable.

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -476,3 +476,58 @@ fn test_struct_declaration_inv_order() {
         "MyStruct2 is not hashable and equatable:\n{output}"
     );
 }
+
+#[test]
+fn test_mutual_recursion_equatable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let struct_a_fields = vec![
+        Named {
+            name: "value".to_string(),
+            doc: Doc::new(),
+            value: Format::U32,
+        },
+        Named {
+            name: "other".to_string(),
+            doc: Doc::new(),
+            value: Format::TypeName(QualifiedTypeName {
+                namespace: Namespace::Root,
+                name: "StructB".to_string(),
+            }),
+        },
+    ];
+
+    let struct_b_fields = vec![
+        Named {
+            name: "value".to_string(),
+            doc: Doc::new(),
+            value: Format::U32,
+        },
+        Named {
+            name: "other".to_string(),
+            doc: Doc::new(),
+            value: Format::TypeName(QualifiedTypeName {
+                namespace: Namespace::Root,
+                name: "StructA".to_string(),
+            }),
+        },
+    ];
+
+    let struct_a = ContainerFormat::Struct(struct_a_fields, Doc::new());
+    let struct_b = ContainerFormat::Struct(struct_b_fields, Doc::new());
+
+    let mut registry = Registry::new();
+    registry.insert(QualifiedTypeName::root("StructA".to_string()), struct_a);
+    registry.insert(QualifiedTypeName::root("StructB".to_string()), struct_b);
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct StructA: Hashable, Equatable {"),
+        "StructA should be hashable and equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct StructB: Hashable, Equatable {"),
+        "StructB should be hashable and equatable:\n{output}"
+    );
+}

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -340,3 +340,139 @@ fn test_with_enum_and_struct_variant_implements_hashable_and_equatable() {
         "MyEnum is not hashable:\n{output}"
     );
 }
+
+#[test]
+fn test_type_cycle_is_hashable_and_equatable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+
+    let fields = vec![Named {
+        name: "str_item".to_string(),
+        doc: Doc::new(),
+        value: Format::Str,
+    }];
+
+    registry.insert(
+        QualifiedTypeName::root("MyStruct".to_string()),
+        ContainerFormat::Struct(fields, Doc::new()),
+    );
+
+    let mut variants = BTreeMap::new();
+
+    let struct_variant = Named {
+        name: "StructVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::TypeName(QualifiedTypeName {
+            namespace: Namespace::Root,
+            name: "MyStruct".to_string(),
+        }))),
+    };
+
+    let self_enum_variant = Named {
+        name: "EnumVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::TypeName(QualifiedTypeName {
+            namespace: Namespace::Root,
+            name: "MyEnum".to_string(),
+        }))),
+    };
+    variants.insert(0, struct_variant);
+    variants.insert(1, self_enum_variant);
+
+    registry.insert(
+        QualifiedTypeName::root("MyEnum".to_string()),
+        ContainerFormat::Enum(variants, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("indirect public enum MyEnum: Hashable, Equatable {"),
+        "MyEnum is not hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_struct_declaration_easy_order() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+    let fields = vec![
+        Named {
+            name: "items".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::Str),
+                value: Box::new(Format::Str),
+            },
+        },
+        // MyStruct2, it will be added to the registry before MyStruct1
+        Named {
+            name: "struct_2".to_string(),
+            doc: Doc::new(),
+            value: Format::TypeName(QualifiedTypeName {
+                namespace: Namespace::Root,
+                name: "MyStruct2".to_string(),
+            }),
+        },
+    ];
+    let struct1 = ContainerFormat::Struct(fields.clone(), Doc::new());
+    let struct2 = ContainerFormat::Struct(fields, Doc::new());
+
+    let mut registry = Registry::new();
+
+    registry.insert(QualifiedTypeName::root("MyStruct2".to_string()), struct2);
+    registry.insert(QualifiedTypeName::root("MyStruct1".to_string()), struct1);
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct MyStruct1: Hashable, Equatable {"),
+        "MyStruct1 is not hashable and equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct MyStruct2: Hashable, Equatable {"),
+        "MyStruct2 is not hashable and equatable:\n{output}"
+    );
+}
+
+#[test]
+fn test_struct_declaration_inv_order() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+    let fields = vec![
+        Named {
+            name: "items".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::Str),
+                value: Box::new(Format::Str),
+            },
+        },
+        // MyStruct2, will be added to the registry after MyStruct1
+        Named {
+            name: "struct_2".to_string(),
+            doc: Doc::new(),
+            value: Format::TypeName(QualifiedTypeName {
+                namespace: Namespace::Root,
+                name: "MyStruct2".to_string(),
+            }),
+        },
+    ];
+    let struct1 = ContainerFormat::Struct(fields.clone(), Doc::new());
+    let struct2 = ContainerFormat::Struct(fields, Doc::new());
+
+    let mut registry = Registry::new();
+
+    registry.insert(QualifiedTypeName::root("MyStruct1".to_string()), struct1);
+    registry.insert(QualifiedTypeName::root("MyStruct2".to_string()), struct2);
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct MyStruct1: Hashable, Equatable {"),
+        "MyStruct1 is not hashable and equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct MyStruct2: Hashable, Equatable {"),
+        "MyStruct2 is not hashable and equatable:\n{output}"
+    );
+}

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -162,3 +162,181 @@ fn test_no_trait_helpers_without_encoding() {
         "No encoding means no trait helpers: {output}"
     );
 }
+
+#[test]
+fn test_map_with_hashable_k_v_implement_hashable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+    let fields = vec![Named {
+        name: "items".to_string(),
+        doc: Doc::new(),
+        value: Format::Map {
+            key: Box::new(Format::Str),
+            value: Box::new(Format::Str),
+        },
+    }];
+    registry.insert(
+        QualifiedTypeName::root("MyStruct".to_string()),
+        ContainerFormat::Struct(fields, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct MyStruct: Hashable {"),
+        "Struct is not hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_struct_with_hashable_scalar_implements_hashable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+    let fields = vec![Named {
+        name: "items".to_string(),
+        doc: Doc::new(),
+        value: Format::U8,
+    }];
+    registry.insert(
+        QualifiedTypeName::root("MyStruct".to_string()),
+        ContainerFormat::Struct(fields, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct MyStruct: Hashable {"),
+        "Struct is not hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_struct_with_hashable_map_implements_hashable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+    let fields = vec![Named {
+        name: "items".to_string(),
+        doc: Doc::new(),
+        value: Format::Map {
+            key: Box::new(Format::Str),
+            value: Box::new(Format::Str),
+        },
+    }];
+    registry.insert(
+        QualifiedTypeName::root("MyStruct".to_string()),
+        ContainerFormat::Struct(fields, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct MyStruct: Hashable {"),
+        "Struct is not hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_enum_with_hashable_variants_implements_hashable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+    let mut variants = BTreeMap::new();
+
+    let str_variant = Named {
+        name: "StrVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::Str)),
+    };
+
+    variants.insert(0, str_variant);
+
+    let map_variant = Named {
+        name: "MapVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::Map {
+            key: Box::new(Format::Str),
+            value: Box::new(Format::Str),
+        })),
+    };
+    variants.insert(1, map_variant);
+
+    registry.insert(
+        QualifiedTypeName::root("MyEnum".to_string()),
+        ContainerFormat::Enum(variants, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("indirect public enum MyEnum: Hashable {"),
+        "MyEnum is not hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_with_enum_and_struct_variant_implements_hashable() {
+    let config = CodeGeneratorConfig::new("MyPackage".to_string());
+
+    let mut registry = Registry::new();
+
+    let fields = vec![
+        Named {
+            name: "str_item".to_string(),
+            doc: Doc::new(),
+            value: Format::Str,
+        },
+        Named {
+            name: "str_map".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::Str),
+                value: Box::new(Format::Str),
+            },
+        },
+        Named {
+            name: "str_option".to_string(),
+            doc: Doc::new(),
+            value: Format::Option(Box::new(Format::Str)),
+        },
+    ];
+
+    registry.insert(
+        QualifiedTypeName::root("MyStruct".to_string()),
+        ContainerFormat::Struct(fields, Doc::new()),
+    );
+
+    let mut variants = BTreeMap::new();
+
+    let str_variant = Named {
+        name: "StrVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::Str)),
+    };
+
+    variants.insert(0, str_variant);
+
+    let struct_variant = Named {
+        name: "StructVariant".to_string(),
+        doc: Doc::new(),
+        value: VariantFormat::NewType(Box::new(Format::TypeName(QualifiedTypeName {
+            namespace: Namespace::Root,
+            name: "MyStruct".to_string(),
+        }))),
+    };
+    variants.insert(1, struct_variant);
+
+    registry.insert(
+        QualifiedTypeName::root("MyEnum".to_string()),
+        ContainerFormat::Enum(variants, Doc::new()),
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("indirect public enum MyEnum: Hashable {"),
+        "MyEnum is not hashable:\n{output}"
+    );
+}

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -164,7 +164,7 @@ fn test_no_trait_helpers_without_encoding() {
 }
 
 #[test]
-fn test_map_with_hashable_k_v_implement_hashable() {
+fn test_map_with_hashable_k_v_implement_hashable_and_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 
     let mut registry = Registry::new();
@@ -184,13 +184,13 @@ fn test_map_with_hashable_k_v_implement_hashable() {
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
 
     assert!(
-        output.contains("public struct MyStruct: Hashable {"),
-        "Struct is not hashable:\n{output}"
+        output.contains("public struct MyStruct: Hashable, Equatable {"),
+        "Struct is not hashable and equatable:\n{output}"
     );
 }
 
 #[test]
-fn test_struct_with_hashable_scalar_implements_hashable() {
+fn test_struct_with_hashable_scalar_implements_hashable_and_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 
     let mut registry = Registry::new();
@@ -207,13 +207,13 @@ fn test_struct_with_hashable_scalar_implements_hashable() {
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
 
     assert!(
-        output.contains("public struct MyStruct: Hashable {"),
-        "Struct is not hashable:\n{output}"
+        output.contains("public struct MyStruct: Hashable, Equatable {"),
+        "Struct is not hashable and equatable:\n{output}"
     );
 }
 
 #[test]
-fn test_struct_with_hashable_map_implements_hashable() {
+fn test_struct_with_hashable_map_implements_hashable_and_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 
     let mut registry = Registry::new();
@@ -233,13 +233,13 @@ fn test_struct_with_hashable_map_implements_hashable() {
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
 
     assert!(
-        output.contains("public struct MyStruct: Hashable {"),
-        "Struct is not hashable:\n{output}"
+        output.contains("public struct MyStruct: Hashable, Equatable {"),
+        "Struct is not hashable and equatable:\n{output}"
     );
 }
 
 #[test]
-fn test_enum_with_hashable_variants_implements_hashable() {
+fn test_enum_with_hashable_variants_implements_hashable_and_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 
     let mut registry = Registry::new();
@@ -271,13 +271,13 @@ fn test_enum_with_hashable_variants_implements_hashable() {
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
 
     assert!(
-        output.contains("indirect public enum MyEnum: Hashable {"),
+        output.contains("indirect public enum MyEnum: Hashable, Equatable {"),
         "MyEnum is not hashable:\n{output}"
     );
 }
 
 #[test]
-fn test_with_enum_and_struct_variant_implements_hashable() {
+fn test_with_enum_and_struct_variant_implements_hashable_and_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 
     let mut registry = Registry::new();
@@ -336,7 +336,7 @@ fn test_with_enum_and_struct_variant_implements_hashable() {
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
 
     assert!(
-        output.contains("indirect public enum MyEnum: Hashable {"),
+        output.contains("indirect public enum MyEnum: Hashable, Equatable {"),
         "MyEnum is not hashable:\n{output}"
     );
 }

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -478,6 +478,7 @@ fn test_struct_declaration_inv_order() {
 }
 
 #[test]
+#[allow(clippy::similar_names)]
 fn test_mutual_recursion_equatable() {
     let config = CodeGeneratorConfig::new("MyPackage".to_string());
 

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Example/Example.swift
@@ -95,7 +95,7 @@ func deserializeSet<T: Hashable, D: Deserializer>(
     return obj
 }
 
-public struct Child: Hashable {
+public struct Child: Hashable, Equatable {
     public var name: String
 
     public init(name: String) {
@@ -131,7 +131,7 @@ public struct Child: Hashable {
     }
 }
 
-public struct MyStruct: Hashable {
+public struct MyStruct: Hashable, Equatable {
     public var stringToInt: [String: Int32]
     public var mapToList: [String: [Int32]]
     public var optionOfVecOfSet: [Set<String>]?
@@ -209,7 +209,7 @@ public struct MyStruct: Hashable {
     }
 }
 
-indirect public enum Parent: Hashable {
+indirect public enum Parent: Hashable, Equatable {
     case child(Child)
 
     public func serialize<S: Serializer>(serializer: S) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/swift/Sources/Example/Example.swift
@@ -131,7 +131,7 @@ public struct Child: Hashable {
     }
 }
 
-public struct MyStruct: Equatable {
+public struct MyStruct: Hashable {
     public var stringToInt: [String: Int32]
     public var mapToList: [String: [Int32]]
     public var optionOfVecOfSet: [Set<String>]?

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/swift/Sources/Example/Example.swift
@@ -1,7 +1,7 @@
 import Other
 import Serde
 
-public struct Child: Hashable {
+public struct Child: Hashable, Equatable {
     public var external: Other.OtherParent
 
     public init(external: Other.OtherParent) {
@@ -37,7 +37,7 @@ public struct Child: Hashable {
     }
 }
 
-indirect public enum Parent: Hashable {
+indirect public enum Parent: Hashable, Equatable {
     case child(Child)
 
     public func serialize<S: Serializer>(serializer: S) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Example/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/swift/Example/Sources/Example/Example.swift
@@ -1,6 +1,6 @@
 import Serde
 
-public struct Child: Hashable {
+public struct Child: Hashable, Equatable {
     public var name: String
 
     public init(name: String) {
@@ -36,7 +36,7 @@ public struct Child: Hashable {
     }
 }
 
-indirect public enum Parent: Hashable {
+indirect public enum Parent: Hashable, Equatable {
     case child(Child)
 
     public func serialize<S: Serializer>(serializer: S) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/swift/Sources/Example/Example.swift
@@ -1,6 +1,6 @@
 import Serde
 
-public struct Child: Hashable {
+public struct Child: Hashable, Equatable {
     public var name: String
 
     public init(name: String) {
@@ -36,7 +36,7 @@ public struct Child: Hashable {
     }
 }
 
-indirect public enum Parent: Hashable {
+indirect public enum Parent: Hashable, Equatable {
     case child(Child)
 
     public func serialize<S: Serializer>(serializer: S) throws {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/swift/Sources/Example/Example.swift
@@ -1,6 +1,6 @@
 import Serde
 
-public struct Child: Hashable {
+public struct Child: Hashable, Equatable {
     public var name: String
 
     public init(name: String) {
@@ -36,7 +36,7 @@ public struct Child: Hashable {
     }
 }
 
-indirect public enum Parent: Hashable {
+indirect public enum Parent: Hashable, Equatable {
     case child(Child)
 
     public func serialize<S: Serializer>(serializer: S) throws {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/swift/Sources/Example/Example.swift
@@ -53,7 +53,7 @@ func deserializeUuid<D: Deserializer>(
     ))
 }
 
-public struct StructWithUuid: Hashable {
+public struct StructWithUuid: Hashable, Equatable {
     public var id: UUID
     public var parentId: UUID?
     public var name: String

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Example/Example.swift
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/swift/Sources/Example/Example.swift
@@ -43,7 +43,7 @@ func deserializeUuid<D: Deserializer>(
     return uuid
 }
 
-public struct StructWithUuid: Hashable {
+public struct StructWithUuid: Hashable, Equatable {
     public var id: UUID
     public var parentId: UUID?
     public var name: String


### PR DESCRIPTION
This changeset does a couple of things:

- Generate a Hashable implementation for maps in swift:
   According to https://developer.apple.com/documentation/swift/hashable, a map is hashable if its keys and values are.
- Allow codegen to both implement Hashable and Equatable when possible.
- Check TypeName fields for hashable and equatable (regardless of the declaration order)

I tried to update / write test to the best of my knowledge but I'm not too proficient in swift, so any advice or review would be very appreciated!