### PR TITLE
fixes: Hashable implementation across namespace + Non hashable value in map

### DIFF
--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -439,15 +439,8 @@ impl Emitter<Swift> for Format {
                         ),
                     ));
                 }
-                if !is_hashable(value, lang) {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        formatdoc!(
-                            "Map value type is not Hashable in Swift; \
-                             native tuples and dictionaries do not conform to Hashable"
-                        ),
-                    ));
-                }
+                // Swift requires K: Hashable for [K: V] to compile, but V need not be Hashable.
+                // If the containing type requires Hashable, that is gated by the all_hashable check.
                 write!(w, "[")?;
                 key.write(w, lang)?;
                 write!(w, ": ")?;

--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -72,7 +72,9 @@ use crate::{
         plugin::{EmitContext, EmitterPlugin},
         swift::generator::{compute_equatable_types, compute_hashable_types},
     },
-    reflection::format::{ContainerFormat, Doc, Format, Named, Namespace, VariantFormat},
+    reflection::format::{
+        ContainerFormat, Doc, Format, Named, Namespace, QualifiedTypeName, VariantFormat,
+    },
 };
 
 /// Language tag for Swift code generation.
@@ -90,11 +92,13 @@ use crate::{
 pub struct Swift {
     /// The code-generator configuration for the current module.
     pub(crate) config: CodeGeneratorConfig,
-    /// Type names (root-namespace) that can synthesize `Hashable` conformance.
-    pub(crate) hashable_types: BTreeSet<String>,
-    /// Type names (root-namespace) that can synthesize or manually implement
-    /// `Equatable` conformance.
-    pub(crate) equatable_types: BTreeSet<String>,
+    /// Qualified names of every type defined in this module's registry.
+    pub(crate) local_types: BTreeSet<QualifiedTypeName>,
+    /// Local types that can synthesize `Hashable` conformance.
+    pub(crate) hashable_types: BTreeSet<QualifiedTypeName>,
+    /// Local types that can synthesize or manually implement `Equatable`
+    /// conformance.
+    pub(crate) equatable_types: BTreeSet<QualifiedTypeName>,
     pub(crate) plugins: Vec<Arc<dyn EmitterPlugin<Self>>>,
 }
 
@@ -109,6 +113,7 @@ impl Swift {
     pub fn new(config: &CodeGeneratorConfig, registry: &Registry) -> Self {
         Self {
             config: config.clone(),
+            local_types: registry.keys().cloned().collect(),
             hashable_types: compute_hashable_types(registry),
             equatable_types: compute_equatable_types(registry),
             plugins: vec![],
@@ -151,10 +156,11 @@ pub fn is_hashable(format: &Format, lang: &Swift) -> bool {
             is_hashable(key, lang) && is_hashable(value, lang)
         },
 
-        Format::TypeName(qtn) => match &qtn.namespace {
-            Namespace::Root => lang.hashable_types.contains(&qtn.name),
-            Namespace::Named(_) => true, // external — assume hashable
-        },
+        // External types (absent from this module's registry) are assumed
+        // hashable; local types must have been computed as hashable.
+        Format::TypeName(qtn) => {
+            !lang.local_types.contains(qtn) || lang.hashable_types.contains(qtn)
+        }
 
         Format::Bool
         | Format::I8
@@ -231,10 +237,11 @@ fn needs_indirect(format: &Format, struct_name: &str) -> bool {
 
 fn is_equatable_auto(format: &Format, lang: &Swift) -> bool {
     match format {
-        Format::TypeName(qtn) => match &qtn.namespace {
-            Namespace::Root => lang.equatable_types.contains(&qtn.name),
-            Namespace::Named(_) => true,
-        },
+        // External types (absent from this module's registry) are assumed
+        // equatable; local types must have been computed as equatable.
+        Format::TypeName(qtn) => {
+            !lang.local_types.contains(qtn) || lang.equatable_types.contains(qtn)
+        }
         Format::Variable(_) | Format::Unit => false,
         Format::Bool
         | Format::I8
@@ -358,17 +365,23 @@ impl Emitter<Swift> for Container<'_> {
 // Format emitter
 // ---------------------------------------------------------------------------
 
+/// Renders a type reference for display: same-module and root-namespace types
+/// emit a bare name, while external namespaces are prefixed with the namespace
+/// in `UpperCamelCase` (e.g. `Other.Child`).
+fn render_type_name(qtn: &QualifiedTypeName, config: &CodeGeneratorConfig) -> String {
+    match &qtn.namespace {
+        Namespace::Root => qtn.name.clone(),
+        Namespace::Named(ns) if ns == config.module_name() => qtn.name.clone(),
+        Namespace::Named(ns) => format!("{}.{}", heck::AsUpperCamelCase(ns), qtn.name),
+    }
+}
+
 impl Emitter<Swift> for Format {
     fn write<W: IndentWrite>(&self, w: &mut W, lang: &Swift) -> Result<()> {
         match &self {
             Self::Variable(_variable) => unreachable!("placeholders should not get this far"),
             Self::TypeName(qualified_type_name) => {
-                write!(
-                    w,
-                    "{ty}",
-                    ty = qualified_type_name
-                        .format(|ns| heck::AsUpperCamelCase(ns).to_string(), ".")
-                )
+                write!(w, "{}", render_type_name(qualified_type_name, &lang.config))
             }
             Self::Unit => write!(w, "Void"),
             Self::Bool => write!(w, "Bool"),
@@ -422,6 +435,15 @@ impl Emitter<Swift> for Format {
                         io::ErrorKind::InvalidInput,
                         formatdoc!(
                             "Map key type is not Hashable in Swift; \
+                             native tuples and dictionaries do not conform to Hashable"
+                        ),
+                    ));
+                }
+                if !is_hashable(value, lang) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        formatdoc!(
+                            "Map value type is not Hashable in Swift; \
                              native tuples and dictionaries do not conform to Hashable"
                         ),
                     ));

--- a/crates/facet_generate/src/generation/swift/emitter/tests.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests.rs
@@ -625,6 +625,23 @@ fn struct_with_map_fields() {
 }
 
 #[test]
+fn struct_with_map_field_with_non_hashable_value_is_rejected() {
+    // The key (String) is Hashable, but the value is a multi-element native
+    // tuple, which is not Hashable in Swift.
+    #[derive(Facet)]
+    struct MyStruct {
+        map: BTreeMap<String, (i32, i32)>,
+    }
+
+    let error = emit!(MyStruct as Swift).unwrap_err();
+
+    assert!(
+        error.to_string().contains("Map value type is not Hashable"),
+        "expected a Map-value hashability error, got: {error}"
+    );
+}
+
+#[test]
 fn struct_with_hashset_field() {
     // NOTE: HashSet<T> now maps to Set<T> in Kotlin with the new Format::Set variant.
     // This preserves the uniqueness constraint and provides better type safety.
@@ -924,6 +941,78 @@ fn type_in_root_and_named_namespace() {
         public init(child: Child, otherChild: Other.Child) {
             self.child = child
             self.otherChild = otherChild
+        }
+    }
+    ");
+}
+
+#[test]
+fn type_in_root_and_map_in_named_namespace() {
+    #[derive(Facet)]
+    struct Child {
+        value: String,
+    }
+
+    mod other {
+        use crate as fg;
+        use facet::Facet;
+
+        #[derive(Facet)]
+        #[facet(fg::namespace = "other")]
+        pub struct Child {
+            value: std::collections::HashMap<Key, Value>,
+        }
+        #[derive(PartialEq, Eq, Hash, Facet)]
+        #[facet(fg::namespace = "other")]
+        pub struct Key(String);
+        #[derive(Facet)]
+        #[facet(fg::namespace = "other")]
+        pub struct Value(i32);
+    }
+
+    #[derive(Facet)]
+    struct Parent {
+        other_map: other::Child,
+    }
+
+    let (other_module, root_module) = emit_two_modules!(SwiftCodeGenerator, Parent, "root");
+
+    // Snapshot the "other" module - types in named namespace should render with bare names internally
+    insta::assert_snapshot!(other_module, @r"
+    public struct Child {
+        public var value: [Key: Value]
+
+        public init(value: [Key: Value]) {
+            self.value = value
+        }
+    }
+
+    public struct Key {
+        public var value: String
+
+        public init(value: String) {
+            self.value = value
+        }
+    }
+
+    public struct Value {
+        public var value: Int32
+
+        public init(value: Int32) {
+            self.value = value
+        }
+    }
+    ");
+
+    // Snapshot the "root" module - references to external namespace should be prefixed
+    insta::assert_snapshot!(root_module, @r"
+    import Other
+
+    public struct Parent {
+        public var otherMap: Other.Child
+
+        public init(otherMap: Other.Child) {
+            self.otherMap = otherMap
         }
     }
     ");

--- a/crates/facet_generate/src/generation/swift/emitter/tests.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/tests.rs
@@ -625,20 +625,25 @@ fn struct_with_map_fields() {
 }
 
 #[test]
-fn struct_with_map_field_with_non_hashable_value_is_rejected() {
+fn struct_with_map_field_with_non_hashable_value_generates_without_hashable() {
     // The key (String) is Hashable, but the value is a multi-element native
-    // tuple, which is not Hashable in Swift.
+    // tuple, which is not Hashable in Swift. The struct should still generate
+    // — it just won't have Hashable conformance.
     #[derive(Facet)]
     struct MyStruct {
         map: BTreeMap<String, (i32, i32)>,
     }
 
-    let error = emit!(MyStruct as Swift).unwrap_err();
+    let actual = emit!(MyStruct as Swift).unwrap();
+    insta::assert_snapshot!(actual, @r"
+    public struct MyStruct {
+        public var map: [String: (Int32, Int32)]
 
-    assert!(
-        error.to_string().contains("Map value type is not Hashable"),
-        "expected a Map-value hashability error, got: {error}"
-    );
+        public init(map: [String: (Int32, Int32)]) {
+            self.map = map
+        }
+    }
+    ");
 }
 
 #[test]

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -15,9 +15,7 @@ use crate::{
         CodeGenerator, CodeGeneratorConfig, Container, Emitter, indent::IndentedWriter,
         module::Module, plugin::EmitterPlugin, swift::emitter::Swift,
     },
-    reflection::format::{
-        ContainerFormat, Format, FormatHolder, Namespace, QualifiedTypeName, VariantFormat,
-    },
+    reflection::format::{ContainerFormat, Format, QualifiedTypeName, VariantFormat},
 };
 
 /// Main configuration object for Swift code generation.
@@ -85,40 +83,12 @@ impl<'a> SwiftCodeGenerator<'a> {
 
         Module::new(&config).write(w, &lang)?;
 
-        let updated_registry = Self::update_qualified_names(&config, registry);
-        for container in updated_registry.iter().map(Container::from) {
+        for container in registry.iter().map(Container::from) {
             writeln!(w)?;
             container.write(w, &lang)?;
         }
 
         Ok(())
-    }
-
-    /// Updates `QualifiedTypeName` instances so external types include their namespace prefix.
-    /// For example, a type `Tree` in namespace `foo` becomes `Foo.Tree` in the output.
-    fn update_qualified_names(config: &CodeGeneratorConfig, registry: &Registry) -> Registry {
-        let mut updated_registry = registry.clone();
-
-        for container_format in updated_registry.values_mut() {
-            let _ = container_format.visit_mut(&mut |format| {
-                if let Format::TypeName(qualified_name) = format
-                    && let Namespace::Named(namespace) = &qualified_name.namespace
-                {
-                    if namespace == config.module_name() {
-                        // Same-module type: strip namespace so it renders as a bare name
-                        *qualified_name = QualifiedTypeName::root(qualified_name.name.clone());
-                    } else if config.external_definitions.contains_key(namespace) {
-                        *qualified_name = QualifiedTypeName::namespaced(
-                            namespace.clone(),
-                            qualified_name.name.clone(),
-                        );
-                    }
-                }
-                Ok(())
-            });
-        }
-
-        updated_registry
     }
 }
 
@@ -132,111 +102,95 @@ impl<'a> SwiftCodeGenerator<'a> {
 /// non-recursive stored properties are themselves `Hashable`.
 ///
 /// External types (not present in the registry) are assumed to be hashable.
-pub fn compute_hashable_types(registry: &Registry) -> BTreeSet<String> {
-    let local_names: BTreeSet<&str> = registry
-        .keys()
-        .filter(|k| matches!(k.namespace, Namespace::Root))
-        .map(|k| k.name.as_str())
-        .collect();
-
-    let mut known: BTreeSet<String> = BTreeSet::new();
-    let mut visiting: BTreeSet<String> = BTreeSet::new();
+pub fn compute_hashable_types(registry: &Registry) -> BTreeSet<QualifiedTypeName> {
+    let mut known: BTreeSet<&QualifiedTypeName> = BTreeSet::new();
+    let mut visiting: BTreeSet<&QualifiedTypeName> = BTreeSet::new();
 
     for qtn in registry.keys() {
-        if local_names.contains(qtn.name.as_str()) && !known.contains(&qtn.name) {
-            check_type_hashable(registry, qtn, &local_names, &mut known, &mut visiting);
+        if !known.contains(qtn) {
+            check_type_hashable(registry, qtn, &mut known, &mut visiting);
         }
     }
 
-    known
+    known.into_iter().cloned().collect()
 }
 
 /// Checks whether a type (and transitively all types it references) can
 /// conform to `Hashable`.
 ///
-/// On success the type name is inserted into `known` so that subsequent
-/// checks short-circuit.
-fn check_type_hashable(
-    registry: &Registry,
-    qtn: &QualifiedTypeName,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+/// On success the qualified type name is inserted into `known` so that
+/// subsequent checks short-circuit.
+fn check_type_hashable<'a>(
+    registry: &'a Registry,
+    qtn: &'a QualifiedTypeName,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
-    let name = &qtn.name;
-
-    if known.contains(name) {
+    if known.contains(qtn) {
         return true;
     }
-    if visiting.contains(name) {
+    if visiting.contains(qtn) {
         // Cycle detected — strongly-connected components are either all
         // hashable or all non-hashable, so optimism is safe here.
         return true;
     }
-    if !local_names.contains(name.as_str()) {
-        return true; // external type
-    }
 
     let Some(container) = registry.get(qtn) else {
-        return false;
+        return true; // external type (absent from the registry) — assume hashable
     };
 
-    visiting.insert(name.clone());
+    visiting.insert(qtn);
 
     let result = match container {
         ContainerFormat::UnitStruct(_) => true,
-        ContainerFormat::NewTypeStruct(fmt, _) => {
-            fmt_is_hashable(registry, fmt, local_names, known, visiting)
-        }
+        ContainerFormat::NewTypeStruct(fmt, _) => fmt_is_hashable(registry, fmt, known, visiting),
         ContainerFormat::TupleStruct(fmts, _) => fmts
             .iter()
-            .all(|f| fmt_is_hashable(registry, f, local_names, known, visiting)),
+            .all(|f| fmt_is_hashable(registry, f, known, visiting)),
         ContainerFormat::Struct(fields, _) => fields
             .iter()
-            .all(|f| fmt_is_hashable(registry, &f.value, local_names, known, visiting)),
+            .all(|f| fmt_is_hashable(registry, &f.value, known, visiting)),
         ContainerFormat::Enum(variants, _) => variants
             .values()
-            .all(|v| variant_is_hashable(registry, &v.value, local_names, known, visiting)),
+            .all(|v| variant_is_hashable(registry, &v.value, known, visiting)),
     };
 
-    visiting.remove(name);
+    visiting.remove(qtn);
 
     if result {
-        known.insert(name.clone());
+        known.insert(qtn);
     }
 
     result
 }
 
-fn variant_is_hashable(
-    registry: &Registry,
-    format: &VariantFormat,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+fn variant_is_hashable<'a>(
+    registry: &'a Registry,
+    format: &'a VariantFormat,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => fmt_is_hashable(registry, fmt, local_names, known, visiting),
+        VariantFormat::NewType(fmt) => fmt_is_hashable(registry, fmt, known, visiting),
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_is_hashable(registry, f, local_names, known, visiting)),
+            .all(|f| fmt_is_hashable(registry, f, known, visiting)),
         VariantFormat::Struct(fields) => fields
             .iter()
-            .all(|f| fmt_is_hashable(registry, &f.value, local_names, known, visiting)),
+            .all(|f| fmt_is_hashable(registry, &f.value, known, visiting)),
     }
 }
 
-fn fmt_is_hashable(
-    registry: &Registry,
-    format: &Format,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+fn fmt_is_hashable<'a>(
+    registry: &'a Registry,
+    format: &'a Format,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
     match format {
-        Format::TypeName(qtn) => check_type_hashable(registry, qtn, local_names, known, visiting),
+        Format::TypeName(qtn) => check_type_hashable(registry, qtn, known, visiting),
         Format::Bool
         | Format::I8
         | Format::I16
@@ -259,15 +213,14 @@ fn fmt_is_hashable(
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_is_hashable(registry, inner, local_names, known, visiting)
+            fmt_is_hashable(registry, inner, known, visiting)
         }
         Format::Map { key, value } => {
-            fmt_is_hashable(registry, key, local_names, known, visiting)
-                && fmt_is_hashable(registry, value, local_names, known, visiting)
+            fmt_is_hashable(registry, key, known, visiting)
+                && fmt_is_hashable(registry, value, known, visiting)
         }
         Format::Tuple(formats) => {
-            formats.len() == 1
-                && fmt_is_hashable(registry, &formats[0], local_names, known, visiting)
+            formats.len() == 1 && fmt_is_hashable(registry, &formats[0], known, visiting)
         }
     }
 }
@@ -286,113 +239,95 @@ fn fmt_is_hashable(
 /// `==` operator using Swift's built-in tuple `==`.
 ///
 /// External types (not present in the registry) are assumed to be equatable.
-pub fn compute_equatable_types(registry: &Registry) -> BTreeSet<String> {
-    let local_names: BTreeSet<&str> = registry
-        .keys()
-        .filter(|k| matches!(k.namespace, Namespace::Root))
-        .map(|k| k.name.as_str())
-        .collect();
-
-    let mut known: BTreeSet<String> = BTreeSet::new();
-    let mut visiting: BTreeSet<String> = BTreeSet::new();
+pub fn compute_equatable_types(registry: &Registry) -> BTreeSet<QualifiedTypeName> {
+    let mut known: BTreeSet<&QualifiedTypeName> = BTreeSet::new();
+    let mut visiting: BTreeSet<&QualifiedTypeName> = BTreeSet::new();
 
     for qtn in registry.keys() {
-        if local_names.contains(qtn.name.as_str()) && !known.contains(&qtn.name) {
-            check_type_equatable(registry, qtn, &local_names, &mut known, &mut visiting);
+        if !known.contains(qtn) {
+            check_type_equatable(registry, qtn, &mut known, &mut visiting);
         }
     }
 
-    known
+    known.into_iter().cloned().collect()
 }
 
 /// Checks whether a type (and transitively all types it references) can
 /// conform to `Equatable`.
 ///
-/// On success the type name is inserted into `known` so that subsequent
-/// checks short-circuit.
-fn check_type_equatable(
-    registry: &Registry,
-    qtn: &QualifiedTypeName,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+/// On success the qualified type name is inserted into `known` so that
+/// subsequent checks short-circuit.
+fn check_type_equatable<'a>(
+    registry: &'a Registry,
+    qtn: &'a QualifiedTypeName,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
-    let name = &qtn.name;
-
-    if known.contains(name) {
+    if known.contains(qtn) {
         return true;
     }
-    if visiting.contains(name) {
+    if visiting.contains(qtn) {
         // Cycle detected — strongly-connected components are either all
         // equatable or all non-equatable, so optimism is safe here.
         return true;
     }
-    if !local_names.contains(name.as_str()) {
-        return true; // external type
-    }
 
     let Some(container) = registry.get(qtn) else {
-        return false;
+        return true; // external type (absent from the registry) — assume equatable
     };
 
-    visiting.insert(name.clone());
+    visiting.insert(qtn);
 
     let result = match container {
         ContainerFormat::UnitStruct(_) => true,
-        ContainerFormat::NewTypeStruct(fmt, _) => {
-            fmt_is_equatable(registry, fmt, local_names, known, visiting)
-        }
+        ContainerFormat::NewTypeStruct(fmt, _) => fmt_is_equatable(registry, fmt, known, visiting),
         ContainerFormat::TupleStruct(fmts, _) => fmts
             .iter()
-            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
+            .all(|f| fmt_is_equatable(registry, f, known, visiting)),
         ContainerFormat::Struct(fields, _) => fields
             .iter()
-            .all(|f| fmt_is_equatable(registry, &f.value, local_names, known, visiting)),
+            .all(|f| fmt_is_equatable(registry, &f.value, known, visiting)),
         ContainerFormat::Enum(variants, _) => variants
             .values()
-            .all(|v| variant_is_equatable(registry, &v.value, local_names, known, visiting)),
+            .all(|v| variant_is_equatable(registry, &v.value, known, visiting)),
     };
 
-    visiting.remove(name);
+    visiting.remove(qtn);
 
     if result {
-        known.insert(name.clone());
+        known.insert(qtn);
     }
 
     result
 }
 
-fn variant_is_equatable(
-    registry: &Registry,
-    format: &VariantFormat,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+fn variant_is_equatable<'a>(
+    registry: &'a Registry,
+    format: &'a VariantFormat,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
     match format {
         VariantFormat::Variable(_) => false,
         VariantFormat::Unit => true,
-        VariantFormat::NewType(fmt) => {
-            fmt_is_equatable(registry, fmt, local_names, known, visiting)
-        }
+        VariantFormat::NewType(fmt) => fmt_is_equatable(registry, fmt, known, visiting),
         VariantFormat::Tuple(fmts) => fmts
             .iter()
-            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
+            .all(|f| fmt_is_equatable(registry, f, known, visiting)),
         VariantFormat::Struct(fields) => fields
             .iter()
-            .all(|f| fmt_is_equatable(registry, &f.value, local_names, known, visiting)),
+            .all(|f| fmt_is_equatable(registry, &f.value, known, visiting)),
     }
 }
 
-fn fmt_is_equatable(
-    registry: &Registry,
-    format: &Format,
-    local_names: &BTreeSet<&str>,
-    known: &mut BTreeSet<String>,
-    visiting: &mut BTreeSet<String>,
+fn fmt_is_equatable<'a>(
+    registry: &'a Registry,
+    format: &'a Format,
+    known: &mut BTreeSet<&'a QualifiedTypeName>,
+    visiting: &mut BTreeSet<&'a QualifiedTypeName>,
 ) -> bool {
     match format {
-        Format::TypeName(qtn) => check_type_equatable(registry, qtn, local_names, known, visiting),
+        Format::TypeName(qtn) => check_type_equatable(registry, qtn, known, visiting),
         Format::Bool
         | Format::I8
         | Format::I16
@@ -415,15 +350,15 @@ fn fmt_is_equatable(
         | Format::Set(inner)
         | Format::Seq(inner)
         | Format::TupleArray { content: inner, .. } => {
-            fmt_is_equatable(registry, inner, local_names, known, visiting)
+            fmt_is_equatable(registry, inner, known, visiting)
         }
         Format::Map { key, value } => {
-            fmt_is_equatable(registry, key, local_names, known, visiting)
-                && fmt_is_equatable(registry, value, local_names, known, visiting)
+            fmt_is_equatable(registry, key, known, visiting)
+                && fmt_is_equatable(registry, value, known, visiting)
         }
         Format::Tuple(formats) => formats
             .iter()
-            .all(|f| fmt_is_equatable(registry, f, local_names, known, visiting)),
+            .all(|f| fmt_is_equatable(registry, f, known, visiting)),
     }
 }
 

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use crate::{
     generation::{CodeGeneratorConfig, bincode::BincodePlugin, plugin::EmitterPlugin},
-    reflection::format::{ContainerFormat, Doc, Format, Named, QualifiedTypeName},
+    reflection::format::{ContainerFormat, Doc, Format, Named, Namespace, QualifiedTypeName},
 };
 
 use super::*;
@@ -530,5 +530,335 @@ fn test_mutual_recursion_equatable() {
     assert!(
         output.contains("public struct StructB: Hashable, Equatable {"),
         "StructB should be hashable and equatable:\n{output}"
+    );
+}
+
+#[test]
+fn test_named_namespace_map_key_value_are_hashable() {
+    let config = CodeGeneratorConfig::new("other".to_string());
+
+    let child = ContainerFormat::Struct(
+        vec![Named {
+            name: "value".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "other".to_string(),
+                    "Key".to_string(),
+                ))),
+                value: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "other".to_string(),
+                    "Value".to_string(),
+                ))),
+            },
+        }],
+        Doc::new(),
+    );
+    let key = ContainerFormat::NewTypeStruct(Box::new(Format::Str), Doc::new());
+    let value = ContainerFormat::NewTypeStruct(Box::new(Format::I32), Doc::new());
+
+    let mut registry = Registry::new();
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Child".to_string()),
+        child,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Key".to_string()),
+        key,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Value".to_string()),
+        value,
+    );
+
+    let output = generate(&config, vec![], &registry);
+
+    assert!(
+        output.contains("public var value: [Key: Value]"),
+        "same-module map key/value should render with bare names and not be rejected as non-Hashable:\n{output}"
+    );
+}
+
+#[test]
+fn test_named_namespace_struct_implements_hashable_and_equatable() {
+    let config = CodeGeneratorConfig::new("other".to_string());
+
+    let parent = ContainerFormat::Struct(
+        vec![Named {
+            name: "child".to_string(),
+            doc: Doc::new(),
+            value: Format::TypeName(QualifiedTypeName::namespaced(
+                "other".to_string(),
+                "Child".to_string(),
+            )),
+        }],
+        Doc::new(),
+    );
+    let child = ContainerFormat::NewTypeStruct(Box::new(Format::Str), Doc::new());
+
+    let mut registry = Registry::new();
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Parent".to_string()),
+        parent,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Child".to_string()),
+        child,
+    );
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct Parent: Hashable, Equatable {"),
+        "Parent referencing a same-module Hashable type should be Hashable, Equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct Child: Hashable, Equatable {"),
+        "Child in a named namespace should be Hashable, Equatable:\n{output}"
+    );
+}
+
+/// Builds the post-split `other` registry: `Child { value: [Key: Value] }`
+/// with `Key(String)` and `Value(i32)`, all in namespace `other`.
+fn other_namespace_map_registry() -> Registry {
+    let child = ContainerFormat::Struct(
+        vec![Named {
+            name: "value".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "other".to_string(),
+                    "Key".to_string(),
+                ))),
+                value: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "other".to_string(),
+                    "Value".to_string(),
+                ))),
+            },
+        }],
+        Doc::new(),
+    );
+    let key = ContainerFormat::NewTypeStruct(Box::new(Format::Str), Doc::new());
+    let value = ContainerFormat::NewTypeStruct(Box::new(Format::I32), Doc::new());
+
+    let mut registry = Registry::new();
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Child".to_string()),
+        child,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Key".to_string()),
+        key,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Value".to_string()),
+        value,
+    );
+    registry
+}
+
+#[test]
+fn test_compute_hashable_types_covers_named_namespace() {
+    let registry = other_namespace_map_registry();
+
+    let hashable = compute_hashable_types(&registry);
+
+    for name in ["Child", "Key", "Value"] {
+        assert!(
+            hashable.contains(&QualifiedTypeName::namespaced(
+                "other".to_string(),
+                name.to_string()
+            )),
+            "other::{name} should be computed as hashable, got {hashable:?}"
+        );
+    }
+}
+
+#[test]
+fn test_compute_hashable_types_is_collision_safe() {
+    let root_child = ContainerFormat::Struct(
+        vec![Named {
+            name: "x".to_string(),
+            doc: Doc::new(),
+            value: Format::U32,
+        }],
+        Doc::new(),
+    );
+    // A multi-element native tuple is not Hashable in Swift.
+    let other_child = ContainerFormat::Struct(
+        vec![Named {
+            name: "pair".to_string(),
+            doc: Doc::new(),
+            value: Format::Tuple(vec![Format::U32, Format::U32]),
+        }],
+        Doc::new(),
+    );
+
+    let mut registry = Registry::new();
+    registry.insert(QualifiedTypeName::root("Child".to_string()), root_child);
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Child".to_string()),
+        other_child,
+    );
+
+    let hashable = compute_hashable_types(&registry);
+
+    assert!(
+        hashable.contains(&QualifiedTypeName::root("Child".to_string())),
+        "root Child (scalar field) should be hashable: {hashable:?}"
+    );
+    assert!(
+        !hashable.contains(&QualifiedTypeName::namespaced(
+            "other".to_string(),
+            "Child".to_string()
+        )),
+        "other::Child (tuple field) should not be hashable; same bare name must not leak: {hashable:?}"
+    );
+}
+
+#[test]
+fn test_compute_hashable_types_assumes_external_hashable() {
+    let parent = ContainerFormat::Struct(
+        vec![Named {
+            name: "m".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "external".to_string(),
+                    "Key".to_string(),
+                ))),
+                value: Box::new(Format::Str),
+            },
+        }],
+        Doc::new(),
+    );
+
+    let mut registry = Registry::new();
+    registry.insert(QualifiedTypeName::root("Parent".to_string()), parent);
+
+    let hashable = compute_hashable_types(&registry);
+
+    assert!(
+        hashable.contains(&QualifiedTypeName::root("Parent".to_string())),
+        "Parent keyed by an absent external type should be hashable: {hashable:?}"
+    );
+}
+
+#[test]
+fn test_non_hashable_local_named_map_key_is_rejected() {
+    let config = CodeGeneratorConfig::new("other".to_string());
+
+    let child = ContainerFormat::Struct(
+        vec![Named {
+            name: "m".to_string(),
+            doc: Doc::new(),
+            value: Format::Map {
+                key: Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                    "other".to_string(),
+                    "Bad".to_string(),
+                ))),
+                value: Box::new(Format::Str),
+            },
+        }],
+        Doc::new(),
+    );
+    let bad = ContainerFormat::Struct(
+        vec![Named {
+            name: "pair".to_string(),
+            doc: Doc::new(),
+            value: Format::Tuple(vec![Format::U32, Format::U32]),
+        }],
+        Doc::new(),
+    );
+
+    let mut registry = Registry::new();
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Child".to_string()),
+        child,
+    );
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Bad".to_string()),
+        bad,
+    );
+
+    let generator = SwiftCodeGenerator::new(&config);
+    let mut output = Vec::new();
+    let result = generator.output(&mut output, &registry);
+
+    assert!(
+        result.is_err(),
+        "a local Named map key that is not Hashable must be rejected"
+    );
+}
+
+#[test]
+fn test_self_referential_named_type_is_hashable() {
+    let node = ContainerFormat::Struct(
+        vec![Named {
+            name: "next".to_string(),
+            doc: Doc::new(),
+            value: Format::Option(Box::new(Format::TypeName(QualifiedTypeName::namespaced(
+                "other".to_string(),
+                "Node".to_string(),
+            )))),
+        }],
+        Doc::new(),
+    );
+
+    let mut registry = Registry::new();
+    registry.insert(
+        QualifiedTypeName::namespaced("other".to_string(), "Node".to_string()),
+        node,
+    );
+
+    let hashable = compute_hashable_types(&registry);
+
+    assert!(
+        hashable.contains(&QualifiedTypeName::namespaced(
+            "other".to_string(),
+            "Node".to_string()
+        )),
+        "a self-referential Named type should be hashable via cycle optimism: {hashable:?}"
+    );
+}
+
+#[test]
+fn test_named_namespace_map_struct_implements_hashable_with_plugin() {
+    let config = CodeGeneratorConfig::new("other".to_string());
+    let registry = other_namespace_map_registry();
+
+    let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
+
+    assert!(
+        output.contains("public struct Child: Hashable, Equatable {"),
+        "Child with a [Key: Value] map of same-module Hashable types should be Hashable, Equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct Key: Hashable, Equatable {"),
+        "Key should be Hashable, Equatable:\n{output}"
+    );
+    assert!(
+        output.contains("public struct Value: Hashable, Equatable {"),
+        "Value should be Hashable, Equatable:\n{output}"
+    );
+}
+
+#[test]
+fn test_named_namespace_map_struct_omits_conformance_without_plugin() {
+    let config = CodeGeneratorConfig::new("other".to_string());
+    let registry = other_namespace_map_registry();
+
+    let output = generate(&config, vec![], &registry);
+
+    // Conformance display is intentionally gated on an active serialization
+    // plugin: plain generation emits bare declarations even for types that
+    // qualify. Changing this should be a deliberate decision, not silent drift.
+    assert!(
+        output.contains("public struct Child {"),
+        "without a plugin, Child should render bare (no conformance suffix):\n{output}"
+    );
+    assert!(
+        !output.contains("public struct Child: "),
+        "without a plugin, Child should not declare any conformance:\n{output}"
     );
 }


### PR DESCRIPTION
This changeset adds a couple of tests and fixes two bugs:
- Map values weren't checked for hashability: in [K;V] if K was hashable but not V, swift would still generate a hashable impl although this isn't valid.
- Structures in names namespace weren't recognized as hashable. This is due to former namespace stripping before we emit the swift types, which conflated all types as `Root` thus missing namespace differences, and not relying on the actual types Hashable implementation.