### PR TITLE
keep readme output snippets correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `facet_generate` · [![GitHub license](https://img.shields.io/github/license/redbadger/facet-generate?color=blue)](https://github.com/redbadger/facet-generate/blob/master/LICENSE) [![Crate version](https://img.shields.io/crates/v/facet_generate.svg)](https://crates.io/crates/facet_generate) [![Docs](https://img.shields.io/badge/docs.rs-facet_generate-green)](https://docs.rs/facet_generate/) [![Build status](https://img.shields.io/github/actions/workflow/status/redbadger/facet-generate/build.yaml)](https://github.com/redbadger/facet-generate/actions)
 
-Reflect types annotated with [`#[derive(Facet)]`](https://crates.io/crates/facet) into Swift, Kotlin, and TypeScript. Optionally generates serialization and deserialization code for [Bincode](https://github.com/bincode-org/bincode) and JSON encodings.
+Reflect types annotated with [`#[derive(Facet)]`](https://crates.io/crates/facet) into Swift, Kotlin, TypeScript, and C#. Optionally generates serialization and deserialization code for [Bincode](https://github.com/bincode-org/bincode) and JSON encodings.
 
 ## Usage
 
@@ -73,16 +73,29 @@ kotlin::Installer::new("com.example", &out_dir)
 typescript::Installer::new("example", &out_dir)
     .plugin(BincodePlugin)
     .generate(&registry)?;
+
+// C#
+csharp::Installer::new("Example", &out_dir)
+    .plugin(BincodePlugin)
+    .generate(&registry)?;
 ```
 
-With `BincodePlugin`, the generated types include `serialize` and `deserialize` methods. For the types above, this generates the following code (showing `HttpHeader` as a representative example — all types are generated similarly):
+With `BincodePlugin`, the generated types include `serialize` and `deserialize` methods. For the types above, this generates the following code (showing `HttpHeader` as a representative example — all types are generated similarly).
+
+> [!NOTE]
+> The code blocks below are generated from the real output of the code
+> generators and kept in sync by the `readme` integration test
+> (`crates/facet_generate/tests/readme.rs`). Do not edit them by hand — run
+> `UPDATE_EXPECT=1 cargo test -p facet_generate --test readme` to refresh them.
 
 ### Swift
 
+<!-- generated:swift:start -->
+
 ```swift
-public struct HttpHeader: Hashable {
-    @Indirect public var name: String
-    @Indirect public var value: String
+public struct HttpHeader: Hashable, Equatable {
+    public var name: String
+    public var value: String
 
     public init(name: String, value: String) {
         self.name = name
@@ -121,7 +134,11 @@ public struct HttpHeader: Hashable {
 }
 ```
 
+<!-- generated:swift:end -->
+
 ### Kotlin
+
+<!-- generated:kotlin:start -->
 
 ```kotlin
 data class HttpHeader(
@@ -166,25 +183,88 @@ data class HttpHeader(
 }
 ```
 
+<!-- generated:kotlin:end -->
+
 ### TypeScript
+
+<!-- generated:typescript:start -->
 
 ```typescript
 export class HttpHeader {
-  constructor (public name: str, public value: str) {
-  }
+    constructor (public name: str, public value: str) {
+    }
 
-  public serialize(serializer: Serializer): void {
-    serializer.serializeStr(this.name);
-    serializer.serializeStr(this.value);
-  }
+    public serialize(serializer: Serializer): void {
+        serializer.serializeStr(this.name);
+        serializer.serializeStr(this.value);
+    }
 
-  static deserialize(deserializer: Deserializer): HttpHeader {
-    const name = deserializer.deserializeStr();
-    const value = deserializer.deserializeStr();
-    return new HttpHeader(name,value);
-  }
+    static deserialize(deserializer: Deserializer): HttpHeader {
+        const name = deserializer.deserializeStr();
+        const value = deserializer.deserializeStr();
+        return new HttpHeader(name,value);
+    }
 }
 ```
+
+<!-- generated:typescript:end -->
+
+### C#
+
+<!-- generated:csharp:start -->
+
+```csharp
+public partial class HttpHeader : ObservableObject, IFacetSerializable, IFacetDeserializable<HttpHeader> {
+    [ObservableProperty]
+    private string _name;
+    [ObservableProperty]
+    private string _value;
+
+    public void Serialize(ISerializer serializer)
+    {
+        serializer.IncreaseContainerDepth();
+        serializer.SerializeStr(Name);
+        serializer.SerializeStr(Value);
+        serializer.DecreaseContainerDepth();
+    }
+
+    public static HttpHeader Deserialize(IDeserializer deserializer)
+    {
+        deserializer.IncreaseContainerDepth();
+        var name = deserializer.DeserializeStr();
+        var value = deserializer.DeserializeStr();
+        deserializer.DecreaseContainerDepth();
+        return new HttpHeader {
+            Name = name,
+            Value = value,
+        };
+    }
+
+    public byte[] BincodeSerialize()
+    {
+        var serializer = new BincodeSerializer();
+        Serialize(serializer);
+        return serializer.GetBytes();
+    }
+
+    public static HttpHeader BincodeDeserialize(byte[] input)
+    {
+        if (input is null)
+        {
+            throw new DeserializationError("Cannot deserialize null array");
+        }
+        var deserializer = new BincodeDeserializer(input);
+        var value = Deserialize(deserializer);
+        if (deserializer.GetBufferOffset() < input.Length)
+        {
+            throw new DeserializationError("Some input bytes were not read");
+        }
+        return value;
+    }
+}
+```
+
+<!-- generated:csharp:end -->
 
 ## Facet attributes
 
@@ -195,6 +275,7 @@ Types that are explicitly annotated as belonging to a specific namespace are emi
 * In Swift, namespaces become a separate target in the current package
 * In Kotlin, they are emitted as a child namespace of the package's namespace
 * In TypeScript they are emitted alongside as a separate `.ts` file
+* In C#, each namespace becomes a file-scoped `namespace` written to a directory matching the dotted module path (e.g. `Company.Models.Shared`)
 
 Notes:
 
@@ -363,11 +444,11 @@ struct MyStruct {
 }
 ```
 
-With `#[facet(transparent)]`, `Inner` is unwrapped and `MyStruct.inner` is generated as a plain `i32` / `Int32` / `number` in the target language.
+With `#[facet(transparent)]`, `Inner` is unwrapped and `MyStruct.inner` is generated as a plain `Int32` (Swift) / `Int` (Kotlin) / `number` (TypeScript) / `int` (C#) in the target language.
 
 ### Bytes
 
-In order to generate byte array types (e.g. `[UInt8]` in Swift, `Bytes` in Kotlin, `Uint8Array` in TypeScript) for `Vec<u8>` and `&'a [u8]`, use the `#[facet(fg::bytes)]` attribute:
+In order to generate byte array types (e.g. `[UInt8]` in Swift, `Bytes` in Kotlin, `Uint8Array` in TypeScript, `byte[]` in C#) for `Vec<u8>` and `&'a [u8]`, use the `#[facet(fg::bytes)]` attribute:
 
 ```rust
 #[derive(Facet)]

--- a/crates/facet_generate/Cargo.toml
+++ b/crates/facet_generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "facet_generate"
-description = "Generate Swift, Kotlin and TypeScript from types annotated with `#[derive(Facet)]`"
+description = "Generate Swift, Kotlin, TypeScript, and C# from types annotated with `#[derive(Facet)]`"
 version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/facet_generate/tests/readme.rs
+++ b/crates/facet_generate/tests/readme.rs
@@ -1,0 +1,285 @@
+//! Keeps the generated-code examples in the top-level `README.md` in sync with
+//! what the generators actually produce.
+//!
+//! For each target language we reflect the `HttpHeader` type used in the README,
+//! generate the bincode-enabled output, extract just the `HttpHeader`
+//! declaration, and compare it against the fenced code block embedded in the
+//! README between marker comments such as:
+//!
+//! ```text
+//! <!-- generated:swift:start -->
+//! ```swift
+//! ...generated code...
+//! ```
+//! <!-- generated:swift:end -->
+//! ```
+//!
+//! Run `UPDATE_EXPECT=1 cargo test -p facet_generate --test readme` (or
+//! `just test`, which enables snapshot updates) to rewrite the README blocks
+//! from the real generator output.
+
+#![cfg(all(
+    feature = "swift",
+    feature = "kotlin",
+    feature = "typescript",
+    feature = "csharp"
+))]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use facet::Facet;
+use facet_generate::{
+    Registry,
+    generation::{bincode::BincodePlugin, csharp, kotlin, swift, typescript},
+    reflect,
+};
+
+#[derive(Facet)]
+struct HttpHeader {
+    name: String,
+    value: String,
+}
+
+/// The README block we keep in sync, identified by the marker name and the
+/// language used for the fenced code block.
+struct Block {
+    /// Marker name, e.g. `swift` in `<!-- generated:swift:start -->`.
+    marker: &'static str,
+    /// Language tag for the ```` ```lang ```` fence.
+    fence: &'static str,
+    /// The generated source for the `HttpHeader` declaration.
+    code: String,
+}
+
+#[test]
+fn readme_examples_are_up_to_date() {
+    let registry = reflect!(HttpHeader).unwrap();
+
+    let blocks = vec![
+        Block {
+            marker: "swift",
+            fence: "swift",
+            code: generate_swift(&registry),
+        },
+        Block {
+            marker: "kotlin",
+            fence: "kotlin",
+            code: generate_kotlin(&registry),
+        },
+        Block {
+            marker: "typescript",
+            fence: "typescript",
+            code: generate_typescript(&registry),
+        },
+        Block {
+            marker: "csharp",
+            fence: "csharp",
+            code: generate_csharp(&registry),
+        },
+    ];
+
+    let readme_path = readme_path();
+    let original = fs::read_to_string(&readme_path).expect("failed to read README.md");
+
+    let mut updated = original.clone();
+    for block in &blocks {
+        updated = replace_block(&updated, block);
+    }
+
+    if updated == original {
+        return;
+    }
+
+    if update_enabled() {
+        fs::write(&readme_path, updated).expect("failed to write README.md");
+    } else {
+        panic!(
+            "README.md generated-code blocks are out of date.\n\
+             Run `UPDATE_EXPECT=1 cargo test -p facet_generate --test readme` to update them."
+        );
+    }
+}
+
+fn update_enabled() -> bool {
+    std::env::var_os("UPDATE_EXPECT").is_some() || std::env::var_os("UPDATE_README").is_some()
+}
+
+fn readme_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../README.md")
+}
+
+// --- generation helpers ----------------------------------------------------
+
+fn generate_swift(registry: &Registry) -> String {
+    let dir = tempfile::tempdir().unwrap();
+    swift::Installer::new("Example", dir.path())
+        .plugin(BincodePlugin)
+        .generate(registry)
+        .unwrap();
+    extract_declaration(dir.path(), "HttpHeader")
+}
+
+fn generate_kotlin(registry: &Registry) -> String {
+    let dir = tempfile::tempdir().unwrap();
+    kotlin::Installer::new("com.example", dir.path())
+        .plugin(BincodePlugin)
+        .generate(registry)
+        .unwrap();
+    extract_declaration(dir.path(), "HttpHeader")
+}
+
+fn generate_typescript(registry: &Registry) -> String {
+    let dir = tempfile::tempdir().unwrap();
+    typescript::Installer::new("example", dir.path())
+        .plugin(BincodePlugin)
+        .generate(registry)
+        .unwrap();
+    extract_declaration(dir.path(), "HttpHeader")
+}
+
+fn generate_csharp(registry: &Registry) -> String {
+    let dir = tempfile::tempdir().unwrap();
+    csharp::Installer::new("Example", dir.path())
+        .plugin(BincodePlugin)
+        .generate(registry)
+        .unwrap();
+    extract_declaration(dir.path(), "HttpHeader")
+}
+
+/// Walks `dir`, finds the generated module file that declares `type_name`, and
+/// returns the dedented source for just that declaration (including any
+/// immediately-preceding attribute/doc-comment lines).
+fn extract_declaration(dir: &Path, type_name: &str) -> String {
+    let source = find_source_with_declaration(dir, type_name).unwrap_or_else(|| {
+        panic!(
+            "no generated file declares `{type_name}` under {}",
+            dir.display()
+        )
+    });
+    extract_block(&source, type_name)
+}
+
+fn find_source_with_declaration(dir: &Path, type_name: &str) -> Option<String> {
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries = fs::read_dir(&path).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if let Ok(contents) = fs::read_to_string(&path)
+                && declares_type(&contents, type_name)
+            {
+                return Some(contents);
+            }
+        }
+    }
+    None
+}
+
+fn declares_type(source: &str, type_name: &str) -> bool {
+    source.lines().any(|line| is_declaration(line, type_name))
+}
+
+fn is_declaration(line: &str, type_name: &str) -> bool {
+    const KEYWORDS: [&str; 4] = ["struct ", "class ", "interface ", "enum "];
+    KEYWORDS.iter().any(|kw| line.contains(kw)) && line.contains(type_name)
+}
+
+/// Extracts the brace-balanced block declaring `type_name`, including any
+/// directly preceding attribute (`[...]`) or doc-comment (`///`) lines, then
+/// removes common leading indentation.
+fn extract_block(source: &str, type_name: &str) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let decl = lines
+        .iter()
+        .position(|line| is_declaration(line, type_name))
+        .expect("declaration line not found");
+
+    // Include directly-preceding attribute / doc-comment lines.
+    let mut start = decl;
+    while start > 0 {
+        let prev = lines[start - 1].trim_start();
+        if prev.starts_with("///") || prev.starts_with('[') {
+            start -= 1;
+        } else {
+            break;
+        }
+    }
+
+    let mut depth = 0i32;
+    let mut seen_brace = false;
+    let mut end = decl;
+    for (offset, line) in lines[decl..].iter().enumerate() {
+        for ch in line.chars() {
+            match ch {
+                '{' => {
+                    depth += 1;
+                    seen_brace = true;
+                }
+                '}' => depth -= 1,
+                _ => {}
+            }
+        }
+        if seen_brace && depth == 0 {
+            end = decl + offset;
+            break;
+        }
+    }
+
+    dedent(&lines[start..=end])
+}
+
+fn dedent(lines: &[&str]) -> String {
+    let indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|line| {
+            if line.len() >= indent {
+                &line[indent..]
+            } else {
+                line.trim_start()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// --- README rewriting -------------------------------------------------------
+
+fn replace_block(readme: &str, block: &Block) -> String {
+    let start_marker = format!("<!-- generated:{}:start -->", block.marker);
+    let end_marker = format!("<!-- generated:{}:end -->", block.marker);
+
+    let start = readme
+        .find(&start_marker)
+        .unwrap_or_else(|| panic!("missing `{start_marker}` in README.md"));
+    let end = readme
+        .find(&end_marker)
+        .unwrap_or_else(|| panic!("missing `{end_marker}` in README.md"));
+    assert!(
+        end > start,
+        "`{end_marker}` appears before `{start_marker}` in README.md"
+    );
+
+    let replacement = format!(
+        "{start_marker}\n\n```{fence}\n{code}\n```\n\n",
+        fence = block.fence,
+        code = block.code,
+    );
+
+    let mut out = String::with_capacity(readme.len());
+    out.push_str(&readme[..start]);
+    out.push_str(&replacement);
+    out.push_str(&readme[end..]);
+    out
+}


### PR DESCRIPTION
Adds a test to verify that the outputs for each language in the Readme are correct.  Fails in CI if they are not. To update the snippets: `UPDATE_EXPECT=1 cargo test -p facet_generate --test readme`