### PR TITLE
feat: TypeScript ADTs as discriminated unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,123 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.18.0] - unreleased
+
+TypeScript enums are now generated as **discriminated union types** instead of abstract class hierarchies. This is a breaking change for any code that was constructing or matching TypeScript enum values, but the new output is far more idiomatic and integrates naturally with TypeScript's type narrowing.
+
+### 💥 Breaking Changes
+
+- **TypeScript enums are no longer emitted as abstract classes.** Each enum is now a `type` alias over a union of object literals. Code that used `new FooVariant(...)` or `instanceof` checks must be updated to use the generated constructor functions and `matchX` helpers described below. [#106](https://github.com/redbadger/facet-generate/pull/106)
+
+### 🚀 Features
+
+- **feat(typescript): discriminated union types for enums** — Rust enums now generate a `type` alias, a typed constructor arrow function per variant, and an exhaustive `matchX<R>(...)` helper [#106](https://github.com/redbadger/facet-generate/pull/106)
+- **feat(typescript): `EnumTagging` in format AST** — `#[facet(tag = "...")]` and `#[facet(tag = "...", content = "...")]` are now reflected into the format as `EnumTagging::Internal` and `EnumTagging::Adjacent`, controlling the shape of each variant's object literal [#106](https://github.com/redbadger/facet-generate/pull/106)
+- **feat(typescript): standalone serialize/deserialize for enums** — the Bincode and JSON plugins now emit `serializeX(value, serializer)` / `deserializeX(deserializer)` functions alongside each enum type rather than expecting a `.serialize()` method on the value [#106](https://github.com/redbadger/facet-generate/pull/106)
+
 ### 🐛 Bug Fixes
 
+- **fix(typescript): quote non-identifier property keys in match function** — variant names that are not valid JavaScript identifiers (e.g. `"number-array"` from `rename_all = "kebab-case"`) are now correctly quoted as string keys in the `matchX` cases object type [#106](https://github.com/redbadger/facet-generate/pull/106)
 - fix(typescript): Correct `deserializeI64` / `deserializeI128` when the low limb has its high bit set. The previous BigInt `|` of signed halves dropped the upper limb (e.g. epoch-millis timestamps).
+
+### 🧪 Tests
+
+- Enabled TypeScript output for 21 previously-disabled or untested expect-file test cases covering structs, unit enums, externally/internally/adjacently tagged enums, skipped variants, readonly fields, deprecation notices, and anonymous struct variants [#106](https://github.com/redbadger/facet-generate/pull/106)
+
+---
+
+#### Usage examples
+
+Given this Rust enum:
+
+```rust
+#[derive(Facet)]
+#[repr(C)]
+pub enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+    Point,
+}
+```
+
+The generated TypeScript is:
+
+```typescript
+export type Shape =
+    | { kind: "Circle"; radius: float64 }
+    | { kind: "Rectangle"; width: float64; height: float64 }
+    | { kind: "Point" };
+
+export const shapeCircle = (radius: float64): Shape => ({ kind: "Circle", radius });
+export const shapeRectangle = (width: float64, height: float64): Shape => ({ kind: "Rectangle", width, height });
+export const shapePoint = (): Shape => ({ kind: "Point" });
+
+export function matchShape<R>(value: Shape, cases: {
+    Circle: (v: Extract<Shape, { kind: "Circle" }>) => R;
+    Rectangle: (v: Extract<Shape, { kind: "Rectangle" }>) => R;
+    Point: (v: Extract<Shape, { kind: "Point" }>) => R;
+}): R {
+    return cases[value.kind as Shape["kind"]](value as never);
+}
+```
+
+**Constructing values:**
+
+```typescript
+const circle = shapeCircle(3.14);
+const rect = shapeRectangle(10, 20);
+const point = shapePoint();
+```
+
+**Exhaustive pattern matching:**
+
+```typescript
+const area = matchShape(shape, {
+    Circle: ({ radius }) => Math.PI * radius ** 2,
+    Rectangle: ({ width, height }) => width * height,
+    Point: () => 0,
+});
+```
+
+**Type narrowing without `matchShape`** — TypeScript's built-in narrowing works directly on the `kind` field:
+
+```typescript
+if (shape.kind === "Circle") {
+    console.log(shape.radius); // TypeScript knows this is a Circle
+}
+```
+
+**Internally tagged enums** (`#[facet(tag = "type")]`) inline the tag alongside the payload fields:
+
+```rust
+#[facet(tag = "type")]
+pub enum Event {
+    Click { x: i32, y: i32 },
+    KeyPress { key: String },
+}
+```
+
+```typescript
+export type Event =
+    | { type: "Click"; x: int32; y: int32 }
+    | { type: "KeyPress"; key: str };
+```
+
+**Adjacently tagged enums** (`#[facet(tag = "type", content = "data")]`) wrap the payload under a content field:
+
+```rust
+#[facet(tag = "type", content = "data")]
+pub enum Message {
+    Text(String),
+    Image { url: String, alt: String },
+}
+```
+
+```typescript
+export type Message =
+    | { type: "Text"; data: str }
+    | { type: "Image"; data: { url: str; alt: str; } };
+```
 
 ## [0.17.2] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -10,47 +10,24 @@ cargo add facet facet_generate
 
 ```rust
 use facet::Facet;
-use facet_generate as fg;
+use facet_generate::reflection::RegistryBuilder;
 
 #[derive(Facet)]
-#[repr(C)]
-enum HttpResult {
-    Ok(HttpResponse),
-    Err(HttpError),
-}
-
-#[derive(Facet)]
-struct HttpResponse {
-    status: u16,
-    headers: Vec<HttpHeader>,
-    #[facet(fg::bytes)]
-    body: Vec<u8>,
-}
-
-#[derive(Facet)]
-struct HttpHeader {
-    name: String,
-    value: String,
+struct Point {
+    x: f64,
+    y: f64,
 }
 
 #[derive(Facet)]
 #[repr(C)]
-enum HttpError {
-    #[facet(skip)]
-    Http {
-        status: u16,
-        message: String,
-        body: Option<Vec<u8>>,
-    },
-    #[facet(skip)]
-    Json(String),
-    Url(String),
-    Io(String),
-    Timeout,
+enum Shape {
+    Circle { centre: Point, radius: f64 },
+    Rectangle { position: Point, width: f64, height: f64 },
 }
 
+// Point is discovered automatically as a field type of Shape
 let registry = RegistryBuilder::new()
-    .add_type::<HttpResult>()?
+    .add_type::<Shape>()?
     .build()?;
 ```
 
@@ -80,7 +57,7 @@ csharp::Installer::new("Example", &out_dir)
     .generate(&registry)?;
 ```
 
-With `BincodePlugin`, the generated types include `serialize` and `deserialize` methods. For the types above, this generates the following code (showing `HttpHeader` as a representative example — all types are generated similarly).
+With `BincodePlugin`, structs gain `serialize`/`deserialize` methods and enums gain standalone `serializeX`/`deserializeX` functions alongside a discriminated union type, per-variant constructor functions, and an exhaustive `matchX` helper. The examples below show the complete output for `Point` (struct) and `Shape` (enum). Swift, Kotlin, and C# show `Point` only; TypeScript shows the full generated module for both types.
 
 > [!NOTE]
 > The code blocks below are generated from the real output of the code
@@ -93,19 +70,19 @@ With `BincodePlugin`, the generated types include `serialize` and `deserialize` 
 <!-- generated:swift:start -->
 
 ```swift
-public struct HttpHeader: Hashable, Equatable {
-    public var name: String
-    public var value: String
+public struct Point: Hashable, Equatable {
+    public var x: Double
+    public var y: Double
 
-    public init(name: String, value: String) {
-        self.name = name
-        self.value = value
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
     }
 
     public func serialize<S: Serializer>(serializer: S) throws {
         try serializer.increase_container_depth()
-        try serializer.serialize_str(value: self.name)
-        try serializer.serialize_str(value: self.value)
+        try serializer.serialize_f64(value: self.x)
+        try serializer.serialize_f64(value: self.y)
         try serializer.decrease_container_depth()
     }
 
@@ -115,15 +92,15 @@ public struct HttpHeader: Hashable, Equatable {
         return serializer.get_bytes()
     }
 
-    public static func deserialize<D: Deserializer>(deserializer: D) throws -> HttpHeader {
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> Point {
         try deserializer.increase_container_depth()
-        let name = try deserializer.deserialize_str()
-        let value = try deserializer.deserialize_str()
+        let x = try deserializer.deserialize_f64()
+        let y = try deserializer.deserialize_f64()
         try deserializer.decrease_container_depth()
-        return HttpHeader(name: name, value: value)
+        return Point(x: x, y: y)
     }
 
-    public static func bincodeDeserialize(input: [UInt8]) throws -> HttpHeader {
+    public static func bincodeDeserialize(input: [UInt8]) throws -> Point {
         let deserializer = BincodeDeserializer.init(input: input);
         let obj = try deserialize(deserializer: deserializer)
         if deserializer.get_buffer_offset() < input.count {
@@ -141,14 +118,14 @@ public struct HttpHeader: Hashable, Equatable {
 <!-- generated:kotlin:start -->
 
 ```kotlin
-data class HttpHeader(
-    val name: String,
-    val value: String,
+data class Point(
+    val x: Double,
+    val y: Double,
 ) {
     fun serialize(serializer: Serializer) {
         serializer.increase_container_depth()
-        serializer.serialize_str(name)
-        serializer.serialize_str(value)
+        serializer.serialize_f64(x)
+        serializer.serialize_f64(y)
         serializer.decrease_container_depth()
     }
 
@@ -159,16 +136,16 @@ data class HttpHeader(
     }
 
     companion object {
-        fun deserialize(deserializer: Deserializer): HttpHeader {
+        fun deserialize(deserializer: Deserializer): Point {
             deserializer.increase_container_depth()
-            val name = deserializer.deserialize_str()
-            val value = deserializer.deserialize_str()
+            val x = deserializer.deserialize_f64()
+            val y = deserializer.deserialize_f64()
             deserializer.decrease_container_depth()
-            return HttpHeader(name, value)
+            return Point(x, y)
         }
 
         @Throws(DeserializationError::class)
-        fun bincodeDeserialize(input: ByteArray?): HttpHeader {
+        fun bincodeDeserialize(input: ByteArray?): Point {
             if (input == null) {
                 throw DeserializationError("Cannot deserialize null array")
             }
@@ -190,19 +167,73 @@ data class HttpHeader(
 <!-- generated:typescript:start -->
 
 ```typescript
-export class HttpHeader {
-    constructor (public name: str, public value: str) {
+type float64 = number;
+
+export class Point {
+    constructor (public x: float64, public y: float64) {
     }
 
     public serialize(serializer: Serializer): void {
-        serializer.serializeStr(this.name);
-        serializer.serializeStr(this.value);
+        serializer.serializeF64(this.x);
+        serializer.serializeF64(this.y);
     }
 
-    static deserialize(deserializer: Deserializer): HttpHeader {
-        const name = deserializer.deserializeStr();
-        const value = deserializer.deserializeStr();
-        return new HttpHeader(name,value);
+    static deserialize(deserializer: Deserializer): Point {
+        const x = deserializer.deserializeF64();
+        const y = deserializer.deserializeF64();
+        return new Point(x,y);
+    }
+}
+
+export type Shape =
+    | { kind: "Circle"; centre: Point; radius: float64 }
+    | { kind: "Rectangle"; position: Point; width: float64; height: float64 };
+
+export const shapeCircle = (centre: Point, radius: float64): Shape => ({ kind: "Circle", centre, radius });
+
+export const shapeRectangle = (position: Point, width: float64, height: float64): Shape => ({ kind: "Rectangle", position, width, height });
+
+export function matchShape<R>(value: Shape, cases: {
+    Circle: (v: Extract<Shape, { kind: "Circle" }>) => R;
+    Rectangle: (v: Extract<Shape, { kind: "Rectangle" }>) => R;
+}): R {
+    return cases[value.kind as Shape["kind"]](value as never);
+}
+
+export function serializeShape(value: Shape, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Circle": {
+            serializer.serializeVariantIndex(0);
+            value.centre.serialize(serializer);
+            serializer.serializeF64(value.radius);
+            break;
+        }
+        case "Rectangle": {
+            serializer.serializeVariantIndex(1);
+            value.position.serialize(serializer);
+            serializer.serializeF64(value.width);
+            serializer.serializeF64(value.height);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeShape(deserializer: Deserializer): Shape {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const centre = Point.deserialize(deserializer);
+            const radius = deserializer.deserializeF64();
+            return { kind: "Circle", centre, radius };
+        }
+        case 1: {
+            const position = Point.deserialize(deserializer);
+            const width = deserializer.deserializeF64();
+            const height = deserializer.deserializeF64();
+            return { kind: "Rectangle", position, width, height };
+        }
+        default: throw new Error("Unknown variant index for Shape: " + index);
     }
 }
 ```
@@ -214,29 +245,29 @@ export class HttpHeader {
 <!-- generated:csharp:start -->
 
 ```csharp
-public partial class HttpHeader : ObservableObject, IFacetSerializable, IFacetDeserializable<HttpHeader> {
+public partial class Point : ObservableObject, IFacetSerializable, IFacetDeserializable<Point> {
     [ObservableProperty]
-    private string _name;
+    private double _x;
     [ObservableProperty]
-    private string _value;
+    private double _y;
 
     public void Serialize(ISerializer serializer)
     {
         serializer.IncreaseContainerDepth();
-        serializer.SerializeStr(Name);
-        serializer.SerializeStr(Value);
+        serializer.SerializeF64(X);
+        serializer.SerializeF64(Y);
         serializer.DecreaseContainerDepth();
     }
 
-    public static HttpHeader Deserialize(IDeserializer deserializer)
+    public static Point Deserialize(IDeserializer deserializer)
     {
         deserializer.IncreaseContainerDepth();
-        var name = deserializer.DeserializeStr();
-        var value = deserializer.DeserializeStr();
+        var x = deserializer.DeserializeF64();
+        var y = deserializer.DeserializeF64();
         deserializer.DecreaseContainerDepth();
-        return new HttpHeader {
-            Name = name,
-            Value = value,
+        return new Point {
+            X = x,
+            Y = y,
         };
     }
 
@@ -247,7 +278,7 @@ public partial class HttpHeader : ObservableObject, IFacetSerializable, IFacetDe
         return serializer.GetBytes();
     }
 
-    public static HttpHeader BincodeDeserialize(byte[] input)
+    public static Point BincodeDeserialize(byte[] input)
     {
         if (input is null)
         {

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ csharp::Installer::new("Example", &out_dir)
     .generate(&registry)?;
 ```
 
-With `BincodePlugin`, structs gain `serialize`/`deserialize` methods and enums gain standalone `serializeX`/`deserializeX` functions alongside a discriminated union type, per-variant constructor functions, and an exhaustive `matchX` helper. The examples below show the complete output for `Point` (struct) and `Shape` (enum). Swift, Kotlin, and C# show `Point` only; TypeScript shows the full generated module for both types.
+With `BincodePlugin`, structs gain `serialize`/`deserialize` methods and enums gain standalone `serializeX`/`deserializeX` functions alongside a discriminated union type, per-variant constructor functions, and an exhaustive `matchX` helper. The examples below show the full generated module for both `Point` (struct) and `Shape` (enum) in each language.
 
 > [!NOTE]
 > The code blocks below are generated from the real output of the code
@@ -65,7 +65,8 @@ With `BincodePlugin`, structs gain `serialize`/`deserialize` methods and enums g
 > (`crates/facet_generate/tests/readme.rs`). Do not edit them by hand — run
 > `UPDATE_EXPECT=1 cargo test -p facet_generate --test readme` to refresh them.
 
-### Swift
+<details>
+<summary>Swift</summary>
 
 <!-- generated:swift:start -->
 
@@ -109,11 +110,69 @@ public struct Point: Hashable, Equatable {
         return obj
     }
 }
+
+indirect public enum Shape: Hashable, Equatable {
+    case circle(centre: Point, radius: Double)
+    case rectangle(position: Point, width: Double, height: Double)
+
+    public func serialize<S: Serializer>(serializer: S) throws {
+        try serializer.increase_container_depth()
+        switch self {
+        case .circle(let centre, let radius):
+            try serializer.serialize_variant_index(value: 0)
+            try centre.serialize(serializer: serializer)
+            try serializer.serialize_f64(value: radius)
+        case .rectangle(let position, let width, let height):
+            try serializer.serialize_variant_index(value: 1)
+            try position.serialize(serializer: serializer)
+            try serializer.serialize_f64(value: width)
+            try serializer.serialize_f64(value: height)
+        }
+        try serializer.decrease_container_depth()
+    }
+
+    public func bincodeSerialize() throws -> [UInt8] {
+        let serializer = BincodeSerializer.init();
+        try self.serialize(serializer: serializer)
+        return serializer.get_bytes()
+    }
+
+    public static func deserialize<D: Deserializer>(deserializer: D) throws -> Shape {
+        let index = try deserializer.deserialize_variant_index()
+        try deserializer.increase_container_depth()
+        switch index {
+        case 0:
+            let centre = try Point.deserialize(deserializer: deserializer)
+            let radius = try deserializer.deserialize_f64()
+            try deserializer.decrease_container_depth()
+            return .circle(centre: centre, radius: radius)
+        case 1:
+            let position = try Point.deserialize(deserializer: deserializer)
+            let width = try deserializer.deserialize_f64()
+            let height = try deserializer.deserialize_f64()
+            try deserializer.decrease_container_depth()
+            return .rectangle(position: position, width: width, height: height)
+        default: throw DeserializationError.invalidInput(issue: "Unknown variant index for Shape: \(index)")
+        }
+    }
+
+    public static func bincodeDeserialize(input: [UInt8]) throws -> Shape {
+        let deserializer = BincodeDeserializer.init(input: input);
+        let obj = try deserialize(deserializer: deserializer)
+        if deserializer.get_buffer_offset() < input.count {
+            throw DeserializationError.invalidInput(issue: "Some input bytes were not read")
+        }
+        return obj
+    }
+}
 ```
 
 <!-- generated:swift:end -->
 
-### Kotlin
+</details>
+
+<details>
+<summary>Kotlin</summary>
 
 <!-- generated:kotlin:start -->
 
@@ -158,11 +217,98 @@ data class Point(
         }
     }
 }
+
+sealed interface Shape {
+    fun serialize(serializer: Serializer)
+
+    fun bincodeSerialize(): ByteArray {
+        val serializer = BincodeSerializer()
+        serialize(serializer)
+        return serializer.get_bytes()
+    }
+
+    data class Circle(
+        val centre: com.example.Point,
+        val radius: Double,
+    ) : Shape {
+        override fun serialize(serializer: Serializer) {
+            serializer.increase_container_depth()
+            serializer.serialize_variant_index(0)
+            centre.serialize(serializer)
+            serializer.serialize_f64(radius)
+            serializer.decrease_container_depth()
+        }
+
+        companion object {
+            fun deserialize(deserializer: Deserializer): Circle {
+                deserializer.increase_container_depth()
+                val centre = com.example.Point.deserialize(deserializer)
+                val radius = deserializer.deserialize_f64()
+                deserializer.decrease_container_depth()
+                return Circle(centre, radius)
+            }
+        }
+    }
+
+    data class Rectangle(
+        val position: com.example.Point,
+        val width: Double,
+        val height: Double,
+    ) : Shape {
+        override fun serialize(serializer: Serializer) {
+            serializer.increase_container_depth()
+            serializer.serialize_variant_index(1)
+            position.serialize(serializer)
+            serializer.serialize_f64(width)
+            serializer.serialize_f64(height)
+            serializer.decrease_container_depth()
+        }
+
+        companion object {
+            fun deserialize(deserializer: Deserializer): Rectangle {
+                deserializer.increase_container_depth()
+                val position = com.example.Point.deserialize(deserializer)
+                val width = deserializer.deserialize_f64()
+                val height = deserializer.deserialize_f64()
+                deserializer.decrease_container_depth()
+                return Rectangle(position, width, height)
+            }
+        }
+    }
+
+    companion object {
+        @Throws(DeserializationError::class)
+        fun deserialize(deserializer: Deserializer): Shape {
+            val index = deserializer.deserialize_variant_index()
+            return when (index) {
+                0 -> Circle.deserialize(deserializer)
+                1 -> Rectangle.deserialize(deserializer)
+                else -> throw DeserializationError("Unknown variant index for Shape: $index")
+            }
+        }
+
+        @Throws(DeserializationError::class)
+        fun bincodeDeserialize(input: ByteArray?): Shape {
+            if (input == null) {
+                throw DeserializationError("Cannot deserialize null array")
+            }
+            val deserializer = BincodeDeserializer(input)
+            val value = deserialize(deserializer)
+            if (deserializer.get_buffer_offset() < input.size) {
+                throw DeserializationError("Some input bytes were not read")
+            }
+            return value
+        }
+    }
+}
 ```
 
 <!-- generated:kotlin:end -->
 
-### TypeScript
+</details>
+
+<details>
+<summary>TypeScript</summary>
 
 <!-- generated:typescript:start -->
 
@@ -240,11 +386,16 @@ export function deserializeShape(deserializer: Deserializer): Shape {
 
 <!-- generated:typescript:end -->
 
-### C#
+</details>
+
+<details>
+<summary>C#</summary>
 
 <!-- generated:csharp:start -->
 
 ```csharp
+namespace Example;
+
 public partial class Point : ObservableObject, IFacetSerializable, IFacetDeserializable<Point> {
     [ObservableProperty]
     private double _x;
@@ -293,9 +444,93 @@ public partial class Point : ObservableObject, IFacetSerializable, IFacetDeseria
         return value;
     }
 }
+
+public abstract record Shape : IFacetSerializable, IFacetDeserializable<Shape> {
+    public sealed partial record Circle(Point Centre, double Radius) : Shape;
+
+    public sealed partial record Rectangle(Point Position, double Width, double Height) : Shape;
+
+    public abstract void Serialize(ISerializer serializer);
+
+    private static Shape DeserializeCircle(IDeserializer deserializer)
+    {
+        var centre = Point.Deserialize(deserializer);
+        var radius = deserializer.DeserializeF64();
+        return new Circle(centre, radius);
+    }
+
+    public sealed partial record Circle
+    {
+        public override void Serialize(ISerializer serializer)
+        {
+            serializer.IncreaseContainerDepth();
+            serializer.SerializeVariantIndex(0);
+            Centre.Serialize(serializer);
+            serializer.SerializeF64(Radius);
+            serializer.DecreaseContainerDepth();
+        }
+
+    }
+    private static Shape DeserializeRectangle(IDeserializer deserializer)
+    {
+        var position = Point.Deserialize(deserializer);
+        var width = deserializer.DeserializeF64();
+        var height = deserializer.DeserializeF64();
+        return new Rectangle(position, width, height);
+    }
+
+    public sealed partial record Rectangle
+    {
+        public override void Serialize(ISerializer serializer)
+        {
+            serializer.IncreaseContainerDepth();
+            serializer.SerializeVariantIndex(1);
+            Position.Serialize(serializer);
+            serializer.SerializeF64(Width);
+            serializer.SerializeF64(Height);
+            serializer.DecreaseContainerDepth();
+        }
+
+    }
+    public static Shape Deserialize(IDeserializer deserializer)
+    {
+        var index = deserializer.DeserializeVariantIndex();
+        return index switch
+        {
+            0 => DeserializeCircle(deserializer),
+            1 => DeserializeRectangle(deserializer),
+            _ => throw new DeserializationError("Unknown variant index for Shape: " + index),
+        }
+        ;
+    }
+
+    public byte[] BincodeSerialize()
+    {
+        var serializer = new BincodeSerializer();
+        Serialize(serializer);
+        return serializer.GetBytes();
+    }
+
+    public static Shape BincodeDeserialize(byte[] input)
+    {
+        if (input is null)
+        {
+            throw new DeserializationError("Cannot deserialize null array");
+        }
+        var deserializer = new BincodeDeserializer(input);
+        var value = Deserialize(deserializer);
+        if (deserializer.GetBufferOffset() < input.Length)
+        {
+            throw new DeserializationError("Some input bytes were not read");
+        }
+        return value;
+    }
+}
 ```
 
 <!-- generated:csharp:end -->
+
+</details>
 
 ## Facet attributes
 

--- a/crates/facet_generate/src/generation/bincode/csharp.rs
+++ b/crates/facet_generate/src/generation/bincode/csharp.rs
@@ -195,7 +195,7 @@ impl EmitterPlugin<CSharp> for BincodePlugin {
     /// - Non-unit enum → abstract `Serialize`, per-variant helpers, static `Deserialize`
     /// - Everything else → `Serialize`, `Deserialize`, `BincodeSerialize`, `BincodeDeserialize`
     fn type_body(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
-        if let ContainerFormat::Enum(variants_map, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants_map, _, _) = ctx.container.format {
             if is_all_unit_enum(ctx.container.format) {
                 return Ok(());
             }
@@ -213,7 +213,7 @@ impl EmitterPlugin<CSharp> for BincodePlugin {
 
     /// Emits the `{EnumName}Bincode` static helper class after all-unit enum declarations.
     fn after_type(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
-        if let ContainerFormat::Enum(variants_map, _) = ctx.container.format
+        if let ContainerFormat::Enum(variants_map, _, _) = ctx.container.format
             && is_all_unit_enum(ctx.container.format)
         {
             writeln!(w)?;
@@ -230,7 +230,7 @@ impl EmitterPlugin<CSharp> for BincodePlugin {
 /// Returns `true` when every variant of the given `ContainerFormat::Enum` is
 /// [`VariantFormat::Unit`] (i.e. this is a C-style enum).
 fn is_all_unit_enum(format: &ContainerFormat) -> bool {
-    if let ContainerFormat::Enum(variants, _) = format {
+    if let ContainerFormat::Enum(variants, _, _) = format {
         variants
             .values()
             .all(|v| matches!(v.value, VariantFormat::Unit))
@@ -1075,7 +1075,7 @@ mod tests {
         indent::{IndentConfig, IndentedWriter},
         plugin::EmitContext,
     };
-    use crate::reflection::format::{ContainerFormat, Doc, QualifiedTypeName};
+    use crate::reflection::format::{ContainerFormat, Doc, EnumTagging, QualifiedTypeName};
 
     fn render(f: impl FnOnce(&mut dyn IndentWrite) -> io::Result<()>) -> String {
         let mut buf = Vec::new();
@@ -1133,7 +1133,7 @@ mod tests {
         variants.insert(0u32, Named::new(&VariantFormat::Unit, "A".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -1170,7 +1170,7 @@ mod tests {
         variants.insert(0u32, Named::new(&VariantFormat::Unit, "A".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -1226,7 +1226,7 @@ mod tests {
         variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/bincode/kotlin.rs
+++ b/crates/facet_generate/src/generation/bincode/kotlin.rs
@@ -850,7 +850,7 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
             return Ok(());
         }
 
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format {
             let all_unit = variants
                 .values()
                 .all(|v| matches!(v.value, VariantFormat::Unit));
@@ -911,7 +911,7 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
         }
 
         // ---- Top-level enum (enum class / sealed interface) ----
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format {
             let all_unit = variants
                 .values()
                 .all(|v| matches!(v.value, VariantFormat::Unit));
@@ -947,6 +947,7 @@ impl EmitterPlugin<Kotlin> for BincodePlugin {
 mod tests {
     use super::*;
     use crate::generation::CodeGeneratorConfig;
+    use crate::reflection::format::EnumTagging;
     use std::collections::BTreeSet;
 
     fn make_config(features: &[Feature]) -> CodeGeneratorConfig {
@@ -1042,7 +1043,7 @@ mod tests {
             },
         );
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -1081,7 +1082,7 @@ mod tests {
             },
         );
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -1185,7 +1186,7 @@ mod tests {
             },
         );
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/bincode/swift.rs
+++ b/crates/facet_generate/src/generation/bincode/swift.rs
@@ -266,7 +266,7 @@ impl EmitterPlugin<Swift> for BincodePlugin {
 
     fn type_body(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
         let name = ctx.name();
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format {
             write_enum_type_body(w, name, variants)
         } else {
             write_struct_type_body(w, name, &ctx.fields())
@@ -751,6 +751,7 @@ mod tests {
     use super::*;
     use crate::generation::CodeGeneratorConfig;
     use crate::generation::indent::IndentedWriter;
+    use crate::reflection::format::EnumTagging;
     use std::collections::BTreeSet;
 
     fn make_config(features: &[Feature]) -> CodeGeneratorConfig {
@@ -955,7 +956,7 @@ mod tests {
             },
         );
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/bincode/typescript.rs
+++ b/crates/facet_generate/src/generation/bincode/typescript.rs
@@ -300,7 +300,7 @@ impl EmitterPlugin<TypeScript> for BincodePlugin {
             write_variant_type_body(w, variant)
         } else {
             match ctx.container.format {
-                ContainerFormat::Enum(variants, _) => write_enum_type_body(w, ctx.name(), variants),
+                ContainerFormat::Enum(variants, _, _) => write_enum_type_body(w, ctx.name(), variants),
                 _ => write_struct_type_body(w, ctx.name(), &ctx.fields()),
             }
         }
@@ -745,7 +745,7 @@ mod tests {
         indent::{IndentConfig, IndentedWriter},
         plugin::EmitContext,
     };
-    use crate::reflection::format::{ContainerFormat, Doc, QualifiedTypeName};
+    use crate::reflection::format::{ContainerFormat, Doc, EnumTagging, QualifiedTypeName};
 
     fn make_config(features: &[Feature]) -> CodeGeneratorConfig {
         let mut cfg = CodeGeneratorConfig::new("test".to_string());
@@ -926,7 +926,7 @@ mod tests {
         variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -973,7 +973,7 @@ mod tests {
         );
 
         let name = QualifiedTypeName::root("Result".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/bincode/typescript.rs
+++ b/crates/facet_generate/src/generation/bincode/typescript.rs
@@ -508,7 +508,8 @@ fn write_deserialize_variant_return(
             for (i, f) in formats.iter().enumerate() {
                 write_deserialize(w, Some(&format!("field{i}")), f, config)?;
             }
-            let field_names: Vec<String> = (0..formats.len()).map(|i| format!("field{i}")).collect();
+            let field_names: Vec<String> =
+                (0..formats.len()).map(|i| format!("field{i}")).collect();
             let all_parts: Vec<String> =
                 std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
                     .chain(field_names)
@@ -586,7 +587,9 @@ fn write_serialize(
                 w,
                 "serializeOption({value_expr}, serializer, (value, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "value", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Seq(inner) => {
@@ -594,7 +597,9 @@ fn write_serialize(
                 w,
                 "serializeArray({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "item", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Set(inner) => {
@@ -602,7 +607,9 @@ fn write_serialize(
                 w,
                 "serializeSet({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "item", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Map { key, value } => {
@@ -776,7 +783,9 @@ fn write_deserialize(
                     "return deserializeOption(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -792,7 +801,9 @@ fn write_deserialize(
                     "return deserializeArray(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -805,7 +816,9 @@ fn write_deserialize(
             } else {
                 write!(w, "return deserializeSet(deserializer, (deserializer) => ")?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -820,7 +833,11 @@ fn write_deserialize(
             }
             with_block(w, Newlines::OPEN, |w| {
                 if is_primitive_or_named(key) {
-                    writeln!(w, "const key = {};", deserialize_primitive_expr(key, config))?;
+                    writeln!(
+                        w,
+                        "const key = {};",
+                        deserialize_primitive_expr(key, config)
+                    )?;
                 } else {
                     write_deserialize(w, Some("key"), key, config)?;
                 }
@@ -1086,7 +1103,10 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(out.is_empty(), "type_body for enum should emit nothing, got:\n{out}");
+        assert!(
+            out.is_empty(),
+            "type_body for enum should emit nothing, got:\n{out}"
+        );
     }
 
     #[test]
@@ -1109,7 +1129,9 @@ mod tests {
 
         let out = render(|w| plugin.after_type(w, &ctx));
         assert!(
-            out.contains("export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"),
+            out.contains(
+                "export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"
+            ),
             "{out}"
         );
         assert!(
@@ -1140,6 +1162,9 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.after_type(w, &ctx));
-        assert!(out.is_empty(), "after_type for struct should emit nothing, got:\n{out}");
+        assert!(
+            out.is_empty(),
+            "after_type for struct should emit nothing, got:\n{out}"
+        );
     }
 }

--- a/crates/facet_generate/src/generation/bincode/typescript.rs
+++ b/crates/facet_generate/src/generation/bincode/typescript.rs
@@ -26,10 +26,10 @@ use heck::ToUpperCamelCase;
 use crate::generation::{
     CodeGeneratorConfig, Feature, PackageLocation, SERDE_NAMESPACE,
     indent::{IndentWrite, Newlines, with_block},
-    plugin::{EmitContext, EmitterPlugin, RuntimeFile, VariantInfo},
+    plugin::{EmitContext, EmitterPlugin, RuntimeFile},
     typescript::TypeScript,
 };
-use crate::reflection::format::{ContainerFormat, Format, Named, VariantFormat};
+use crate::reflection::format::{ContainerFormat, EnumTagging, Format, Named, VariantFormat};
 
 use super::BincodePlugin;
 
@@ -296,14 +296,18 @@ impl EmitterPlugin<TypeScript> for BincodePlugin {
     }
 
     fn type_body(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
-        if let Some(variant) = &ctx.variant {
-            write_variant_type_body(w, variant)
-        } else {
-            match ctx.container.format {
-                ContainerFormat::Enum(variants, _, _) => write_enum_type_body(w, ctx.name(), variants),
-                _ => write_struct_type_body(w, ctx.name(), &ctx.fields()),
-            }
+        if matches!(ctx.container.format, ContainerFormat::Enum(_, _, _)) {
+            // Enums are union types; serialize/deserialize are emitted via after_type
+            return Ok(());
         }
+        write_struct_type_body(w, ctx.name(), &ctx.fields(), ctx.config)
+    }
+
+    fn after_type(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
+        if let ContainerFormat::Enum(variants, tagging, _) = ctx.container.format {
+            write_enum_standalone_functions(w, ctx.name(), variants, tagging, ctx.config)?;
+        }
+        Ok(())
     }
 }
 
@@ -316,12 +320,13 @@ fn write_struct_type_body(
     w: &mut dyn IndentWrite,
     name: &str,
     fields: &[Named<Format>],
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
     writeln!(w)?;
     write!(w, "public serialize(serializer: Serializer): void ")?;
     with_block(w, Newlines::BOTH, |w| {
         for field in fields {
-            write_serialize(w, &format!("this.{}", field.name), &field.value)?;
+            write_serialize(w, &format!("this.{}", field.name), &field.value, config)?;
         }
         Ok(())
     })?;
@@ -329,7 +334,7 @@ fn write_struct_type_body(
     write!(w, "static deserialize(deserializer: Deserializer): {name} ")?;
     with_block(w, Newlines::BOTH, |w| {
         for field in fields {
-            write_deserialize(w, Some(&field.name), &field.value)?;
+            write_deserialize(w, Some(&field.name), &field.value, config)?;
         }
         writeln!(
             w,
@@ -344,66 +349,63 @@ fn write_struct_type_body(
     Ok(())
 }
 
-/// Emit `serialize` (with variant index) / `load` for an enum variant subclass.
-fn write_variant_type_body(w: &mut dyn IndentWrite, variant: &VariantInfo<'_>) -> io::Result<()> {
-    let name = variant.name;
-    let index = variant.index;
-    let parent_name = variant.parent_name;
-    let base_variant_name = format!("{parent_name}Variant");
-    let fields = variant.fields;
-
-    writeln!(w)?;
-    write!(w, "public serialize(serializer: Serializer): void ")?;
-    with_block(w, Newlines::BOTH, |w| {
-        writeln!(w, "serializer.serializeVariantIndex({index});")?;
-        for field in fields {
-            write_serialize(w, &format!("this.{}", field.name), &field.value)?;
-        }
-        Ok(())
-    })?;
-    writeln!(w)?;
-    write!(
-        w,
-        "static load(deserializer: Deserializer): {base_variant_name}{name} "
-    )?;
-    with_block(w, Newlines::BOTH, |w| {
-        for field in fields {
-            write_deserialize(w, Some(&field.name), &field.value)?;
-        }
-        writeln!(
-            w,
-            "return new {base_variant_name}{name}({args});",
-            args = fields
-                .iter()
-                .map(|f| f.name.clone())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
-    })?;
-    Ok(())
-}
-
-/// Emit the abstract class body for an enum: `abstract serialize` declaration
-/// plus a `static deserialize` switch dispatch.
-fn write_enum_type_body(
+/// Emit standalone `export function serialize{Name}` and `export function deserialize{Name}`.
+fn write_enum_standalone_functions(
     w: &mut dyn IndentWrite,
     name: &str,
     variants: &BTreeMap<u32, Named<VariantFormat>>,
+    tagging: &EnumTagging,
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
-    // The trailing `\n` in the format string creates the blank line between
-    // the abstract declaration and the static deserialize method.
-    writeln!(w, "abstract serialize(serializer: Serializer): void;\n")?;
-    write!(w, "static deserialize(deserializer: Deserializer): {name} ")?;
+    let tag_field = match tagging {
+        EnumTagging::External => "kind",
+        EnumTagging::Internal { tag } | EnumTagging::Adjacent { tag, .. } => tag.as_str(),
+    };
+
+    writeln!(w)?;
+    write!(
+        w,
+        "export function serialize{name}(value: {name}, serializer: Serializer): void "
+    )?;
+    with_block(w, Newlines::BOTH, |w| {
+        write!(w, "switch (value.{tag_field}) ")?;
+        with_block(w, Newlines::BOTH, |w| {
+            for (index, variant) in variants {
+                let vname = &variant.name;
+                write!(w, r#"case "{vname}": "#)?;
+                with_block(w, Newlines::BOTH, |w| {
+                    writeln!(w, "serializer.serializeVariantIndex({index});")?;
+                    write_serialize_variant_fields(w, tagging, &variant.value, config)?;
+                    writeln!(w, "break;")
+                })?;
+            }
+            writeln!(
+                w,
+                r#"default: throw new Error("Unknown variant: " + (value as any).{tag_field});"#
+            )
+        })
+    })?;
+
+    writeln!(w)?;
+    write!(
+        w,
+        "export function deserialize{name}(deserializer: Deserializer): {name} "
+    )?;
     with_block(w, Newlines::BOTH, |w| {
         writeln!(w, "const index = deserializer.deserializeVariantIndex();")?;
         write!(w, "switch (index) ")?;
         with_block(w, Newlines::BOTH, |w| {
             for (index, variant) in variants {
-                writeln!(
-                    w,
-                    "case {index}: return {name}Variant{vname}.load(deserializer);",
-                    vname = variant.name
-                )?;
+                write!(w, "case {index}: ")?;
+                with_block(w, Newlines::BOTH, |w| {
+                    write_deserialize_variant_return(
+                        w,
+                        &variant.name,
+                        tagging,
+                        &variant.value,
+                        config,
+                    )
+                })?;
             }
             writeln!(
                 w,
@@ -411,16 +413,156 @@ fn write_enum_type_body(
             )
         })
     })?;
+
     Ok(())
+}
+
+/// Emit serialize statements for a single variant's payload fields.
+fn write_serialize_variant_fields(
+    w: &mut dyn IndentWrite,
+    tagging: &EnumTagging,
+    variant: &VariantFormat,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
+    match (tagging, variant) {
+        (_, VariantFormat::Unit) => Ok(()),
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::NewType(format)) => {
+            write_serialize(w, &format!("value.{content}"), format, config)
+        }
+        (_, VariantFormat::NewType(format)) => write_serialize(w, "value.value", format, config),
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_serialize(w, &format!("value.{content}[{i}]"), f, config)?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_serialize(w, &format!("value.field{i}"), f, config)?;
+            }
+            Ok(())
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_serialize(
+                    w,
+                    &format!("value.{content}.{}", field.name),
+                    &field.value,
+                    config,
+                )?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_serialize(w, &format!("value.{}", field.name), &field.value, config)?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Variable(_)) => panic!("unexpected variable in variant fields"),
+    }
+}
+
+/// Emit deserialize statements and a `return { ... }` for a single variant.
+fn write_deserialize_variant_return(
+    w: &mut dyn IndentWrite,
+    variant_name: &str,
+    tagging: &EnumTagging,
+    variant: &VariantFormat,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
+    let tag_field = match tagging {
+        EnumTagging::External => "kind",
+        EnumTagging::Internal { tag } | EnumTagging::Adjacent { tag, .. } => tag.as_str(),
+    };
+
+    match (tagging, variant) {
+        (_, VariantFormat::Unit) => {
+            writeln!(w, r#"return {{ {tag_field}: "{variant_name}" }};"#)
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::NewType(format)) => {
+            write_deserialize(w, Some("inner"), format, config)?;
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: inner }};"#
+            )
+        }
+        (_, VariantFormat::NewType(format)) => {
+            write_deserialize(w, Some("value"), format, config)?;
+            writeln!(w, r#"return {{ {tag_field}: "{variant_name}", value }};"#)
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
+            }
+            let fields_joined = (0..formats.len())
+                .map(|i| format!("field{i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: [{fields_joined}] }};"#
+            )
+        }
+        (_, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
+            }
+            let field_names: Vec<String> = (0..formats.len()).map(|i| format!("field{i}")).collect();
+            let all_parts: Vec<String> =
+                std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
+                    .chain(field_names)
+                    .collect();
+            writeln!(w, "return {{ {} }};", all_parts.join(", "))
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_deserialize(w, Some(&field.name), &field.value, config)?;
+            }
+            let struct_fields = fields
+                .iter()
+                .map(|f| f.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: {{ {struct_fields} }} }};"#
+            )
+        }
+        (_, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_deserialize(w, Some(&field.name), &field.value, config)?;
+            }
+            let field_names: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
+            let all_parts: Vec<String> =
+                std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
+                    .chain(field_names)
+                    .collect();
+            writeln!(w, "return {{ {} }};", all_parts.join(", "))
+        }
+        (_, VariantFormat::Variable(_)) => panic!("unexpected variable in variant return"),
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Serialize helpers
 // ---------------------------------------------------------------------------
 
-fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -> io::Result<()> {
+fn write_serialize(
+    w: &mut dyn IndentWrite,
+    value_expr: &str,
+    format: &Format,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
     match format {
-        Format::TypeName(_) => writeln!(w, "{value_expr}.serialize(serializer);"),
+        Format::TypeName(qualified_name) => {
+            let type_name = qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".");
+            if config.enum_type_names.contains(&type_name) {
+                writeln!(w, "serialize{type_name}({value_expr}, serializer);")
+            } else {
+                writeln!(w, "{value_expr}.serialize(serializer);")
+            }
+        }
         Format::Unit => writeln!(w, "serializer.serializeUnit({value_expr});"),
         Format::Bool => writeln!(w, "serializer.serializeBool({value_expr});"),
         Format::I8 => writeln!(w, "serializer.serializeI8({value_expr});"),
@@ -444,7 +586,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeOption({value_expr}, serializer, (value, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner, config))?;
             writeln!(w, ");")
         }
         Format::Seq(inner) => {
@@ -452,7 +594,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeArray({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
             writeln!(w, ");")
         }
         Format::Set(inner) => {
@@ -460,7 +602,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeSet({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
             writeln!(w, ");")
         }
         Format::Map { key, value } => {
@@ -469,14 +611,14 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 "serializeMap({value_expr}, serializer, (key, value, serializer) => "
             )?;
             with_block(w, Newlines::OPEN, |w| {
-                write_serialize(w, "key", key)?;
-                write_serialize(w, "value", value)
+                write_serialize(w, "key", key, config)?;
+                write_serialize(w, "value", value, config)
             })?;
             writeln!(w, ");")
         }
         Format::Tuple(formats) => {
             for (i, fmt) in formats.iter().enumerate() {
-                write_serialize(w, &format!("{value_expr}[{i}]"), fmt)?;
+                write_serialize(w, &format!("{value_expr}[{i}]"), fmt, config)?;
             }
             Ok(())
         }
@@ -486,7 +628,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 "serializeTupleArray({value_expr}, serializer, (item, serializer) => "
             )?;
             with_block(w, Newlines::OPEN, |w| {
-                write_serialize(w, "item[0]", content)
+                write_serialize(w, "item[0]", content, config)
             })?;
             writeln!(w, ");")
         }
@@ -542,12 +684,16 @@ fn quote_type(format: &Format) -> String {
 }
 
 /// Returns the deserialize expression for a primitive or named type.
-fn deserialize_primitive_expr(format: &Format) -> String {
+fn deserialize_primitive_expr(format: &Format, config: &CodeGeneratorConfig) -> String {
     match format {
-        Format::TypeName(qualified_name) => format!(
-            "{}.deserialize(deserializer)",
-            qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".")
-        ),
+        Format::TypeName(qualified_name) => {
+            let type_name = qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".");
+            if config.enum_type_names.contains(&type_name) {
+                format!("deserialize{type_name}(deserializer)")
+            } else {
+                format!("{type_name}.deserialize(deserializer)")
+            }
+        }
         Format::Unit => "deserializer.deserializeUnit()".to_string(),
         Format::Bool => "deserializer.deserializeBool()".to_string(),
         Format::I8 => "deserializer.deserializeI8()".to_string(),
@@ -605,11 +751,12 @@ fn write_deserialize(
     w: &mut dyn IndentWrite,
     field_name: Option<&str>,
     format: &Format,
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
     match format {
         // Primitive and named types — simple single-expression form.
         f if is_primitive_or_named(f) => {
-            let expr = deserialize_primitive_expr(f);
+            let expr = deserialize_primitive_expr(f, config);
             if let Some(name) = field_name {
                 writeln!(w, "const {name} = {expr};")
             } else {
@@ -629,7 +776,7 @@ fn write_deserialize(
                     "return deserializeOption(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -645,7 +792,7 @@ fn write_deserialize(
                     "return deserializeArray(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -658,7 +805,7 @@ fn write_deserialize(
             } else {
                 write!(w, "return deserializeSet(deserializer, (deserializer) => ")?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -673,14 +820,18 @@ fn write_deserialize(
             }
             with_block(w, Newlines::OPEN, |w| {
                 if is_primitive_or_named(key) {
-                    writeln!(w, "const key = {};", deserialize_primitive_expr(key))?;
+                    writeln!(w, "const key = {};", deserialize_primitive_expr(key, config))?;
                 } else {
-                    write_deserialize(w, Some("key"), key)?;
+                    write_deserialize(w, Some("key"), key, config)?;
                 }
                 if is_primitive_or_named(value) {
-                    writeln!(w, "const value = {};", deserialize_primitive_expr(value))?;
+                    writeln!(
+                        w,
+                        "const value = {};",
+                        deserialize_primitive_expr(value, config)
+                    )?;
                 } else {
-                    write_deserialize(w, Some("value"), value)?;
+                    write_deserialize(w, Some("value"), value, config)?;
                 }
                 writeln!(w, "return [key, value];")
             })?;
@@ -689,7 +840,7 @@ fn write_deserialize(
 
         Format::Tuple(formats) => {
             for (i, f) in formats.iter().enumerate() {
-                write_deserialize(w, Some(&format!("field{i}")), f)?;
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
             }
             let fields_joined = (0..formats.len())
                 .map(|i| format!("field{i}"))
@@ -720,7 +871,7 @@ fn write_deserialize(
                 )?;
             }
             with_block(w, Newlines::OPEN, |w| {
-                write_deserialize(w, Some("item"), content)?;
+                write_deserialize(w, Some("item"), content, config)?;
                 writeln!(w, "return [item];")
             })?;
             writeln!(w, ");")
@@ -913,11 +1064,11 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // type_body — enum / variant shapes
+    // type_body + after_type — enum shapes
     // -------------------------------------------------------------------------
 
     #[test]
-    fn type_body_enum_with_variants() {
+    fn type_body_enum_emits_nothing() {
         use crate::reflection::format::VariantFormat;
         let plugin = &BincodePlugin as &dyn EmitterPlugin<TypeScript>;
 
@@ -935,73 +1086,60 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(
-            out.contains("abstract serialize(serializer: Serializer): void;"),
-            "{out}"
-        );
-        assert!(
-            out.contains("static deserialize(deserializer: Deserializer): MyEnum"),
-            "{out}"
-        );
-        assert!(
-            out.contains("deserializer.deserializeVariantIndex()"),
-            "{out}"
-        );
-        assert!(
-            out.contains("case 0: return MyEnumVariantAlpha.load(deserializer);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("case 1: return MyEnumVariantBeta.load(deserializer);"),
-            "{out}"
-        );
+        assert!(out.is_empty(), "type_body for enum should emit nothing, got:\n{out}");
     }
 
     #[test]
-    fn type_body_variant_subclass() {
-        use crate::reflection::format::{Format, VariantFormat};
+    fn after_type_enum_emits_standalone_functions() {
+        use crate::reflection::format::VariantFormat;
         let plugin = &BincodePlugin as &dyn EmitterPlugin<TypeScript>;
 
         let mut variants = BTreeMap::new();
-        let variant_fields = vec![Named::new(&Format::Str, "value".to_string())];
-        variants.insert(
-            0u32,
-            Named::new(
-                &VariantFormat::Struct(variant_fields.clone()),
-                "Ok".to_string(),
-            ),
-        );
+        variants.insert(0u32, Named::new(&VariantFormat::Unit, "Alpha".to_string()));
+        variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
-        let name = QualifiedTypeName::root("Result".to_string());
+        let name = QualifiedTypeName::root("MyEnum".to_string());
         let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
         };
+        let config = CodeGeneratorConfig::new("test".to_string());
+        let ctx = EmitContext::top_level(&container, &config);
 
-        let variant_info = crate::generation::plugin::VariantInfo {
-            name: "Ok",
-            index: 0,
-            format: &VariantFormat::Struct(variant_fields.clone()),
-            fields: &variant_fields,
-            parent_name: "Result",
+        let out = render(|w| plugin.after_type(w, &ctx));
+        assert!(
+            out.contains("export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"),
+            "{out}"
+        );
+        assert!(
+            out.contains("export function deserializeMyEnum(deserializer: Deserializer): MyEnum"),
+            "{out}"
+        );
+        assert!(out.contains(r#"case "Alpha":"#), "{out}");
+        assert!(out.contains(r#"case "Beta":"#), "{out}");
+        assert!(
+            out.contains("deserializer.deserializeVariantIndex()"),
+            "{out}"
+        );
+        assert!(out.contains("case 0:"), "{out}");
+        assert!(out.contains("case 1:"), "{out}");
+    }
+
+    #[test]
+    fn after_type_struct_emits_nothing() {
+        let plugin = &BincodePlugin as &dyn EmitterPlugin<TypeScript>;
+
+        let name = QualifiedTypeName::root("Foo".to_string());
+        let format = ContainerFormat::Struct(vec![], Doc::default());
+        let container = Container {
+            name: &name,
+            format: &format,
         };
         let config = CodeGeneratorConfig::new("test".to_string());
-        let ctx = EmitContext::for_variant(&container, &config, variant_info);
+        let ctx = EmitContext::top_level(&container, &config);
 
-        let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(
-            out.contains("serializer.serializeVariantIndex(0);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("serializer.serializeStr(this.value);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("static load(deserializer: Deserializer): ResultVariantOk"),
-            "{out}"
-        );
-        assert!(out.contains("return new ResultVariantOk(value);"), "{out}");
+        let out = render(|w| plugin.after_type(w, &ctx));
+        assert!(out.is_empty(), "after_type for struct should emit nothing, got:\n{out}");
     }
 }

--- a/crates/facet_generate/src/generation/config.rs
+++ b/crates/facet_generate/src/generation/config.rs
@@ -284,7 +284,7 @@ impl CodeGeneratorConfig {
                 entry.push(name.name.clone());
             }
 
-            if let ContainerFormat::Enum(variants, _) = format
+            if let ContainerFormat::Enum(variants, _, _) = format
                 && variants
                     .values()
                     .all(|v| matches!(v.value, VariantFormat::Unit))

--- a/crates/facet_generate/src/generation/config.rs
+++ b/crates/facet_generate/src/generation/config.rs
@@ -61,6 +61,11 @@ pub struct CodeGeneratorConfig {
     /// Populated by `update_from`. Used by the C# Bincode plugin to dispatch
     /// enum-typed fields through `{TypeName}Bincode.Serialize(...)` helpers.
     pub unit_variant_enums: BTreeSet<String>,
+    /// Names of all enum types in the registry.
+    /// Populated by `update_from`. Used by TypeScript bincode/json plugins to
+    /// branch `Format::TypeName` serialization: enums use standalone
+    /// `serializeX(value, serializer)` functions while structs use `.serialize(serializer)`.
+    pub enum_type_names: BTreeSet<String>,
 }
 
 /// Container or leaf types in the registry that need a runtime support file
@@ -143,6 +148,7 @@ impl CodeGeneratorConfig {
             used_format_types: BTreeSet::new(),
             referenced_namespaces: BTreeSet::new(),
             unit_variant_enums: BTreeSet::new(),
+            enum_type_names: BTreeSet::new(),
             indent: IndentConfig::Space(4),
         }
     }
@@ -284,12 +290,14 @@ impl CodeGeneratorConfig {
                 entry.push(name.name.clone());
             }
 
-            if let ContainerFormat::Enum(variants, _, _) = format
-                && variants
+            if let ContainerFormat::Enum(variants, _, _) = format {
+                self.enum_type_names.insert(name.name.clone());
+                if variants
                     .values()
                     .all(|v| matches!(v.value, VariantFormat::Unit))
-            {
-                self.unit_variant_enums.insert(name.name.clone());
+                {
+                    self.unit_variant_enums.insert(name.name.clone());
+                }
             }
         }
     }

--- a/crates/facet_generate/src/generation/csharp/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/csharp/emitter/mod.rs
@@ -176,7 +176,7 @@ impl Emitter<CSharp> for Container<'_> {
                     write_class(w, self, name, fields, doc, lang)
                 }
             }
-            ContainerFormat::Enum(variants, doc) => {
+            ContainerFormat::Enum(variants, _, doc) => {
                 let all_unit_variants = variants
                     .values()
                     .all(|variant| matches!(variant.value, VariantFormat::Unit));

--- a/crates/facet_generate/src/generation/json/csharp.rs
+++ b/crates/facet_generate/src/generation/json/csharp.rs
@@ -96,7 +96,7 @@ impl EmitterPlugin<CSharp> for JsonPlugin {
     /// - Everything else → nothing
     fn type_annotations(&self, ctx: &EmitContext) -> Vec<String> {
         match ctx.container.format {
-            ContainerFormat::Enum(variants, _) => {
+            ContainerFormat::Enum(variants, _, _) => {
                 let all_unit = variants
                     .values()
                     .all(|v| matches!(v.value, VariantFormat::Unit));
@@ -133,7 +133,7 @@ impl EmitterPlugin<CSharp> for JsonPlugin {
     /// methods — i.e. everything except all-unit enums (plain C# `enum` types
     /// don't need instance helpers).
     fn has_type_body(&self, ctx: &EmitContext) -> bool {
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format
             && variants
                 .values()
                 .all(|v| matches!(v.value, VariantFormat::Unit))
@@ -180,7 +180,7 @@ mod tests {
         indent::{IndentConfig, IndentedWriter},
         plugin::EmitContext,
     };
-    use crate::reflection::format::{ContainerFormat, Doc, Format, Named, QualifiedTypeName};
+    use crate::reflection::format::{ContainerFormat, Doc, EnumTagging, Format, Named, QualifiedTypeName};
 
     fn render(f: impl FnOnce(&mut dyn IndentWrite) -> io::Result<()>) -> String {
         let mut buf = Vec::new();
@@ -219,7 +219,7 @@ mod tests {
         variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -256,7 +256,7 @@ mod tests {
         );
 
         let name = QualifiedTypeName::root("Result".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -370,7 +370,7 @@ mod tests {
         variants.insert(0u32, Named::new(&VariantFormat::Unit, "A".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/json/csharp.rs
+++ b/crates/facet_generate/src/generation/json/csharp.rs
@@ -180,7 +180,9 @@ mod tests {
         indent::{IndentConfig, IndentedWriter},
         plugin::EmitContext,
     };
-    use crate::reflection::format::{ContainerFormat, Doc, EnumTagging, Format, Named, QualifiedTypeName};
+    use crate::reflection::format::{
+        ContainerFormat, Doc, EnumTagging, Format, Named, QualifiedTypeName,
+    };
 
     fn render(f: impl FnOnce(&mut dyn IndentWrite) -> io::Result<()>) -> String {
         let mut buf = Vec::new();

--- a/crates/facet_generate/src/generation/json/kotlin.rs
+++ b/crates/facet_generate/src/generation/json/kotlin.rs
@@ -166,7 +166,7 @@ impl EmitterPlugin<Kotlin> for JsonPlugin {
             return Ok(());
         }
 
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format {
             let all_unit = variants
                 .values()
                 .all(|v| matches!(v.value, VariantFormat::Unit));

--- a/crates/facet_generate/src/generation/json/swift.rs
+++ b/crates/facet_generate/src/generation/json/swift.rs
@@ -254,7 +254,7 @@ impl EmitterPlugin<Swift> for JsonPlugin {
 
     fn type_body(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
         let name = ctx.name();
-        if let ContainerFormat::Enum(variants, _) = ctx.container.format {
+        if let ContainerFormat::Enum(variants, _, _) = ctx.container.format {
             write_enum_type_body(w, name, variants)
         } else {
             write_struct_type_body(w, name, &ctx.fields())
@@ -788,6 +788,7 @@ mod tests {
     use super::*;
     use crate::generation::CodeGeneratorConfig;
     use crate::generation::indent::IndentedWriter;
+    use crate::reflection::format::EnumTagging;
     use std::collections::BTreeSet;
 
     fn make_config(features: &[Feature]) -> CodeGeneratorConfig {
@@ -1003,7 +1004,7 @@ mod tests {
             },
         );
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/json/typescript.rs
+++ b/crates/facet_generate/src/generation/json/typescript.rs
@@ -467,7 +467,8 @@ fn write_deserialize_variant_return(
             for (i, f) in formats.iter().enumerate() {
                 write_deserialize(w, Some(&format!("field{i}")), f, config)?;
             }
-            let field_names: Vec<String> = (0..formats.len()).map(|i| format!("field{i}")).collect();
+            let field_names: Vec<String> =
+                (0..formats.len()).map(|i| format!("field{i}")).collect();
             let all_parts: Vec<String> =
                 std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
                     .chain(field_names)
@@ -545,7 +546,9 @@ fn write_serialize(
                 w,
                 "serializeOption({value_expr}, serializer, (value, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "value", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Seq(inner) => {
@@ -553,7 +556,9 @@ fn write_serialize(
                 w,
                 "serializeArray({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "item", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Set(inner) => {
@@ -561,7 +566,9 @@ fn write_serialize(
                 w,
                 "serializeSet({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_serialize(w, "item", inner, config)
+            })?;
             writeln!(w, ");")
         }
         Format::Map { key, value } => {
@@ -735,7 +742,9 @@ fn write_deserialize(
                     "return deserializeOption(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -751,7 +760,9 @@ fn write_deserialize(
                     "return deserializeArray(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -764,7 +775,9 @@ fn write_deserialize(
             } else {
                 write!(w, "return deserializeSet(deserializer, (deserializer) => ")?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
+            with_block(w, Newlines::OPEN, |w| {
+                write_deserialize(w, None, inner, config)
+            })?;
             writeln!(w, ");")
         }
 
@@ -779,7 +792,11 @@ fn write_deserialize(
             }
             with_block(w, Newlines::OPEN, |w| {
                 if is_primitive_or_named(key) {
-                    writeln!(w, "const key = {};", deserialize_primitive_expr(key, config))?;
+                    writeln!(
+                        w,
+                        "const key = {};",
+                        deserialize_primitive_expr(key, config)
+                    )?;
                 } else {
                     write_deserialize(w, Some("key"), key, config)?;
                 }
@@ -1045,7 +1062,10 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(out.is_empty(), "type_body for enum should emit nothing, got:\n{out}");
+        assert!(
+            out.is_empty(),
+            "type_body for enum should emit nothing, got:\n{out}"
+        );
     }
 
     #[test]
@@ -1068,7 +1088,9 @@ mod tests {
 
         let out = render(|w| plugin.after_type(w, &ctx));
         assert!(
-            out.contains("export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"),
+            out.contains(
+                "export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"
+            ),
             "{out}"
         );
         assert!(
@@ -1077,7 +1099,10 @@ mod tests {
         );
         assert!(out.contains(r#"case "Alpha":"#), "{out}");
         assert!(out.contains(r#"case "Beta":"#), "{out}");
-        assert!(out.contains("deserializer.deserializeVariantIndex()"), "{out}");
+        assert!(
+            out.contains("deserializer.deserializeVariantIndex()"),
+            "{out}"
+        );
         assert!(out.contains("case 0:"), "{out}");
         assert!(out.contains("case 1:"), "{out}");
     }
@@ -1096,6 +1121,9 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.after_type(w, &ctx));
-        assert!(out.is_empty(), "after_type for struct should emit nothing, got:\n{out}");
+        assert!(
+            out.is_empty(),
+            "after_type for struct should emit nothing, got:\n{out}"
+        );
     }
 }

--- a/crates/facet_generate/src/generation/json/typescript.rs
+++ b/crates/facet_generate/src/generation/json/typescript.rs
@@ -26,10 +26,10 @@ use heck::ToUpperCamelCase;
 use crate::generation::{
     CodeGeneratorConfig, Feature, PackageLocation, SERDE_NAMESPACE,
     indent::{IndentWrite, Newlines, with_block},
-    plugin::{EmitContext, EmitterPlugin, RuntimeFile, VariantInfo},
+    plugin::{EmitContext, EmitterPlugin, RuntimeFile},
     typescript::TypeScript,
 };
-use crate::reflection::format::{ContainerFormat, Format, Named, VariantFormat};
+use crate::reflection::format::{ContainerFormat, EnumTagging, Format, Named, VariantFormat};
 
 use super::JsonPlugin;
 
@@ -256,14 +256,17 @@ impl EmitterPlugin<TypeScript> for JsonPlugin {
     }
 
     fn type_body(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
-        if let Some(variant) = &ctx.variant {
-            write_variant_type_body(w, variant)
-        } else {
-            match ctx.container.format {
-                ContainerFormat::Enum(variants, _, _) => write_enum_type_body(w, ctx.name(), variants),
-                _ => write_struct_type_body(w, ctx.name(), &ctx.fields()),
-            }
+        if matches!(ctx.container.format, ContainerFormat::Enum(_, _, _)) {
+            return Ok(());
         }
+        write_struct_type_body(w, ctx.name(), &ctx.fields(), ctx.config)
+    }
+
+    fn after_type(&self, w: &mut dyn IndentWrite, ctx: &EmitContext) -> io::Result<()> {
+        if let ContainerFormat::Enum(variants, tagging, _) = ctx.container.format {
+            write_enum_standalone_functions(w, ctx.name(), variants, tagging, ctx.config)?;
+        }
+        Ok(())
     }
 }
 
@@ -276,12 +279,13 @@ fn write_struct_type_body(
     w: &mut dyn IndentWrite,
     name: &str,
     fields: &[Named<Format>],
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
     writeln!(w)?;
     write!(w, "public serialize(serializer: Serializer): void ")?;
     with_block(w, Newlines::BOTH, |w| {
         for field in fields {
-            write_serialize(w, &format!("this.{}", field.name), &field.value)?;
+            write_serialize(w, &format!("this.{}", field.name), &field.value, config)?;
         }
         Ok(())
     })?;
@@ -289,7 +293,7 @@ fn write_struct_type_body(
     write!(w, "static deserialize(deserializer: Deserializer): {name} ")?;
     with_block(w, Newlines::BOTH, |w| {
         for field in fields {
-            write_deserialize(w, Some(&field.name), &field.value)?;
+            write_deserialize(w, Some(&field.name), &field.value, config)?;
         }
         writeln!(
             w,
@@ -304,66 +308,63 @@ fn write_struct_type_body(
     Ok(())
 }
 
-/// Emit `serialize` (with variant index) / `load` for an enum variant subclass.
-fn write_variant_type_body(w: &mut dyn IndentWrite, variant: &VariantInfo<'_>) -> io::Result<()> {
-    let name = variant.name;
-    let index = variant.index;
-    let parent_name = variant.parent_name;
-    let base_variant_name = format!("{parent_name}Variant");
-    let fields = variant.fields;
-
-    writeln!(w)?;
-    write!(w, "public serialize(serializer: Serializer): void ")?;
-    with_block(w, Newlines::BOTH, |w| {
-        writeln!(w, "serializer.serializeVariantIndex({index});")?;
-        for field in fields {
-            write_serialize(w, &format!("this.{}", field.name), &field.value)?;
-        }
-        Ok(())
-    })?;
-    writeln!(w)?;
-    write!(
-        w,
-        "static load(deserializer: Deserializer): {base_variant_name}{name} "
-    )?;
-    with_block(w, Newlines::BOTH, |w| {
-        for field in fields {
-            write_deserialize(w, Some(&field.name), &field.value)?;
-        }
-        writeln!(
-            w,
-            "return new {base_variant_name}{name}({args});",
-            args = fields
-                .iter()
-                .map(|f| f.name.clone())
-                .collect::<Vec<_>>()
-                .join(",")
-        )
-    })?;
-    Ok(())
-}
-
-/// Emit the abstract class body for an enum: `abstract serialize` declaration
-/// plus a `static deserialize` switch dispatch.
-fn write_enum_type_body(
+/// Emit standalone `export function serialize{Name}` and `export function deserialize{Name}`.
+fn write_enum_standalone_functions(
     w: &mut dyn IndentWrite,
     name: &str,
     variants: &BTreeMap<u32, Named<VariantFormat>>,
+    tagging: &EnumTagging,
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
-    // The trailing `\n` in the format string creates the blank line between
-    // the abstract declaration and the static deserialize method.
-    writeln!(w, "abstract serialize(serializer: Serializer): void;\n")?;
-    write!(w, "static deserialize(deserializer: Deserializer): {name} ")?;
+    let tag_field = match tagging {
+        EnumTagging::External => "kind",
+        EnumTagging::Internal { tag } | EnumTagging::Adjacent { tag, .. } => tag.as_str(),
+    };
+
+    writeln!(w)?;
+    write!(
+        w,
+        "export function serialize{name}(value: {name}, serializer: Serializer): void "
+    )?;
+    with_block(w, Newlines::BOTH, |w| {
+        write!(w, "switch (value.{tag_field}) ")?;
+        with_block(w, Newlines::BOTH, |w| {
+            for (index, variant) in variants {
+                let vname = &variant.name;
+                write!(w, r#"case "{vname}": "#)?;
+                with_block(w, Newlines::BOTH, |w| {
+                    writeln!(w, "serializer.serializeVariantIndex({index});")?;
+                    write_serialize_variant_fields(w, tagging, &variant.value, config)?;
+                    writeln!(w, "break;")
+                })?;
+            }
+            writeln!(
+                w,
+                r#"default: throw new Error("Unknown variant: " + (value as any).{tag_field});"#
+            )
+        })
+    })?;
+
+    writeln!(w)?;
+    write!(
+        w,
+        "export function deserialize{name}(deserializer: Deserializer): {name} "
+    )?;
     with_block(w, Newlines::BOTH, |w| {
         writeln!(w, "const index = deserializer.deserializeVariantIndex();")?;
         write!(w, "switch (index) ")?;
         with_block(w, Newlines::BOTH, |w| {
             for (index, variant) in variants {
-                writeln!(
-                    w,
-                    "case {index}: return {name}Variant{vname}.load(deserializer);",
-                    vname = variant.name
-                )?;
+                write!(w, "case {index}: ")?;
+                with_block(w, Newlines::BOTH, |w| {
+                    write_deserialize_variant_return(
+                        w,
+                        &variant.name,
+                        tagging,
+                        &variant.value,
+                        config,
+                    )
+                })?;
             }
             writeln!(
                 w,
@@ -371,16 +372,156 @@ fn write_enum_type_body(
             )
         })
     })?;
+
     Ok(())
+}
+
+/// Emit serialize statements for a single variant's payload fields.
+fn write_serialize_variant_fields(
+    w: &mut dyn IndentWrite,
+    tagging: &EnumTagging,
+    variant: &VariantFormat,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
+    match (tagging, variant) {
+        (_, VariantFormat::Unit) => Ok(()),
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::NewType(format)) => {
+            write_serialize(w, &format!("value.{content}"), format, config)
+        }
+        (_, VariantFormat::NewType(format)) => write_serialize(w, "value.value", format, config),
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_serialize(w, &format!("value.{content}[{i}]"), f, config)?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_serialize(w, &format!("value.field{i}"), f, config)?;
+            }
+            Ok(())
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_serialize(
+                    w,
+                    &format!("value.{content}.{}", field.name),
+                    &field.value,
+                    config,
+                )?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_serialize(w, &format!("value.{}", field.name), &field.value, config)?;
+            }
+            Ok(())
+        }
+        (_, VariantFormat::Variable(_)) => panic!("unexpected variable in variant fields"),
+    }
+}
+
+/// Emit deserialize statements and a `return { ... }` for a single variant.
+fn write_deserialize_variant_return(
+    w: &mut dyn IndentWrite,
+    variant_name: &str,
+    tagging: &EnumTagging,
+    variant: &VariantFormat,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
+    let tag_field = match tagging {
+        EnumTagging::External => "kind",
+        EnumTagging::Internal { tag } | EnumTagging::Adjacent { tag, .. } => tag.as_str(),
+    };
+
+    match (tagging, variant) {
+        (_, VariantFormat::Unit) => {
+            writeln!(w, r#"return {{ {tag_field}: "{variant_name}" }};"#)
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::NewType(format)) => {
+            write_deserialize(w, Some("inner"), format, config)?;
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: inner }};"#
+            )
+        }
+        (_, VariantFormat::NewType(format)) => {
+            write_deserialize(w, Some("value"), format, config)?;
+            writeln!(w, r#"return {{ {tag_field}: "{variant_name}", value }};"#)
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
+            }
+            let fields_joined = (0..formats.len())
+                .map(|i| format!("field{i}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: [{fields_joined}] }};"#
+            )
+        }
+        (_, VariantFormat::Tuple(formats)) => {
+            for (i, f) in formats.iter().enumerate() {
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
+            }
+            let field_names: Vec<String> = (0..formats.len()).map(|i| format!("field{i}")).collect();
+            let all_parts: Vec<String> =
+                std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
+                    .chain(field_names)
+                    .collect();
+            writeln!(w, "return {{ {} }};", all_parts.join(", "))
+        }
+        (EnumTagging::Adjacent { content, .. }, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_deserialize(w, Some(&field.name), &field.value, config)?;
+            }
+            let struct_fields = fields
+                .iter()
+                .map(|f| f.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(
+                w,
+                r#"return {{ {tag_field}: "{variant_name}", {content}: {{ {struct_fields} }} }};"#
+            )
+        }
+        (_, VariantFormat::Struct(fields)) => {
+            for field in fields {
+                write_deserialize(w, Some(&field.name), &field.value, config)?;
+            }
+            let field_names: Vec<String> = fields.iter().map(|f| f.name.clone()).collect();
+            let all_parts: Vec<String> =
+                std::iter::once(format!(r#"{tag_field}: "{variant_name}""#))
+                    .chain(field_names)
+                    .collect();
+            writeln!(w, "return {{ {} }};", all_parts.join(", "))
+        }
+        (_, VariantFormat::Variable(_)) => panic!("unexpected variable in variant return"),
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Serialize helpers
 // ---------------------------------------------------------------------------
 
-fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -> io::Result<()> {
+fn write_serialize(
+    w: &mut dyn IndentWrite,
+    value_expr: &str,
+    format: &Format,
+    config: &CodeGeneratorConfig,
+) -> io::Result<()> {
     match format {
-        Format::TypeName(_) => writeln!(w, "{value_expr}.serialize(serializer);"),
+        Format::TypeName(qualified_name) => {
+            let type_name = qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".");
+            if config.enum_type_names.contains(&type_name) {
+                writeln!(w, "serialize{type_name}({value_expr}, serializer);")
+            } else {
+                writeln!(w, "{value_expr}.serialize(serializer);")
+            }
+        }
         Format::Unit => writeln!(w, "serializer.serializeUnit({value_expr});"),
         Format::Bool => writeln!(w, "serializer.serializeBool({value_expr});"),
         Format::I8 => writeln!(w, "serializer.serializeI8({value_expr});"),
@@ -404,7 +545,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeOption({value_expr}, serializer, (value, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "value", inner, config))?;
             writeln!(w, ");")
         }
         Format::Seq(inner) => {
@@ -412,7 +553,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeArray({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
             writeln!(w, ");")
         }
         Format::Set(inner) => {
@@ -420,7 +561,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 w,
                 "serializeSet({value_expr}, serializer, (item, serializer) => "
             )?;
-            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner))?;
+            with_block(w, Newlines::OPEN, |w| write_serialize(w, "item", inner, config))?;
             writeln!(w, ");")
         }
         Format::Map { key, value } => {
@@ -429,14 +570,14 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 "serializeMap({value_expr}, serializer, (key, value, serializer) => "
             )?;
             with_block(w, Newlines::OPEN, |w| {
-                write_serialize(w, "key", key)?;
-                write_serialize(w, "value", value)
+                write_serialize(w, "key", key, config)?;
+                write_serialize(w, "value", value, config)
             })?;
             writeln!(w, ");")
         }
         Format::Tuple(formats) => {
             for (i, fmt) in formats.iter().enumerate() {
-                write_serialize(w, &format!("{value_expr}[{i}]"), fmt)?;
+                write_serialize(w, &format!("{value_expr}[{i}]"), fmt, config)?;
             }
             Ok(())
         }
@@ -446,7 +587,7 @@ fn write_serialize(w: &mut dyn IndentWrite, value_expr: &str, format: &Format) -
                 "serializeTupleArray({value_expr}, serializer, (item, serializer) => "
             )?;
             with_block(w, Newlines::OPEN, |w| {
-                write_serialize(w, "item[0]", content)
+                write_serialize(w, "item[0]", content, config)
             })?;
             writeln!(w, ");")
         }
@@ -502,12 +643,16 @@ fn quote_type(format: &Format) -> String {
 }
 
 /// Returns the deserialize expression for a primitive or named type.
-fn deserialize_primitive_expr(format: &Format) -> String {
+fn deserialize_primitive_expr(format: &Format, config: &CodeGeneratorConfig) -> String {
     match format {
-        Format::TypeName(qualified_name) => format!(
-            "{}.deserialize(deserializer)",
-            qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".")
-        ),
+        Format::TypeName(qualified_name) => {
+            let type_name = qualified_name.format(ToUpperCamelCase::to_upper_camel_case, ".");
+            if config.enum_type_names.contains(&type_name) {
+                format!("deserialize{type_name}(deserializer)")
+            } else {
+                format!("{type_name}.deserialize(deserializer)")
+            }
+        }
         Format::Unit => "deserializer.deserializeUnit()".to_string(),
         Format::Bool => "deserializer.deserializeBool()".to_string(),
         Format::I8 => "deserializer.deserializeI8()".to_string(),
@@ -565,11 +710,12 @@ fn write_deserialize(
     w: &mut dyn IndentWrite,
     field_name: Option<&str>,
     format: &Format,
+    config: &CodeGeneratorConfig,
 ) -> io::Result<()> {
     match format {
         // Primitive and named types — simple single-expression form.
         f if is_primitive_or_named(f) => {
-            let expr = deserialize_primitive_expr(f);
+            let expr = deserialize_primitive_expr(f, config);
             if let Some(name) = field_name {
                 writeln!(w, "const {name} = {expr};")
             } else {
@@ -589,7 +735,7 @@ fn write_deserialize(
                     "return deserializeOption(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -605,7 +751,7 @@ fn write_deserialize(
                     "return deserializeArray(deserializer, (deserializer) => "
                 )?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -618,7 +764,7 @@ fn write_deserialize(
             } else {
                 write!(w, "return deserializeSet(deserializer, (deserializer) => ")?;
             }
-            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner))?;
+            with_block(w, Newlines::OPEN, |w| write_deserialize(w, None, inner, config))?;
             writeln!(w, ");")
         }
 
@@ -633,14 +779,18 @@ fn write_deserialize(
             }
             with_block(w, Newlines::OPEN, |w| {
                 if is_primitive_or_named(key) {
-                    writeln!(w, "const key = {};", deserialize_primitive_expr(key))?;
+                    writeln!(w, "const key = {};", deserialize_primitive_expr(key, config))?;
                 } else {
-                    write_deserialize(w, Some("key"), key)?;
+                    write_deserialize(w, Some("key"), key, config)?;
                 }
                 if is_primitive_or_named(value) {
-                    writeln!(w, "const value = {};", deserialize_primitive_expr(value))?;
+                    writeln!(
+                        w,
+                        "const value = {};",
+                        deserialize_primitive_expr(value, config)
+                    )?;
                 } else {
-                    write_deserialize(w, Some("value"), value)?;
+                    write_deserialize(w, Some("value"), value, config)?;
                 }
                 writeln!(w, "return [key, value];")
             })?;
@@ -649,7 +799,7 @@ fn write_deserialize(
 
         Format::Tuple(formats) => {
             for (i, f) in formats.iter().enumerate() {
-                write_deserialize(w, Some(&format!("field{i}")), f)?;
+                write_deserialize(w, Some(&format!("field{i}")), f, config)?;
             }
             let fields_joined = (0..formats.len())
                 .map(|i| format!("field{i}"))
@@ -680,7 +830,7 @@ fn write_deserialize(
                 )?;
             }
             with_block(w, Newlines::OPEN, |w| {
-                write_deserialize(w, Some("item"), content)?;
+                write_deserialize(w, Some("item"), content, config)?;
                 writeln!(w, "return [item];")
             })?;
             writeln!(w, ");")
@@ -873,11 +1023,11 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // type_body — enum / variant shapes
+    // type_body + after_type — enum shapes
     // -------------------------------------------------------------------------
 
     #[test]
-    fn type_body_enum_with_variants() {
+    fn type_body_enum_emits_nothing() {
         use crate::reflection::format::VariantFormat;
         let plugin = &JsonPlugin as &dyn EmitterPlugin<TypeScript>;
 
@@ -895,73 +1045,57 @@ mod tests {
         let ctx = EmitContext::top_level(&container, &config);
 
         let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(
-            out.contains("abstract serialize(serializer: Serializer): void;"),
-            "{out}"
-        );
-        assert!(
-            out.contains("static deserialize(deserializer: Deserializer): MyEnum"),
-            "{out}"
-        );
-        assert!(
-            out.contains("deserializer.deserializeVariantIndex()"),
-            "{out}"
-        );
-        assert!(
-            out.contains("case 0: return MyEnumVariantAlpha.load(deserializer);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("case 1: return MyEnumVariantBeta.load(deserializer);"),
-            "{out}"
-        );
+        assert!(out.is_empty(), "type_body for enum should emit nothing, got:\n{out}");
     }
 
     #[test]
-    fn type_body_variant_subclass() {
-        use crate::reflection::format::{Format, VariantFormat};
+    fn after_type_enum_emits_standalone_functions() {
+        use crate::reflection::format::VariantFormat;
         let plugin = &JsonPlugin as &dyn EmitterPlugin<TypeScript>;
 
         let mut variants = BTreeMap::new();
-        let variant_fields = vec![Named::new(&Format::Str, "value".to_string())];
-        variants.insert(
-            0u32,
-            Named::new(
-                &VariantFormat::Struct(variant_fields.clone()),
-                "Ok".to_string(),
-            ),
-        );
+        variants.insert(0u32, Named::new(&VariantFormat::Unit, "Alpha".to_string()));
+        variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
-        let name = QualifiedTypeName::root("Result".to_string());
+        let name = QualifiedTypeName::root("MyEnum".to_string());
         let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
         };
+        let config = CodeGeneratorConfig::new("test".to_string());
+        let ctx = EmitContext::top_level(&container, &config);
 
-        let variant_info = crate::generation::plugin::VariantInfo {
-            name: "Ok",
-            index: 0,
-            format: &VariantFormat::Struct(variant_fields.clone()),
-            fields: &variant_fields,
-            parent_name: "Result",
+        let out = render(|w| plugin.after_type(w, &ctx));
+        assert!(
+            out.contains("export function serializeMyEnum(value: MyEnum, serializer: Serializer): void"),
+            "{out}"
+        );
+        assert!(
+            out.contains("export function deserializeMyEnum(deserializer: Deserializer): MyEnum"),
+            "{out}"
+        );
+        assert!(out.contains(r#"case "Alpha":"#), "{out}");
+        assert!(out.contains(r#"case "Beta":"#), "{out}");
+        assert!(out.contains("deserializer.deserializeVariantIndex()"), "{out}");
+        assert!(out.contains("case 0:"), "{out}");
+        assert!(out.contains("case 1:"), "{out}");
+    }
+
+    #[test]
+    fn after_type_struct_emits_nothing() {
+        let plugin = &JsonPlugin as &dyn EmitterPlugin<TypeScript>;
+
+        let name = QualifiedTypeName::root("Foo".to_string());
+        let format = ContainerFormat::Struct(vec![], Doc::default());
+        let container = Container {
+            name: &name,
+            format: &format,
         };
         let config = CodeGeneratorConfig::new("test".to_string());
-        let ctx = EmitContext::for_variant(&container, &config, variant_info);
+        let ctx = EmitContext::top_level(&container, &config);
 
-        let out = render(|w| plugin.type_body(w, &ctx));
-        assert!(
-            out.contains("serializer.serializeVariantIndex(0);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("serializer.serializeStr(this.value);"),
-            "{out}"
-        );
-        assert!(
-            out.contains("static load(deserializer: Deserializer): ResultVariantOk"),
-            "{out}"
-        );
-        assert!(out.contains("return new ResultVariantOk(value);"), "{out}");
+        let out = render(|w| plugin.after_type(w, &ctx));
+        assert!(out.is_empty(), "after_type for struct should emit nothing, got:\n{out}");
     }
 }

--- a/crates/facet_generate/src/generation/json/typescript.rs
+++ b/crates/facet_generate/src/generation/json/typescript.rs
@@ -260,7 +260,7 @@ impl EmitterPlugin<TypeScript> for JsonPlugin {
             write_variant_type_body(w, variant)
         } else {
             match ctx.container.format {
-                ContainerFormat::Enum(variants, _) => write_enum_type_body(w, ctx.name(), variants),
+                ContainerFormat::Enum(variants, _, _) => write_enum_type_body(w, ctx.name(), variants),
                 _ => write_struct_type_body(w, ctx.name(), &ctx.fields()),
             }
         }
@@ -705,7 +705,7 @@ mod tests {
         indent::{IndentConfig, IndentedWriter},
         plugin::EmitContext,
     };
-    use crate::reflection::format::{ContainerFormat, Doc, QualifiedTypeName};
+    use crate::reflection::format::{ContainerFormat, Doc, EnumTagging, QualifiedTypeName};
 
     fn make_config(features: &[Feature]) -> CodeGeneratorConfig {
         let mut cfg = CodeGeneratorConfig::new("test".to_string());
@@ -886,7 +886,7 @@ mod tests {
         variants.insert(1u32, Named::new(&VariantFormat::Unit, "Beta".to_string()));
 
         let name = QualifiedTypeName::root("MyEnum".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,
@@ -933,7 +933,7 @@ mod tests {
         );
 
         let name = QualifiedTypeName::root("Result".to_string());
-        let format = ContainerFormat::Enum(variants, Doc::default());
+        let format = ContainerFormat::Enum(variants, EnumTagging::External, Doc::default());
         let container = Container {
             name: &name,
             format: &format,

--- a/crates/facet_generate/src/generation/kotlin/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/kotlin/emitter/mod.rs
@@ -234,7 +234,7 @@ impl Emitter<Kotlin> for Container<'_> {
                     data_class(w, name, None, fields, doc, lang, None)?;
                 }
             }
-            ContainerFormat::Enum(variants, doc) => {
+            ContainerFormat::Enum(variants, _, doc) => {
                 let variant_list: Vec<_> = variants.values().cloned().collect();
 
                 let all_unit_variants = variants

--- a/crates/facet_generate/src/generation/kotlin/generator/tests.rs
+++ b/crates/facet_generate/src/generation/kotlin/generator/tests.rs
@@ -28,7 +28,7 @@ use crate::{
         config::{ExternalPackage, PackageLocation},
     },
     reflection::format::{
-        ContainerFormat, Doc, Named, Namespace, QualifiedTypeName, VariantFormat,
+        ContainerFormat, Doc, EnumTagging, Named, Namespace, QualifiedTypeName, VariantFormat,
     },
 };
 use std::collections::BTreeMap;
@@ -393,7 +393,7 @@ fn test_update_qualified_names_enum_variants() {
 
     let mut variants = BTreeMap::new();
     variants.insert(0, variant);
-    let enum_container = ContainerFormat::Enum(variants, Doc::new());
+    let enum_container = ContainerFormat::Enum(variants, EnumTagging::External, Doc::new());
     let enum_qualified_name = QualifiedTypeName::root("Event".to_string());
     registry.insert(enum_qualified_name, enum_container);
 
@@ -401,7 +401,7 @@ fn test_update_qualified_names_enum_variants() {
 
     // Check the enum variant type
     let (_, container) = updated_registry.iter().next().unwrap();
-    if let ContainerFormat::Enum(variants, _) = container {
+    if let ContainerFormat::Enum(variants, _, _) = container {
         let variant = variants.get(&0).unwrap();
         if let VariantFormat::NewType(boxed_format) = &variant.value {
             if let Format::TypeName(qualified_name) = boxed_format.as_ref() {

--- a/crates/facet_generate/src/generation/module_tests.rs
+++ b/crates/facet_generate/src/generation/module_tests.rs
@@ -46,6 +46,7 @@ fn single_namespace() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {
@@ -194,6 +195,7 @@ fn root_namespace_with_two_child_namespaces() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {
@@ -249,6 +251,7 @@ fn root_namespace_with_two_child_namespaces() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {
@@ -311,6 +314,7 @@ fn root_namespace_with_two_child_namespaces() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {
@@ -404,6 +408,7 @@ fn same_namespace_with_external_dependency_bug_regression() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {
@@ -467,6 +472,7 @@ fn same_namespace_with_external_dependency_bug_regression() {
                 used_format_types: {},
                 referenced_namespaces: {},
                 unit_variant_enums: {},
+                enum_type_names: {},
             },
         ): {
             QualifiedTypeName {

--- a/crates/facet_generate/src/generation/plugin.rs
+++ b/crates/facet_generate/src/generation/plugin.rs
@@ -128,7 +128,7 @@ impl<'a> EmitContext<'a> {
         }
 
         match self.container.format {
-            ContainerFormat::UnitStruct(_) | ContainerFormat::Enum(_, _) => vec![],
+            ContainerFormat::UnitStruct(_) | ContainerFormat::Enum(_, _, _) => vec![],
             ContainerFormat::NewTypeStruct(format, _) => {
                 vec![Named::new(format, "value".to_string())]
             }

--- a/crates/facet_generate/src/generation/swift/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/swift/emitter/mod.rs
@@ -356,7 +356,7 @@ impl Emitter<Swift> for Container<'_> {
             ContainerFormat::Struct(nameds, doc) => {
                 struct_(w, self, &nameds.iter().collect::<Vec<_>>(), doc, lang)
             }
-            ContainerFormat::Enum(variants, doc) => enum_(w, self, variants, doc, lang),
+            ContainerFormat::Enum(variants, _, doc) => enum_(w, self, variants, doc, lang),
         }
     }
 }

--- a/crates/facet_generate/src/generation/swift/generator/mod.rs
+++ b/crates/facet_generate/src/generation/swift/generator/mod.rs
@@ -150,7 +150,7 @@ fn check_type_hashable<'a>(
         ContainerFormat::Struct(fields, _) => fields
             .iter()
             .all(|f| fmt_is_hashable(registry, &f.value, known, visiting)),
-        ContainerFormat::Enum(variants, _) => variants
+        ContainerFormat::Enum(variants, _, _) => variants
             .values()
             .all(|v| variant_is_hashable(registry, &v.value, known, visiting)),
     };
@@ -287,7 +287,7 @@ fn check_type_equatable<'a>(
         ContainerFormat::Struct(fields, _) => fields
             .iter()
             .all(|f| fmt_is_equatable(registry, &f.value, known, visiting)),
-        ContainerFormat::Enum(variants, _) => variants
+        ContainerFormat::Enum(variants, _, _) => variants
             .values()
             .all(|v| variant_is_equatable(registry, &v.value, known, visiting)),
     };

--- a/crates/facet_generate/src/generation/swift/generator/tests.rs
+++ b/crates/facet_generate/src/generation/swift/generator/tests.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 
 use crate::{
     generation::{CodeGeneratorConfig, bincode::BincodePlugin, plugin::EmitterPlugin},
-    reflection::format::{ContainerFormat, Doc, Format, Named, Namespace, QualifiedTypeName},
+    reflection::format::{
+        ContainerFormat, Doc, EnumTagging, Format, Named, Namespace, QualifiedTypeName,
+    },
 };
 
 use super::*;
@@ -265,7 +267,7 @@ fn test_enum_with_hashable_variants_implements_hashable_and_equatable() {
 
     registry.insert(
         QualifiedTypeName::root("MyEnum".to_string()),
-        ContainerFormat::Enum(variants, Doc::new()),
+        ContainerFormat::Enum(variants, EnumTagging::External, Doc::new()),
     );
 
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
@@ -330,7 +332,7 @@ fn test_with_enum_and_struct_variant_implements_hashable_and_equatable() {
 
     registry.insert(
         QualifiedTypeName::root("MyEnum".to_string()),
-        ContainerFormat::Enum(variants, Doc::new()),
+        ContainerFormat::Enum(variants, EnumTagging::External, Doc::new()),
     );
 
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);
@@ -382,7 +384,7 @@ fn test_type_cycle_is_hashable_and_equatable() {
 
     registry.insert(
         QualifiedTypeName::root("MyEnum".to_string()),
-        ContainerFormat::Enum(variants, Doc::new()),
+        ContainerFormat::Enum(variants, EnumTagging::External, Doc::new()),
     );
 
     let output = generate(&config, vec![Arc::new(BincodePlugin)], &registry);

--- a/crates/facet_generate/src/generation/tests/basic/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/basic/snapshots/typescript/example.ts
@@ -5,11 +5,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-}
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
+
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_namespaces_as_external/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_namespaces_as_external/snapshots/typescript/example.ts
@@ -5,11 +5,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-}
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
+
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_namespaces_as_internal/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_namespaces_as_internal/snapshots/typescript/example.ts
@@ -5,11 +5,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-}
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
+
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_namespaces_as_internal/snapshots/typescript/other.ts
+++ b/crates/facet_generate/src/generation/tests/with_namespaces_as_internal/snapshots/typescript/other.ts
@@ -5,11 +5,13 @@ export class OtherChild {
     }
 }
 
-export abstract class OtherParent {
-}
+export type OtherParent =
+    | { kind: "Child"; value: OtherChild };
 
-export class OtherParentVariantChild extends OtherParent {
-    constructor (public value: OtherChild) {
-        super();
-    }
+export const otherParentChild = (value: OtherChild): OtherParent => ({ kind: "Child", value });
+
+export function matchOtherParent<R>(value: OtherParent, cases: {
+    Child: (v: Extract<OtherParent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as OtherParent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/example.ts
@@ -138,7 +138,7 @@ export class MyStruct {
                 });
             });
         });
-        this.parent.serialize(serializer);
+        serializeParent(this.parent, serializer);
     }
 
     static deserialize(deserializer: Deserializer): MyStruct {
@@ -161,7 +161,7 @@ export class MyStruct {
                 });
             });
         });
-        const parent = Parent.deserialize(deserializer);
+        const parent = deserializeParent(deserializer);
         return new MyStruct(string_to_int,map_to_list,option_of_vec_of_set,parent);
     }
 }
@@ -175,4 +175,26 @@ export function matchParent<R>(value: Parent, cases: {
     Child: (v: Extract<Parent, { kind: "Child" }>) => R;
 }): R {
     return cases[value.kind as Parent["kind"]](value as never);
+}
+
+export function serializeParent(value: Parent, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Child": {
+            serializer.serializeVariantIndex(0);
+            value.value.serialize(serializer);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeParent(deserializer: Deserializer): Parent {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const value = Child.deserialize(deserializer);
+            return { kind: "Child", value };
+        }
+        default: throw new Error("Unknown variant index for Parent: " + index);
+    }
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/example.ts
@@ -166,30 +166,13 @@ export class MyStruct {
     }
 }
 
-export abstract class Parent {
-    abstract serialize(serializer: Serializer): void;
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-    static deserialize(deserializer: Deserializer): Parent {
-        const index = deserializer.deserializeVariantIndex();
-        switch (index) {
-            case 0: return ParentVariantChild.load(deserializer);
-            default: throw new Error("Unknown variant index for Parent: " + index);
-        }
-    }
-}
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
-
-    public serialize(serializer: Serializer): void {
-        serializer.serializeVariantIndex(0);
-        this.value.serialize(serializer);
-    }
-
-    static load(deserializer: Deserializer): ParentVariantChild {
-        const value = Child.deserialize(deserializer);
-        return new ParentVariantChild(value);
-    }
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/example.ts
@@ -15,30 +15,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-    abstract serialize(serializer: Serializer): void;
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-    static deserialize(deserializer: Deserializer): Parent {
-        const index = deserializer.deserializeVariantIndex();
-        switch (index) {
-            case 0: return ParentVariantChild.load(deserializer);
-            default: throw new Error("Unknown variant index for Parent: " + index);
-        }
-    }
-}
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
-
-    public serialize(serializer: Serializer): void {
-        serializer.serializeVariantIndex(0);
-        this.value.serialize(serializer);
-    }
-
-    static load(deserializer: Deserializer): ParentVariantChild {
-        const value = Child.deserialize(deserializer);
-        return new ParentVariantChild(value);
-    }
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/example.ts
@@ -25,3 +25,25 @@ export function matchParent<R>(value: Parent, cases: {
 }): R {
     return cases[value.kind as Parent["kind"]](value as never);
 }
+
+export function serializeParent(value: Parent, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Child": {
+            serializer.serializeVariantIndex(0);
+            value.value.serialize(serializer);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeParent(deserializer: Deserializer): Parent {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const value = Child.deserialize(deserializer);
+            return { kind: "Child", value };
+        }
+        default: throw new Error("Unknown variant index for Parent: " + index);
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/example/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/example/example.ts
@@ -15,30 +15,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-    abstract serialize(serializer: Serializer): void;
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-    static deserialize(deserializer: Deserializer): Parent {
-        const index = deserializer.deserializeVariantIndex();
-        switch (index) {
-            case 0: return ParentVariantChild.load(deserializer);
-            default: throw new Error("Unknown variant index for Parent: " + index);
-        }
-    }
-}
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
-
-    public serialize(serializer: Serializer): void {
-        serializer.serializeVariantIndex(0);
-        this.value.serialize(serializer);
-    }
-
-    static load(deserializer: Deserializer): ParentVariantChild {
-        const value = Child.deserialize(deserializer);
-        return new ParentVariantChild(value);
-    }
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/example/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/example/example.ts
@@ -25,3 +25,25 @@ export function matchParent<R>(value: Parent, cases: {
 }): R {
     return cases[value.kind as Parent["kind"]](value as never);
 }
+
+export function serializeParent(value: Parent, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Child": {
+            serializer.serializeVariantIndex(0);
+            value.value.serialize(serializer);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeParent(deserializer: Deserializer): Parent {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const value = Child.deserialize(deserializer);
+            return { kind: "Child", value };
+        }
+        default: throw new Error("Unknown variant index for Parent: " + index);
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/example.ts
@@ -15,30 +15,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-    abstract serialize(serializer: Serializer): void;
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-    static deserialize(deserializer: Deserializer): Parent {
-        const index = deserializer.deserializeVariantIndex();
-        switch (index) {
-            case 0: return ParentVariantChild.load(deserializer);
-            default: throw new Error("Unknown variant index for Parent: " + index);
-        }
-    }
-}
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
-
-    public serialize(serializer: Serializer): void {
-        serializer.serializeVariantIndex(0);
-        this.value.serialize(serializer);
-    }
-
-    static load(deserializer: Deserializer): ParentVariantChild {
-        const value = Child.deserialize(deserializer);
-        return new ParentVariantChild(value);
-    }
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/example.ts
@@ -25,3 +25,25 @@ export function matchParent<R>(value: Parent, cases: {
 }): R {
     return cases[value.kind as Parent["kind"]](value as never);
 }
+
+export function serializeParent(value: Parent, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Child": {
+            serializer.serializeVariantIndex(0);
+            value.value.serialize(serializer);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeParent(deserializer: Deserializer): Parent {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const value = Child.deserialize(deserializer);
+            return { kind: "Child", value };
+        }
+        default: throw new Error("Unknown variant index for Parent: " + index);
+    }
+}

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/typescript/example.ts
@@ -15,30 +15,13 @@ export class Child {
     }
 }
 
-export abstract class Parent {
-    abstract serialize(serializer: Serializer): void;
+export type Parent =
+    | { kind: "Child"; value: Child };
 
-    static deserialize(deserializer: Deserializer): Parent {
-        const index = deserializer.deserializeVariantIndex();
-        switch (index) {
-            case 0: return ParentVariantChild.load(deserializer);
-            default: throw new Error("Unknown variant index for Parent: " + index);
-        }
-    }
-}
+export const parentChild = (value: Child): Parent => ({ kind: "Child", value });
 
-export class ParentVariantChild extends Parent {
-    constructor (public value: Child) {
-        super();
-    }
-
-    public serialize(serializer: Serializer): void {
-        serializer.serializeVariantIndex(0);
-        this.value.serialize(serializer);
-    }
-
-    static load(deserializer: Deserializer): ParentVariantChild {
-        const value = Child.deserialize(deserializer);
-        return new ParentVariantChild(value);
-    }
+export function matchParent<R>(value: Parent, cases: {
+    Child: (v: Extract<Parent, { kind: "Child" }>) => R;
+}): R {
+    return cases[value.kind as Parent["kind"]](value as never);
 }

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/typescript/example.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_local/snapshots/typescript/example.ts
@@ -25,3 +25,25 @@ export function matchParent<R>(value: Parent, cases: {
 }): R {
     return cases[value.kind as Parent["kind"]](value as never);
 }
+
+export function serializeParent(value: Parent, serializer: Serializer): void {
+    switch (value.kind) {
+        case "Child": {
+            serializer.serializeVariantIndex(0);
+            value.value.serialize(serializer);
+            break;
+        }
+        default: throw new Error("Unknown variant: " + (value as any).kind);
+    }
+}
+
+export function deserializeParent(deserializer: Deserializer): Parent {
+    const index = deserializer.deserializeVariantIndex();
+    switch (index) {
+        case 0: {
+            const value = Child.deserialize(deserializer);
+            return { kind: "Child", value };
+        }
+        default: throw new Error("Unknown variant index for Parent: " + index);
+    }
+}

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -47,16 +47,16 @@ use std::{
     sync::Arc,
 };
 
-use heck::ToUpperCamelCase;
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 
 use crate::{
     generation::{
         CodeGeneratorConfig, Container, Emitter, PackageLocation,
         indent::{IndentConfig, IndentWrite, IndentedWriter, Newlines},
         module::Module,
-        plugin::{EmitContext, EmitterPlugin, VariantInfo, collect_from_plugins},
+        plugin::{EmitContext, EmitterPlugin, collect_from_plugins},
     },
-    reflection::format::{ContainerFormat, Doc, Format, Named, VariantFormat},
+    reflection::format::{ContainerFormat, Doc, EnumTagging, Format, Named, VariantFormat},
 };
 
 /// Language tag for TypeScript code generation.
@@ -206,8 +206,8 @@ impl Emitter<TypeScript> for Container<'_> {
                 let ctx = EmitContext::top_level(self, &lang.config);
                 output_struct_or_variant(w, &ctx, name, fields, doc, lang)
             }
-            ContainerFormat::Enum(variants, doc) => {
-                output_enum_container(w, self, name, variants, doc, lang)
+            ContainerFormat::Enum(variants, tagging, doc) => {
+                output_enum_container(w, self, name, variants, tagging, doc, lang)
             }
         }
     }
@@ -304,15 +304,9 @@ fn output_struct_or_variant<W: IndentWrite>(
     doc: &Doc,
     lang: &TypeScript,
 ) -> Result<()> {
-    let variant_base = ctx.variant.as_ref().map(|v| v.parent_name);
-
     writeln!(w)?;
     doc.write(w, lang)?;
-    if let Some(base) = variant_base {
-        write!(w, "export class {base}Variant{name} extends {base} ")?;
-    } else {
-        write!(w, "export class {name} ")?;
-    }
+    write!(w, "export class {name} ")?;
     let mut w = w.block(Newlines::BOTH)?;
 
     let args: Vec<String> = fields
@@ -325,13 +319,9 @@ fn output_struct_or_variant<W: IndentWrite>(
     let args = args.join(", ");
     write!(w, "constructor ({args}) ")?;
     {
-        let mut w = w.block(Newlines::BOTH)?;
-        if variant_base.is_some() {
-            writeln!(w, "super();")?;
-        }
+        let _w = w.block(Newlines::BOTH)?;
     }
 
-    // Plugin type bodies (serialize / deserialize methods).
     for plugin in lang.plugins() {
         plugin.type_body(&mut w as &mut dyn IndentWrite, ctx)?;
     }
@@ -339,40 +329,167 @@ fn output_struct_or_variant<W: IndentWrite>(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
-fn output_variant<W: IndentWrite>(
+fn tag_field_name(tagging: &EnumTagging) -> &str {
+    match tagging {
+        EnumTagging::External => "kind",
+        EnumTagging::Internal { tag } | EnumTagging::Adjacent { tag, .. } => tag.as_str(),
+    }
+}
+
+fn write_variant_type_expr<W: std::io::Write>(
     w: &mut W,
-    parent: &Container<'_>,
-    base: &str,
-    index: u32,
-    name: &str,
+    variant_name: &str,
     variant: &VariantFormat,
-    doc: &Doc,
+    tag_field: &str,
+    content_field: Option<&str>,
+    is_internal: bool,
     lang: &TypeScript,
 ) -> Result<()> {
-    let fields: Vec<Named<Format>> = match variant {
-        VariantFormat::Unit => Vec::new(),
-        VariantFormat::NewType(format) => {
-            vec![Named::new(format.as_ref(), "value".to_string())]
+    match variant {
+        VariantFormat::Unit => {
+            write!(w, r#"{{ {tag_field}: "{variant_name}" }}"#)?;
         }
-        VariantFormat::Tuple(formats) => formats
-            .iter()
-            .enumerate()
-            .map(|(i, f)| Named::new(f, format!("field{i}")))
-            .collect(),
-        VariantFormat::Struct(fields) => fields.clone(),
-        VariantFormat::Variable(_) => panic!("incorrect value"),
+        VariantFormat::NewType(inner) => {
+            let type_str = quote_type(inner, lang);
+            if let Some(content) = content_field {
+                write!(w, r#"{{ {tag_field}: "{variant_name}"; {content}: {type_str} }}"#)?;
+            } else if is_internal && matches!(inner.as_ref(), Format::TypeName(_)) {
+                write!(w, r#"{{ {tag_field}: "{variant_name}" }} & {type_str}"#)?;
+            } else {
+                write!(w, r#"{{ {tag_field}: "{variant_name}"; value: {type_str} }}"#)?;
+            }
+        }
+        VariantFormat::Tuple(formats) => {
+            if let Some(content) = content_field {
+                let types: Vec<String> = formats.iter().map(|f| quote_type(f, lang)).collect();
+                write!(w, r#"{{ {tag_field}: "{variant_name}"; {content}: [{}] }}"#, types.join(", "))?;
+            } else {
+                write!(w, r#"{{ {tag_field}: "{variant_name}""#)?;
+                for (i, f) in formats.iter().enumerate() {
+                    write!(w, "; field{i}: {}", quote_type(f, lang))?;
+                }
+                write!(w, " }}")?;
+            }
+        }
+        VariantFormat::Struct(fields) => {
+            if let Some(content) = content_field {
+                write!(w, r#"{{ {tag_field}: "{variant_name}"; {content}: {{ "#)?;
+                for field in fields {
+                    write!(w, "{}: {}; ", field.name, quote_type(&field.value, lang))?;
+                }
+                write!(w, "}} }}")?;
+            } else {
+                write!(w, r#"{{ {tag_field}: "{variant_name}""#)?;
+                for field in fields {
+                    write!(w, "; {}: {}", field.name, quote_type(&field.value, lang))?;
+                }
+                write!(w, " }}")?;
+            }
+        }
+        VariantFormat::Variable(_) => panic!("unexpected variable format"),
+    }
+    Ok(())
+}
+
+fn write_variant_constructor<W: std::io::Write>(
+    w: &mut W,
+    enum_name: &str,
+    variant_name: &str,
+    variant: &VariantFormat,
+    tag_field: &str,
+    content_field: Option<&str>,
+    is_internal: bool,
+    lang: &TypeScript,
+) -> Result<()> {
+    let fn_name = format!(
+        "{}{}",
+        enum_name.to_lower_camel_case(),
+        variant_name.to_upper_camel_case(),
+    );
+
+    let (params_str, object_str) = match variant {
+        VariantFormat::Unit => (
+            String::new(),
+            format!(r#"{{ {tag_field}: "{variant_name}" }}"#),
+        ),
+        VariantFormat::NewType(inner) => {
+            let type_str = quote_type(inner, lang);
+            let obj = if let Some(content) = content_field {
+                format!(r#"{{ {tag_field}: "{variant_name}", {content}: value }}"#)
+            } else if is_internal && matches!(inner.as_ref(), Format::TypeName(_)) {
+                format!(r#"{{ {tag_field}: "{variant_name}", ...value }}"#)
+            } else {
+                format!(r#"{{ {tag_field}: "{variant_name}", value }}"#)
+            };
+            (format!("value: {type_str}"), obj)
+        }
+        VariantFormat::Tuple(formats) => {
+            let params: Vec<String> = formats
+                .iter()
+                .enumerate()
+                .map(|(i, f)| format!("field{i}: {}", quote_type(f, lang)))
+                .collect();
+            let field_names: Vec<String> =
+                (0..formats.len()).map(|i| format!("field{i}")).collect();
+            let obj = if let Some(content) = content_field {
+                format!(
+                    r#"{{ {tag_field}: "{variant_name}", {content}: [{}] }}"#,
+                    field_names.join(", ")
+                )
+            } else {
+                format!(
+                    r#"{{ {tag_field}: "{variant_name}", {} }}"#,
+                    field_names.join(", ")
+                )
+            };
+            (params.join(", "), obj)
+        }
+        VariantFormat::Struct(fields) => {
+            let params: Vec<String> = fields
+                .iter()
+                .map(|f| format!("{}: {}", f.name, quote_type(&f.value, lang)))
+                .collect();
+            let field_names: Vec<&str> = fields.iter().map(|f| f.name.as_str()).collect();
+            let obj = if let Some(content) = content_field {
+                format!(
+                    r#"{{ {tag_field}: "{variant_name}", {content}: {{ {} }} }}"#,
+                    field_names.join(", ")
+                )
+            } else {
+                format!(
+                    r#"{{ {tag_field}: "{variant_name}", {} }}"#,
+                    field_names.join(", ")
+                )
+            };
+            (params.join(", "), obj)
+        }
+        VariantFormat::Variable(_) => panic!("unexpected variable format"),
     };
 
-    let variant_info = VariantInfo {
-        name,
-        index: index as usize,
-        format: variant,
-        fields: &fields,
-        parent_name: base,
-    };
-    let ctx = EmitContext::for_variant(parent, &lang.config, variant_info);
-    output_struct_or_variant(w, &ctx, name, &fields, doc, lang)
+    writeln!(w, "export const {fn_name} = ({params_str}): {enum_name} => ({object_str});")?;
+    Ok(())
+}
+
+fn write_match_function<W: std::io::Write>(
+    w: &mut W,
+    name: &str,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+    tag_field: &str,
+) -> Result<()> {
+    writeln!(w, "export function match{name}<R>(value: {name}, cases: {{")?;
+    for (_index, variant) in variants {
+        let vname = &variant.name;
+        writeln!(
+            w,
+            r#"    {vname}: (v: Extract<{name}, {{ {tag_field}: "{vname}" }}>) => R;"#
+        )?;
+    }
+    writeln!(w, "}}): R {{")?;
+    writeln!(
+        w,
+        r#"    return cases[value.{tag_field} as {name}["{tag_field}"]](value as never);"#
+    )?;
+    writeln!(w, "}}")
 }
 
 fn output_enum_container<W: IndentWrite>(
@@ -380,31 +497,43 @@ fn output_enum_container<W: IndentWrite>(
     container: &Container<'_>,
     name: &str,
     variants: &BTreeMap<u32, Named<VariantFormat>>,
+    tagging: &EnumTagging,
     doc: &Doc,
     lang: &TypeScript,
 ) -> Result<()> {
+    let tag_field = tag_field_name(tagging);
+    let content_field: Option<&str> = match tagging {
+        EnumTagging::Adjacent { content, .. } => Some(content.as_str()),
+        _ => None,
+    };
+    let is_internal = matches!(tagging, EnumTagging::Internal { .. });
+
     writeln!(w)?;
     doc.write(w, lang)?;
-    write!(w, "export abstract class {name} ")?;
-    {
-        let mut w = w.block(Newlines::BOTH)?;
-        // Plugin type bodies (abstract serialize + static deserialize switch).
-        let ctx = EmitContext::top_level(container, &lang.config);
-        for plugin in lang.plugins() {
-            plugin.type_body(&mut w as &mut dyn IndentWrite, &ctx)?;
-        }
+
+    // 1. Union type alias
+    write!(w, "export type {name} =")?;
+    for (_index, variant) in variants {
+        writeln!(w)?;
+        write!(w, "    | ")?;
+        write_variant_type_expr(w, &variant.name, &variant.value, tag_field, content_field, is_internal, lang)?;
     }
-    for (index, variant) in variants {
-        output_variant(
-            w,
-            container,
-            name,
-            *index,
-            &variant.name,
-            &variant.value,
-            &variant.doc,
-            lang,
-        )?;
+    writeln!(w, ";")?;
+
+    // 2. Constructor helpers
+    for (_index, variant) in variants {
+        writeln!(w)?;
+        write_variant_constructor(w, name, &variant.name, &variant.value, tag_field, content_field, is_internal, lang)?;
+    }
+
+    // 3. Match function
+    writeln!(w)?;
+    write_match_function(w, name, variants, tag_field)?;
+
+    // 4. Plugin after_type hook (for standalone serialize/deserialize functions)
+    let ctx = EmitContext::top_level(container, &lang.config);
+    for plugin in lang.plugins() {
+        plugin.after_type(w as &mut dyn IndentWrite, &ctx)?;
     }
 
     Ok(())

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -352,17 +352,27 @@ fn write_variant_type_expr<W: std::io::Write>(
         VariantFormat::NewType(inner) => {
             let type_str = quote_type(inner, lang);
             if let Some(content) = content_field {
-                write!(w, r#"{{ {tag_field}: "{variant_name}"; {content}: {type_str} }}"#)?;
+                write!(
+                    w,
+                    r#"{{ {tag_field}: "{variant_name}"; {content}: {type_str} }}"#
+                )?;
             } else if is_internal && matches!(inner.as_ref(), Format::TypeName(_)) {
                 write!(w, r#"{{ {tag_field}: "{variant_name}" }} & {type_str}"#)?;
             } else {
-                write!(w, r#"{{ {tag_field}: "{variant_name}"; value: {type_str} }}"#)?;
+                write!(
+                    w,
+                    r#"{{ {tag_field}: "{variant_name}"; value: {type_str} }}"#
+                )?;
             }
         }
         VariantFormat::Tuple(formats) => {
             if let Some(content) = content_field {
                 let types: Vec<String> = formats.iter().map(|f| quote_type(f, lang)).collect();
-                write!(w, r#"{{ {tag_field}: "{variant_name}"; {content}: [{}] }}"#, types.join(", "))?;
+                write!(
+                    w,
+                    r#"{{ {tag_field}: "{variant_name}"; {content}: [{}] }}"#,
+                    types.join(", ")
+                )?;
             } else {
                 write!(w, r#"{{ {tag_field}: "{variant_name}""#)?;
                 for (i, f) in formats.iter().enumerate() {
@@ -391,6 +401,7 @@ fn write_variant_type_expr<W: std::io::Write>(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_variant_constructor<W: std::io::Write>(
     w: &mut W,
     enum_name: &str,
@@ -466,7 +477,10 @@ fn write_variant_constructor<W: std::io::Write>(
         VariantFormat::Variable(_) => panic!("unexpected variable format"),
     };
 
-    writeln!(w, "export const {fn_name} = ({params_str}): {enum_name} => ({object_str});")?;
+    writeln!(
+        w,
+        "export const {fn_name} = ({params_str}): {enum_name} => ({object_str});"
+    )?;
     Ok(())
 }
 
@@ -477,7 +491,7 @@ fn write_match_function<W: std::io::Write>(
     tag_field: &str,
 ) -> Result<()> {
     writeln!(w, "export function match{name}<R>(value: {name}, cases: {{")?;
-    for (_index, variant) in variants {
+    for variant in variants.values() {
         let vname = &variant.name;
         writeln!(
             w,
@@ -513,17 +527,34 @@ fn output_enum_container<W: IndentWrite>(
 
     // 1. Union type alias
     write!(w, "export type {name} =")?;
-    for (_index, variant) in variants {
+    for variant in variants.values() {
         writeln!(w)?;
         write!(w, "    | ")?;
-        write_variant_type_expr(w, &variant.name, &variant.value, tag_field, content_field, is_internal, lang)?;
+        write_variant_type_expr(
+            w,
+            &variant.name,
+            &variant.value,
+            tag_field,
+            content_field,
+            is_internal,
+            lang,
+        )?;
     }
     writeln!(w, ";")?;
 
     // 2. Constructor helpers
-    for (_index, variant) in variants {
+    for variant in variants.values() {
         writeln!(w)?;
-        write_variant_constructor(w, name, &variant.name, &variant.value, tag_field, content_field, is_internal, lang)?;
+        write_variant_constructor(
+            w,
+            name,
+            &variant.name,
+            &variant.value,
+            tag_field,
+            content_field,
+            is_internal,
+            lang,
+        )?;
     }
 
     // 3. Match function

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -484,6 +484,25 @@ fn write_variant_constructor<W: std::io::Write>(
     Ok(())
 }
 
+fn is_js_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => false,
+        Some(c) => {
+            (c.is_alphabetic() || c == '_' || c == '$')
+                && chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+        }
+    }
+}
+
+fn js_property_key(s: &str) -> String {
+    if is_js_identifier(s) {
+        s.to_string()
+    } else {
+        format!("\"{s}\"")
+    }
+}
+
 fn write_match_function<W: std::io::Write>(
     w: &mut W,
     name: &str,
@@ -493,9 +512,10 @@ fn write_match_function<W: std::io::Write>(
     writeln!(w, "export function match{name}<R>(value: {name}, cases: {{")?;
     for variant in variants.values() {
         let vname = &variant.name;
+        let key = js_property_key(vname);
         writeln!(
             w,
-            r#"    {vname}: (v: Extract<{name}, {{ {tag_field}: "{vname}" }}>) => R;"#
+            r#"    {key}: (v: Extract<{name}, {{ {tag_field}: "{vname}" }}>) => R;"#
         )?;
     }
     writeln!(w, "}}): R {{")?;

--- a/crates/facet_generate/src/generation/typescript/emitter/tests.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/tests.rs
@@ -322,35 +322,30 @@ fn enum_with_unit_variants() {
     }
 
     let actual = emit!(EnumWithUnitVariants as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
     /// line one
     /// line two
-    export abstract class EnumWithUnitVariants {
-    }
+    export type EnumWithUnitVariants =
+        | { kind: "Variant1" }
+        | { kind: "Variant2" }
+        | { kind: "Variant3" };
 
-    /// variant one
-    export class EnumWithUnitVariantsVariantVariant1 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-    }
+    export const enumWithUnitVariantsVariant1 = (): EnumWithUnitVariants => ({ kind: "Variant1" });
 
-    /// variant two
-    export class EnumWithUnitVariantsVariantVariant2 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-    }
+    export const enumWithUnitVariantsVariant2 = (): EnumWithUnitVariants => ({ kind: "Variant2" });
 
-    /// variant three
-    export class EnumWithUnitVariantsVariantVariant3 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
+    export const enumWithUnitVariantsVariant3 = (): EnumWithUnitVariants => ({ kind: "Variant3" });
+
+    export function matchEnumWithUnitVariants<R>(value: EnumWithUnitVariants, cases: {
+        Variant1: (v: Extract<EnumWithUnitVariants, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<EnumWithUnitVariants, { kind: "Variant2" }>) => R;
+        Variant3: (v: Extract<EnumWithUnitVariants, { kind: "Variant3" }>) => R;
+    }): R {
+        return cases[value.kind as EnumWithUnitVariants["kind"]](value as never);
     }
-    ");
+    "#);
 }
 
 #[test]
@@ -365,18 +360,20 @@ fn enum_with_unit_struct_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Variant1" };
+
+    export const myEnumVariant1 = (): MyEnum => ({ kind: "Variant1" });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor () {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]
@@ -389,18 +386,20 @@ fn enum_with_1_tuple_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Variant1"; value: str };
+
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]
@@ -414,24 +413,24 @@ fn enum_with_newtype_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Variant1"; value: str }
+        | { kind: "Variant2"; value: int32 };
+
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
+
+    export const myEnumVariant2 = (value: int32): MyEnum => ({ kind: "Variant2", value });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public value: int32) {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]
@@ -445,24 +444,24 @@ fn enum_with_tuple_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Variant1"; field0: str; field1: int32 }
+        | { kind: "Variant2"; field0: bool; field1: float64; field2: uint8 };
+
+    export const myEnumVariant1 = (field0: str, field1: int32): MyEnum => ({ kind: "Variant1", field0, field1 });
+
+    export const myEnumVariant2 = (field0: bool, field1: float64, field2: uint8): MyEnum => ({ kind: "Variant2", field0, field1, field2 });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public field0: bool, public field1: float64, public field2: uint8) {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]
@@ -475,18 +474,20 @@ fn enum_with_struct_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Variant1"; field1: str; field2: int32 };
+
+    export const myEnumVariant1 = (field1: str, field2: int32): MyEnum => ({ kind: "Variant1", field1, field2 });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field1: str, public field2: int32) {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]
@@ -502,36 +503,32 @@ fn enum_with_mixed_variants() {
     }
 
     let actual = emit!(MyEnum as TypeScript).unwrap();
-    insta::assert_snapshot!(actual, @"
+    insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
+    export type MyEnum =
+        | { kind: "Unit" }
+        | { kind: "NewType"; value: str }
+        | { kind: "Tuple"; field0: str; field1: int32 }
+        | { kind: "Struct"; field: bool };
+
+    export const myEnumUnit = (): MyEnum => ({ kind: "Unit" });
+
+    export const myEnumNewType = (value: str): MyEnum => ({ kind: "NewType", value });
+
+    export const myEnumTuple = (field0: str, field1: int32): MyEnum => ({ kind: "Tuple", field0, field1 });
+
+    export const myEnumStruct = (field: bool): MyEnum => ({ kind: "Struct", field });
+
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Unit: (v: Extract<MyEnum, { kind: "Unit" }>) => R;
+        NewType: (v: Extract<MyEnum, { kind: "NewType" }>) => R;
+        Tuple: (v: Extract<MyEnum, { kind: "Tuple" }>) => R;
+        Struct: (v: Extract<MyEnum, { kind: "Struct" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
-
-    export class MyEnumVariantUnit extends MyEnum {
-        constructor () {
-            super();
-        }
-    }
-
-    export class MyEnumVariantNewType extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-    }
-
-    export class MyEnumVariantTuple extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
-    }
-
-    export class MyEnumVariantStruct extends MyEnum {
-        constructor (public field: bool) {
-            super();
-        }
-    }
-    ");
+    "#);
 }
 
 #[test]

--- a/crates/facet_generate/src/generation/typescript/emitter/tests_bincode.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/tests_bincode.rs
@@ -414,6 +414,40 @@ fn enum_with_unit_variants() {
     }): R {
         return cases[value.kind as EnumWithUnitVariants["kind"]](value as never);
     }
+
+    export function serializeEnumWithUnitVariants(value: EnumWithUnitVariants, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                break;
+            }
+            case "Variant3": {
+                serializer.serializeVariantIndex(2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeEnumWithUnitVariants(deserializer: Deserializer): EnumWithUnitVariants {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Variant1" };
+            }
+            case 1: {
+                return { kind: "Variant2" };
+            }
+            case 2: {
+                return { kind: "Variant3" };
+            }
+            default: throw new Error("Unknown variant index for EnumWithUnitVariants: " + index);
+        }
+    }
     "#);
 }
 
@@ -441,6 +475,26 @@ fn enum_with_unit_struct_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Variant1" };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -466,6 +520,28 @@ fn enum_with_1_tuple_variants() {
         Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const value = deserializer.deserializeStr();
+                return { kind: "Variant1", value };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }
@@ -498,6 +574,37 @@ fn enum_with_newtype_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeI32(value.value);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const value = deserializer.deserializeStr();
+                return { kind: "Variant1", value };
+            }
+            case 1: {
+                const value = deserializer.deserializeI32();
+                return { kind: "Variant2", value };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -529,6 +636,43 @@ fn enum_with_tuple_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.field0);
+                serializer.serializeI32(value.field1);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeBool(value.field0);
+                serializer.serializeF64(value.field1);
+                serializer.serializeU8(value.field2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const field0 = deserializer.deserializeStr();
+                const field1 = deserializer.deserializeI32();
+                return { kind: "Variant1", field0, field1 };
+            }
+            case 1: {
+                const field0 = deserializer.deserializeBool();
+                const field1 = deserializer.deserializeF64();
+                const field2 = deserializer.deserializeU8();
+                return { kind: "Variant2", field0, field1, field2 };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -554,6 +698,30 @@ fn enum_with_struct_variants() {
         Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.field1);
+                serializer.serializeI32(value.field2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const field1 = deserializer.deserializeStr();
+                const field2 = deserializer.deserializeI32();
+                return { kind: "Variant1", field1, field2 };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }
@@ -595,6 +763,55 @@ fn enum_with_mixed_variants() {
         Struct: (v: Extract<MyEnum, { kind: "Struct" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Unit": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            case "NewType": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            case "Tuple": {
+                serializer.serializeVariantIndex(2);
+                serializer.serializeStr(value.field0);
+                serializer.serializeI32(value.field1);
+                break;
+            }
+            case "Struct": {
+                serializer.serializeVariantIndex(3);
+                serializer.serializeBool(value.field);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Unit" };
+            }
+            case 1: {
+                const value = deserializer.deserializeStr();
+                return { kind: "NewType", value };
+            }
+            case 2: {
+                const field0 = deserializer.deserializeStr();
+                const field1 = deserializer.deserializeI32();
+                return { kind: "Tuple", field0, field1 };
+            }
+            case 3: {
+                const field = deserializer.deserializeBool();
+                return { kind: "Struct", field };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }

--- a/crates/facet_generate/src/generation/typescript/emitter/tests_bincode.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/tests_bincode.rs
@@ -396,60 +396,23 @@ fn enum_with_unit_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class EnumWithUnitVariants {
-        abstract serialize(serializer: Serializer): void;
+    export type EnumWithUnitVariants =
+        | { kind: "Variant1" }
+        | { kind: "Variant2" }
+        | { kind: "Variant3" };
 
-        static deserialize(deserializer: Deserializer): EnumWithUnitVariants {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return EnumWithUnitVariantsVariantVariant1.load(deserializer);
-                case 1: return EnumWithUnitVariantsVariantVariant2.load(deserializer);
-                case 2: return EnumWithUnitVariantsVariantVariant3.load(deserializer);
-                default: throw new Error("Unknown variant index for EnumWithUnitVariants: " + index);
-            }
-        }
-    }
+    export const enumWithUnitVariantsVariant1 = (): EnumWithUnitVariants => ({ kind: "Variant1" });
 
-    export class EnumWithUnitVariantsVariantVariant1 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
+    export const enumWithUnitVariantsVariant2 = (): EnumWithUnitVariants => ({ kind: "Variant2" });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
+    export const enumWithUnitVariantsVariant3 = (): EnumWithUnitVariants => ({ kind: "Variant3" });
 
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant1 {
-            return new EnumWithUnitVariantsVariantVariant1();
-        }
-    }
-
-    export class EnumWithUnitVariantsVariantVariant2 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-        }
-
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant2 {
-            return new EnumWithUnitVariantsVariantVariant2();
-        }
-    }
-
-    export class EnumWithUnitVariantsVariantVariant3 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(2);
-        }
-
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant3 {
-            return new EnumWithUnitVariantsVariantVariant3();
-        }
+    export function matchEnumWithUnitVariants<R>(value: EnumWithUnitVariants, cases: {
+        Variant1: (v: Extract<EnumWithUnitVariants, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<EnumWithUnitVariants, { kind: "Variant2" }>) => R;
+        Variant3: (v: Extract<EnumWithUnitVariants, { kind: "Variant3" }>) => R;
+    }): R {
+        return cases[value.kind as EnumWithUnitVariants["kind"]](value as never);
     }
     "#);
 }
@@ -468,30 +431,15 @@ fn enum_with_unit_struct_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1" };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (): MyEnum => ({ kind: "Variant1" });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            return new MyEnumVariantVariant1();
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -509,32 +457,15 @@ fn enum_with_1_tuple_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; value: str };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantVariant1(value);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -553,49 +484,19 @@ fn enum_with_newtype_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; value: str }
+        | { kind: "Variant2"; value: int32 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                case 1: return MyEnumVariantVariant2.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
+    export const myEnumVariant2 = (value: int32): MyEnum => ({ kind: "Variant2", value });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantVariant1(value);
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public value: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeI32(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant2 {
-            const value = deserializer.deserializeI32();
-            return new MyEnumVariantVariant2(value);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -614,55 +515,19 @@ fn enum_with_tuple_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; field0: str; field1: int32 }
+        | { kind: "Variant2"; field0: bool; field1: float64; field2: uint8 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                case 1: return MyEnumVariantVariant2.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (field0: str, field1: int32): MyEnum => ({ kind: "Variant1", field0, field1 });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
+    export const myEnumVariant2 = (field0: bool, field1: float64, field2: uint8): MyEnum => ({ kind: "Variant2", field0, field1, field2 });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.field0);
-            serializer.serializeI32(this.field1);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const field0 = deserializer.deserializeStr();
-            const field1 = deserializer.deserializeI32();
-            return new MyEnumVariantVariant1(field0,field1);
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public field0: bool, public field1: float64, public field2: uint8) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeBool(this.field0);
-            serializer.serializeF64(this.field1);
-            serializer.serializeU8(this.field2);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant2 {
-            const field0 = deserializer.deserializeBool();
-            const field1 = deserializer.deserializeF64();
-            const field2 = deserializer.deserializeU8();
-            return new MyEnumVariantVariant2(field0,field1,field2);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -680,34 +545,15 @@ fn enum_with_struct_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; field1: str; field2: int32 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (field1: str, field2: int32): MyEnum => ({ kind: "Variant1", field1, field2 });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field1: str, public field2: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.field1);
-            serializer.serializeI32(this.field2);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const field1 = deserializer.deserializeStr();
-            const field2 = deserializer.deserializeI32();
-            return new MyEnumVariantVariant1(field1,field2);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -728,83 +574,27 @@ fn enum_with_mixed_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Unit" }
+        | { kind: "NewType"; value: str }
+        | { kind: "Tuple"; field0: str; field1: int32 }
+        | { kind: "Struct"; field: bool };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantUnit.load(deserializer);
-                case 1: return MyEnumVariantNewType.load(deserializer);
-                case 2: return MyEnumVariantTuple.load(deserializer);
-                case 3: return MyEnumVariantStruct.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumUnit = (): MyEnum => ({ kind: "Unit" });
 
-    export class MyEnumVariantUnit extends MyEnum {
-        constructor () {
-            super();
-        }
+    export const myEnumNewType = (value: str): MyEnum => ({ kind: "NewType", value });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
+    export const myEnumTuple = (field0: str, field1: int32): MyEnum => ({ kind: "Tuple", field0, field1 });
 
-        static load(deserializer: Deserializer): MyEnumVariantUnit {
-            return new MyEnumVariantUnit();
-        }
-    }
+    export const myEnumStruct = (field: bool): MyEnum => ({ kind: "Struct", field });
 
-    export class MyEnumVariantNewType extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantNewType {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantNewType(value);
-        }
-    }
-
-    export class MyEnumVariantTuple extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(2);
-            serializer.serializeStr(this.field0);
-            serializer.serializeI32(this.field1);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantTuple {
-            const field0 = deserializer.deserializeStr();
-            const field1 = deserializer.deserializeI32();
-            return new MyEnumVariantTuple(field0,field1);
-        }
-    }
-
-    export class MyEnumVariantStruct extends MyEnum {
-        constructor (public field: bool) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(3);
-            serializer.serializeBool(this.field);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantStruct {
-            const field = deserializer.deserializeBool();
-            return new MyEnumVariantStruct(field);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Unit: (v: Extract<MyEnum, { kind: "Unit" }>) => R;
+        NewType: (v: Extract<MyEnum, { kind: "NewType" }>) => R;
+        Tuple: (v: Extract<MyEnum, { kind: "Tuple" }>) => R;
+        Struct: (v: Extract<MyEnum, { kind: "Struct" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }

--- a/crates/facet_generate/src/generation/typescript/emitter/tests_json.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/tests_json.rs
@@ -413,6 +413,40 @@ fn enum_with_unit_variants() {
     }): R {
         return cases[value.kind as EnumWithUnitVariants["kind"]](value as never);
     }
+
+    export function serializeEnumWithUnitVariants(value: EnumWithUnitVariants, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                break;
+            }
+            case "Variant3": {
+                serializer.serializeVariantIndex(2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeEnumWithUnitVariants(deserializer: Deserializer): EnumWithUnitVariants {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Variant1" };
+            }
+            case 1: {
+                return { kind: "Variant2" };
+            }
+            case 2: {
+                return { kind: "Variant3" };
+            }
+            default: throw new Error("Unknown variant index for EnumWithUnitVariants: " + index);
+        }
+    }
     "#);
 }
 
@@ -440,6 +474,26 @@ fn enum_with_unit_struct_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Variant1" };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -465,6 +519,28 @@ fn enum_with_1_tuple_variants() {
         Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const value = deserializer.deserializeStr();
+                return { kind: "Variant1", value };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }
@@ -497,6 +573,37 @@ fn enum_with_newtype_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeI32(value.value);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const value = deserializer.deserializeStr();
+                return { kind: "Variant1", value };
+            }
+            case 1: {
+                const value = deserializer.deserializeI32();
+                return { kind: "Variant2", value };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -528,6 +635,43 @@ fn enum_with_tuple_variants() {
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
     }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.field0);
+                serializer.serializeI32(value.field1);
+                break;
+            }
+            case "Variant2": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeBool(value.field0);
+                serializer.serializeF64(value.field1);
+                serializer.serializeU8(value.field2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const field0 = deserializer.deserializeStr();
+                const field1 = deserializer.deserializeI32();
+                return { kind: "Variant1", field0, field1 };
+            }
+            case 1: {
+                const field0 = deserializer.deserializeBool();
+                const field1 = deserializer.deserializeF64();
+                const field2 = deserializer.deserializeU8();
+                return { kind: "Variant2", field0, field1, field2 };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
+    }
     "#);
 }
 
@@ -553,6 +697,30 @@ fn enum_with_struct_variants() {
         Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Variant1": {
+                serializer.serializeVariantIndex(0);
+                serializer.serializeStr(value.field1);
+                serializer.serializeI32(value.field2);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                const field1 = deserializer.deserializeStr();
+                const field2 = deserializer.deserializeI32();
+                return { kind: "Variant1", field1, field2 };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }
@@ -594,6 +762,55 @@ fn enum_with_mixed_variants() {
         Struct: (v: Extract<MyEnum, { kind: "Struct" }>) => R;
     }): R {
         return cases[value.kind as MyEnum["kind"]](value as never);
+    }
+
+    export function serializeMyEnum(value: MyEnum, serializer: Serializer): void {
+        switch (value.kind) {
+            case "Unit": {
+                serializer.serializeVariantIndex(0);
+                break;
+            }
+            case "NewType": {
+                serializer.serializeVariantIndex(1);
+                serializer.serializeStr(value.value);
+                break;
+            }
+            case "Tuple": {
+                serializer.serializeVariantIndex(2);
+                serializer.serializeStr(value.field0);
+                serializer.serializeI32(value.field1);
+                break;
+            }
+            case "Struct": {
+                serializer.serializeVariantIndex(3);
+                serializer.serializeBool(value.field);
+                break;
+            }
+            default: throw new Error("Unknown variant: " + (value as any).kind);
+        }
+    }
+
+    export function deserializeMyEnum(deserializer: Deserializer): MyEnum {
+        const index = deserializer.deserializeVariantIndex();
+        switch (index) {
+            case 0: {
+                return { kind: "Unit" };
+            }
+            case 1: {
+                const value = deserializer.deserializeStr();
+                return { kind: "NewType", value };
+            }
+            case 2: {
+                const field0 = deserializer.deserializeStr();
+                const field1 = deserializer.deserializeI32();
+                return { kind: "Tuple", field0, field1 };
+            }
+            case 3: {
+                const field = deserializer.deserializeBool();
+                return { kind: "Struct", field };
+            }
+            default: throw new Error("Unknown variant index for MyEnum: " + index);
+        }
     }
     "#);
 }

--- a/crates/facet_generate/src/generation/typescript/emitter/tests_json.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/tests_json.rs
@@ -395,60 +395,23 @@ fn enum_with_unit_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class EnumWithUnitVariants {
-        abstract serialize(serializer: Serializer): void;
+    export type EnumWithUnitVariants =
+        | { kind: "Variant1" }
+        | { kind: "Variant2" }
+        | { kind: "Variant3" };
 
-        static deserialize(deserializer: Deserializer): EnumWithUnitVariants {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return EnumWithUnitVariantsVariantVariant1.load(deserializer);
-                case 1: return EnumWithUnitVariantsVariantVariant2.load(deserializer);
-                case 2: return EnumWithUnitVariantsVariantVariant3.load(deserializer);
-                default: throw new Error("Unknown variant index for EnumWithUnitVariants: " + index);
-            }
-        }
-    }
+    export const enumWithUnitVariantsVariant1 = (): EnumWithUnitVariants => ({ kind: "Variant1" });
 
-    export class EnumWithUnitVariantsVariantVariant1 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
+    export const enumWithUnitVariantsVariant2 = (): EnumWithUnitVariants => ({ kind: "Variant2" });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
+    export const enumWithUnitVariantsVariant3 = (): EnumWithUnitVariants => ({ kind: "Variant3" });
 
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant1 {
-            return new EnumWithUnitVariantsVariantVariant1();
-        }
-    }
-
-    export class EnumWithUnitVariantsVariantVariant2 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-        }
-
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant2 {
-            return new EnumWithUnitVariantsVariantVariant2();
-        }
-    }
-
-    export class EnumWithUnitVariantsVariantVariant3 extends EnumWithUnitVariants {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(2);
-        }
-
-        static load(deserializer: Deserializer): EnumWithUnitVariantsVariantVariant3 {
-            return new EnumWithUnitVariantsVariantVariant3();
-        }
+    export function matchEnumWithUnitVariants<R>(value: EnumWithUnitVariants, cases: {
+        Variant1: (v: Extract<EnumWithUnitVariants, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<EnumWithUnitVariants, { kind: "Variant2" }>) => R;
+        Variant3: (v: Extract<EnumWithUnitVariants, { kind: "Variant3" }>) => R;
+    }): R {
+        return cases[value.kind as EnumWithUnitVariants["kind"]](value as never);
     }
     "#);
 }
@@ -467,30 +430,15 @@ fn enum_with_unit_struct_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1" };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (): MyEnum => ({ kind: "Variant1" });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor () {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            return new MyEnumVariantVariant1();
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -508,32 +456,15 @@ fn enum_with_1_tuple_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; value: str };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantVariant1(value);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -552,49 +483,19 @@ fn enum_with_newtype_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; value: str }
+        | { kind: "Variant2"; value: int32 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                case 1: return MyEnumVariantVariant2.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (value: str): MyEnum => ({ kind: "Variant1", value });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
+    export const myEnumVariant2 = (value: int32): MyEnum => ({ kind: "Variant2", value });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantVariant1(value);
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public value: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeI32(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant2 {
-            const value = deserializer.deserializeI32();
-            return new MyEnumVariantVariant2(value);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -613,55 +514,19 @@ fn enum_with_tuple_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; field0: str; field1: int32 }
+        | { kind: "Variant2"; field0: bool; field1: float64; field2: uint8 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                case 1: return MyEnumVariantVariant2.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (field0: str, field1: int32): MyEnum => ({ kind: "Variant1", field0, field1 });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
+    export const myEnumVariant2 = (field0: bool, field1: float64, field2: uint8): MyEnum => ({ kind: "Variant2", field0, field1, field2 });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.field0);
-            serializer.serializeI32(this.field1);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const field0 = deserializer.deserializeStr();
-            const field1 = deserializer.deserializeI32();
-            return new MyEnumVariantVariant1(field0,field1);
-        }
-    }
-
-    export class MyEnumVariantVariant2 extends MyEnum {
-        constructor (public field0: bool, public field1: float64, public field2: uint8) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeBool(this.field0);
-            serializer.serializeF64(this.field1);
-            serializer.serializeU8(this.field2);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant2 {
-            const field0 = deserializer.deserializeBool();
-            const field1 = deserializer.deserializeF64();
-            const field2 = deserializer.deserializeU8();
-            return new MyEnumVariantVariant2(field0,field1,field2);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+        Variant2: (v: Extract<MyEnum, { kind: "Variant2" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -679,34 +544,15 @@ fn enum_with_struct_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Variant1"; field1: str; field2: int32 };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantVariant1.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumVariant1 = (field1: str, field2: int32): MyEnum => ({ kind: "Variant1", field1, field2 });
 
-    export class MyEnumVariantVariant1 extends MyEnum {
-        constructor (public field1: str, public field2: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-            serializer.serializeStr(this.field1);
-            serializer.serializeI32(this.field2);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantVariant1 {
-            const field1 = deserializer.deserializeStr();
-            const field2 = deserializer.deserializeI32();
-            return new MyEnumVariantVariant1(field1,field2);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Variant1: (v: Extract<MyEnum, { kind: "Variant1" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }
@@ -727,83 +573,27 @@ fn enum_with_mixed_variants() {
     insta::assert_snapshot!(actual, @r#"
 
 
-    export abstract class MyEnum {
-        abstract serialize(serializer: Serializer): void;
+    export type MyEnum =
+        | { kind: "Unit" }
+        | { kind: "NewType"; value: str }
+        | { kind: "Tuple"; field0: str; field1: int32 }
+        | { kind: "Struct"; field: bool };
 
-        static deserialize(deserializer: Deserializer): MyEnum {
-            const index = deserializer.deserializeVariantIndex();
-            switch (index) {
-                case 0: return MyEnumVariantUnit.load(deserializer);
-                case 1: return MyEnumVariantNewType.load(deserializer);
-                case 2: return MyEnumVariantTuple.load(deserializer);
-                case 3: return MyEnumVariantStruct.load(deserializer);
-                default: throw new Error("Unknown variant index for MyEnum: " + index);
-            }
-        }
-    }
+    export const myEnumUnit = (): MyEnum => ({ kind: "Unit" });
 
-    export class MyEnumVariantUnit extends MyEnum {
-        constructor () {
-            super();
-        }
+    export const myEnumNewType = (value: str): MyEnum => ({ kind: "NewType", value });
 
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(0);
-        }
+    export const myEnumTuple = (field0: str, field1: int32): MyEnum => ({ kind: "Tuple", field0, field1 });
 
-        static load(deserializer: Deserializer): MyEnumVariantUnit {
-            return new MyEnumVariantUnit();
-        }
-    }
+    export const myEnumStruct = (field: bool): MyEnum => ({ kind: "Struct", field });
 
-    export class MyEnumVariantNewType extends MyEnum {
-        constructor (public value: str) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(1);
-            serializer.serializeStr(this.value);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantNewType {
-            const value = deserializer.deserializeStr();
-            return new MyEnumVariantNewType(value);
-        }
-    }
-
-    export class MyEnumVariantTuple extends MyEnum {
-        constructor (public field0: str, public field1: int32) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(2);
-            serializer.serializeStr(this.field0);
-            serializer.serializeI32(this.field1);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantTuple {
-            const field0 = deserializer.deserializeStr();
-            const field1 = deserializer.deserializeI32();
-            return new MyEnumVariantTuple(field0,field1);
-        }
-    }
-
-    export class MyEnumVariantStruct extends MyEnum {
-        constructor (public field: bool) {
-            super();
-        }
-
-        public serialize(serializer: Serializer): void {
-            serializer.serializeVariantIndex(3);
-            serializer.serializeBool(this.field);
-        }
-
-        static load(deserializer: Deserializer): MyEnumVariantStruct {
-            const field = deserializer.deserializeBool();
-            return new MyEnumVariantStruct(field);
-        }
+    export function matchMyEnum<R>(value: MyEnum, cases: {
+        Unit: (v: Extract<MyEnum, { kind: "Unit" }>) => R;
+        NewType: (v: Extract<MyEnum, { kind: "NewType" }>) => R;
+        Tuple: (v: Extract<MyEnum, { kind: "Tuple" }>) => R;
+        Struct: (v: Extract<MyEnum, { kind: "Struct" }>) => R;
+    }): R {
+        return cases[value.kind as MyEnum["kind"]](value as never);
     }
     "#);
 }

--- a/crates/facet_generate/src/generation/typescript/generator/tests.rs
+++ b/crates/facet_generate/src/generation/typescript/generator/tests.rs
@@ -31,7 +31,8 @@ use crate::{
         typescript::TypeScript,
     },
     reflection::format::{
-        ContainerFormat, Doc, Format, Named, Namespace, QualifiedTypeName, VariantFormat,
+        ContainerFormat, Doc, EnumTagging, Format, Named, Namespace, QualifiedTypeName,
+        VariantFormat,
     },
 };
 
@@ -204,12 +205,12 @@ fn update_qualified_names_enum_variants() {
     variants.insert(0, variant);
     registry.insert(
         QualifiedTypeName::root("Event".to_string()),
-        ContainerFormat::Enum(variants, Doc::new()),
+        ContainerFormat::Enum(variants, EnumTagging::External, Doc::new()),
     );
 
     let updated = TypeScriptCodeGenerator::update_qualified_names(&config, &registry);
     let (_, container) = updated.iter().next().unwrap();
-    let ContainerFormat::Enum(variants, _) = container else {
+    let ContainerFormat::Enum(variants, _, _) = container else {
         panic!("expected enum");
     };
     let variant = variants.get(&0).unwrap();

--- a/crates/facet_generate/src/reflection/format/mod.rs
+++ b/crates/facet_generate/src/reflection/format/mod.rs
@@ -252,6 +252,25 @@ pub enum Format {
 /// [`Registry`](crate::Registry).
 ///
 /// Each variant holds the [`Format`] nodes that describe
+/// How an enum's variants are tagged during serialization.
+///
+/// Extracted from `#[facet(tag = "...")]` / `#[facet(tag = "...", content = "...")]`
+/// on the Rust source type. Controls the discriminant field name and payload layout
+/// in the generated TypeScript discriminated union.
+#[derive(Serialize, Deserialize, Debug, Eq, Clone, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum EnumTagging {
+    /// No serde tag — the TypeScript discriminant defaults to `kind`.
+    /// Variants render as `{ kind: "VariantName"; ...payload }`.
+    External,
+    /// `#[facet(tag = "X")]` — tag field is inlined with other variant fields.
+    /// Variants render as `{ X: "VariantName"; ...fields }`.
+    Internal { tag: String },
+    /// `#[facet(tag = "X", content = "Y")]` — tag and payload in separate fields.
+    /// Variants render as `{ X: "VariantName"; Y: payload }`.
+    Adjacent { tag: String, content: String },
+}
+
 /// its fields or inner values, plus a [`Doc`] for documentation comments.
 ///
 /// See [`Format`] for how these are referenced from within other containers.
@@ -268,7 +287,7 @@ pub enum ContainerFormat {
     Struct(Vec<Named<Format>>, Doc),
     /// An enum, that is, an enumeration of variants.
     /// Each variant has a unique name and index within the enum.
-    Enum(BTreeMap<u32, Named<VariantFormat>>, Doc),
+    Enum(BTreeMap<u32, Named<VariantFormat>>, EnumTagging, Doc),
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
@@ -547,7 +566,7 @@ impl FormatHolder for ContainerFormat {
                     format.visit(f)?;
                 }
             }
-            Self::Enum(variants, _doc) => {
+            Self::Enum(variants, _tagging, _doc) => {
                 for variant in variants {
                     variant.1.visit(f)?;
                 }
@@ -570,7 +589,7 @@ impl FormatHolder for ContainerFormat {
                     format.visit_mut(f)?;
                 }
             }
-            Self::Enum(variants, _doc) => {
+            Self::Enum(variants, _tagging, _doc) => {
                 for variant in variants {
                     variant.1.visit_mut(f)?;
                 }

--- a/crates/facet_generate/src/reflection/format/tests.rs
+++ b/crates/facet_generate/src/reflection/format/tests.rs
@@ -3,7 +3,9 @@
 
 use std::{collections::HashSet, string::ToString};
 
-use crate::reflection::format::{ContainerFormat, Doc, Format, FormatHolder, Named, VariantFormat};
+use crate::reflection::format::{
+    ContainerFormat, Doc, EnumTagging, Format, FormatHolder, Named, VariantFormat,
+};
 
 #[test]
 fn test_format_visiting() {
@@ -24,6 +26,7 @@ fn test_format_visiting() {
         )]
         .into_iter()
         .collect(),
+        EnumTagging::External,
         Doc::new(),
     );
     let mut names = HashSet::new();

--- a/crates/facet_generate/src/reflection/mod.rs
+++ b/crates/facet_generate/src/reflection/mod.rs
@@ -47,7 +47,8 @@ use crate as fg;
 use crate::{Registry, error::Error};
 
 use format::{
-    ContainerFormat, Format, FormatHolder, Named, Namespace, QualifiedTypeName, VariantFormat,
+    ContainerFormat, EnumTagging, Format, FormatHolder, Named, Namespace, QualifiedTypeName,
+    VariantFormat,
 };
 
 const SUPPORTED_GENERIC_TYPES: [&str; 10] = [
@@ -808,7 +809,7 @@ impl RegistryBuilder {
         self.push_namespace(type_level_namespace);
 
         let variants = self.process_enum_variants(enum_type, shape)?;
-        let container = ContainerFormat::Enum(variants, shape.into());
+        let container = ContainerFormat::Enum(variants, extract_enum_tagging(shape), shape.into());
         self.push_with_type_check(enum_name, container, shape)?;
         self.pop();
 
@@ -1405,7 +1406,7 @@ impl RegistryBuilder {
                         }
                     }
                 }
-                ContainerFormat::Enum(_, _doc) => {
+                ContainerFormat::Enum(_, _, _doc) => {
                     if matches!(mode, UpdateMode::Force) {
                         todo!("Enum container format update not implemented");
                     }
@@ -1670,6 +1671,19 @@ fn extract_rename_from_shape_attributes(shape: &Shape) -> Option<&'static str> {
         }
     }
     None
+}
+
+fn extract_enum_tagging(shape: &Shape) -> EnumTagging {
+    match (shape.tag, shape.content) {
+        (Some(tag), Some(content)) => EnumTagging::Adjacent {
+            tag: tag.to_string(),
+            content: content.to_string(),
+        },
+        (Some(tag), None) => EnumTagging::Internal {
+            tag: tag.to_string(),
+        },
+        _ => EnumTagging::External,
+    }
 }
 
 fn extract_namespace_from_shape(shape: &Shape) -> Result<NamespaceAction, Error> {

--- a/crates/facet_generate/src/reflection/namespace_tests.rs
+++ b/crates/facet_generate/src/reflection/namespace_tests.rs
@@ -155,6 +155,7 @@ fn nested_namespaced_enums() {
                       NAMED: two
                     name: Child
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: one
@@ -168,6 +169,7 @@ fn nested_namespaced_enums() {
                       NAMED: one
                     name: GrandChild
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: one
@@ -177,6 +179,7 @@ fn nested_namespaced_enums() {
             None:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: two
@@ -186,6 +189,7 @@ fn nested_namespaced_enums() {
             Data:
               - NEWTYPE: STR
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -519,6 +523,7 @@ fn complex_namespaced_enums() {
             Simple:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: events
@@ -949,6 +954,7 @@ fn explicit_namespace_declarations() {
                       NAMED: events
                     name: SystemData
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: events
@@ -1174,6 +1180,7 @@ fn enums_with_explicit_namespace() {
             Empty:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: api
@@ -1525,6 +1532,7 @@ fn enum_variant_field_points_to_type_in_a_namespace() {
                       NAMED: other_namespace
                     name: Child
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: other_namespace
@@ -1569,6 +1577,7 @@ fn enum_struct_variant_field_points_to_type_in_a_namespace() {
                           name: Child
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: other_namespace
@@ -1630,6 +1639,7 @@ fn enum_struct_variant_multiple_fields_with_different_namespaces() {
                       - STR
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: namespace_a
@@ -2066,6 +2076,7 @@ fn enum_with_explicit_none_namespace() {
             Empty:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: data
@@ -2571,6 +2582,7 @@ fn enum_tuple_variant_collection_inheritance() {
                           NAMED: ns2
                         name: Item2
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: ns1
@@ -2641,6 +2653,7 @@ fn enum_struct_variant_collection_inheritance() {
                               name: Item2
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace:
         NAMED: ns1

--- a/crates/facet_generate/src/reflection/regression_tests/mod.rs
+++ b/crates/facet_generate/src/reflection/regression_tests/mod.rs
@@ -7,7 +7,7 @@
 //! Now they should all work correctly, demonstrating that the underlying issues have been resolved.
 
 use crate::reflection::RegistryBuilder;
-use crate::reflection::format::{ContainerFormat, Format, VariantFormat};
+use crate::reflection::format::{ContainerFormat, EnumTagging, Format, VariantFormat};
 
 #[cfg(test)]
 mod tests {
@@ -201,7 +201,7 @@ mod tests {
             },
         );
 
-        let enum_container = ContainerFormat::Enum(variants, Doc::new());
+        let enum_container = ContainerFormat::Enum(variants, EnumTagging::External, Doc::new());
         let type_name = QualifiedTypeName {
             namespace: Namespace::Named("test".to_string()),
             name: "EnumWithUnresolvedVariant".to_string(),

--- a/crates/facet_generate/src/reflection/tests.rs
+++ b/crates/facet_generate/src/reflection/tests.rs
@@ -912,6 +912,7 @@ fn nested_unit_enum() {
                         namespace: ROOT
                         name: MyUnit
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: MyUnit
@@ -928,6 +929,7 @@ fn nested_unit_enum() {
             C:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1003,6 +1005,7 @@ fn nested_enum_newtype_transparent_with_vec_of_u8_to_bytes() {
                   - BYTES
                   - U32
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: MyWrapper
@@ -1074,6 +1077,7 @@ fn nested_enum_newtype_transparent_with_str() {
                       - SEQ: STR
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: MyWrapper
@@ -1337,6 +1341,7 @@ fn enum_with_unit_variants() {
             Variant2:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1388,6 +1393,7 @@ fn enum_with_newtype_variants() {
             Variant7:
               - NEWTYPE: UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1425,6 +1431,7 @@ fn enum_with_newtype_variants_containing_user_defined_types() {
             Variant2:
               - NEWTYPE: U8
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1460,6 +1467,7 @@ fn enum_with_tuple_struct_variants() {
                   - I8
                   - U32
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1502,6 +1510,7 @@ fn enum_with_tuple_variants_containing_user_defined_types() {
                       namespace: ROOT
                       name: Inner
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1553,6 +1562,7 @@ fn enum_with_inline_struct_variants() {
                     namespace: ROOT
                     name: Inner
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1629,6 +1639,7 @@ fn enum_with_struct_variants_mixed_types() {
                           name: Inner
                       - []
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1663,6 +1674,7 @@ fn enum_with_struct_variant() {
                       - U8
                       - []
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1704,6 +1716,7 @@ fn struct_variant_with_only_opaque() {
             Ignore:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1726,6 +1739,7 @@ fn tuple_variant_with_only_opaque() {
             Ignore:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1776,6 +1790,7 @@ fn struct_variant_with_opaque() {
                       - U32
                       - []
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1799,6 +1814,7 @@ fn tuple_variant_with_opaque() {
               - TUPLE:
                   - STR
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1866,6 +1882,7 @@ fn enum_with_skip_serializing() {
             Variant3:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1912,6 +1929,7 @@ fn map_of_string_and_bool() {
                     KEY: STR
                     VALUE: BOOL
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -1934,6 +1952,7 @@ fn set_of_string() {
               - NEWTYPE:
                   SET: STR
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2111,6 +2130,7 @@ fn complex_map() {
                             SIZE: 4
                     VALUE: UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2244,6 +2264,7 @@ fn own_result_enum() {
             Timeout:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: HttpHeader
@@ -2288,6 +2309,7 @@ fn own_result_enum() {
                     namespace: ROOT
                     name: HttpError
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2337,6 +2359,7 @@ fn enum_rename() {
             Two:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2414,6 +2437,7 @@ fn enum_variant_rename() {
             Id:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2456,6 +2480,7 @@ fn enum_variant_rename_with_rename_all() {
             Id:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2501,6 +2526,7 @@ fn rename_all_enum() {
             someOtherVariant:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2528,6 +2554,7 @@ fn rename_all_enum_with_variant_rename_override() {
             someOtherVariant:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2678,6 +2705,7 @@ fn enum_struct_variant_field_rename() {
                       - STR
                       - []
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -2821,6 +2849,7 @@ fn tree_struct_with_mutual_recursion() {
                     ),
                 },
             },
+            External,
             Doc(
                 [],
             ),
@@ -2923,6 +2952,7 @@ fn tree_enum_with_mutual_recursion() {
                     ),
                 },
             },
+            External,
             Doc(
                 [],
             ),
@@ -3132,6 +3162,7 @@ fn enum_with_ref_variants() {
                     namespace: ROOT
                     name: Inner
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -3239,6 +3270,7 @@ fn enum_with_a_tuple_variant_that_is_itself_a_tuple() {
                     namespace: ROOT
                     name: (…)
               - []
+        - EXTERNAL
         - []
     ");
 }
@@ -3277,6 +3309,7 @@ fn enum_with_tuple_variant_of_user_types_in_a_mod() {
                       namespace: ROOT
                       name: Test2
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test1
@@ -3321,6 +3354,7 @@ fn enum_with_tuple_variant_of_lists_of_user_types() {
                         namespace: ROOT
                         name: Test2
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test1
@@ -3365,6 +3399,7 @@ fn enum_with_tuple_variant_of_option_of_user_types() {
                         namespace: ROOT
                         name: Test2
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test1
@@ -3414,6 +3449,7 @@ fn enum_with_tuple_variant_of_map_of_user_types() {
                           namespace: ROOT
                           name: Test2
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test1
@@ -3458,6 +3494,7 @@ fn enum_with_tuple_variant_of_set_of_user_types() {
                         namespace: ROOT
                         name: Test2
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test1
@@ -3500,6 +3537,7 @@ fn chrono_date_time() {
                       - STR
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: MyStruct

--- a/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/mod.rs
@@ -40,3 +40,7 @@ pub enum AdvancedColors2 {
     /// Comment on the last element
     ReallyCoolType(ExplicitlyNamedStruct),
 }
+
+crate::test! {
+    ExplicitlyNamedStruct, AdvancedColors, AdvancedColors2 for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/output.ts
@@ -1,30 +1,69 @@
-/** Struct comment */
-export interface ExplicitlyNamedStruct {
-    /** Field comment */
-    a: number;
-    b: number;
+type int32 = number;
+type Seq<T> = T[];
+type str = string;
+type uint32 = number;
+
+/// Enum comment
+export type AdvancedColors =
+    | { type: "Unit" }
+    | { type: "Str"; content: str }
+    | { type: "Number"; content: int32 }
+    | { type: "UnsignedNumber"; content: uint32 }
+    | { type: "NumberArray"; content: Seq<int32> }
+    | { type: "TestWithAnonymousStruct"; content: { a: uint32; b: uint32; } }
+    | { type: "TestWithExplicitlyNamedStruct"; content: ExplicitlyNamedStruct };
+
+export const advancedColorsUnit = (): AdvancedColors => ({ type: "Unit" });
+
+export const advancedColorsStr = (value: str): AdvancedColors => ({ type: "Str", content: value });
+
+export const advancedColorsNumber = (value: int32): AdvancedColors => ({ type: "Number", content: value });
+
+export const advancedColorsUnsignedNumber = (value: uint32): AdvancedColors => ({ type: "UnsignedNumber", content: value });
+
+export const advancedColorsNumberArray = (value: Seq<int32>): AdvancedColors => ({ type: "NumberArray", content: value });
+
+export const advancedColorsTestWithAnonymousStruct = (a: uint32, b: uint32): AdvancedColors => ({ type: "TestWithAnonymousStruct", content: { a, b } });
+
+export const advancedColorsTestWithExplicitlyNamedStruct = (value: ExplicitlyNamedStruct): AdvancedColors => ({ type: "TestWithExplicitlyNamedStruct", content: value });
+
+export function matchAdvancedColors<R>(value: AdvancedColors, cases: {
+    Unit: (v: Extract<AdvancedColors, { type: "Unit" }>) => R;
+    Str: (v: Extract<AdvancedColors, { type: "Str" }>) => R;
+    Number: (v: Extract<AdvancedColors, { type: "Number" }>) => R;
+    UnsignedNumber: (v: Extract<AdvancedColors, { type: "UnsignedNumber" }>) => R;
+    NumberArray: (v: Extract<AdvancedColors, { type: "NumberArray" }>) => R;
+    TestWithAnonymousStruct: (v: Extract<AdvancedColors, { type: "TestWithAnonymousStruct" }>) => R;
+    TestWithExplicitlyNamedStruct: (v: Extract<AdvancedColors, { type: "TestWithExplicitlyNamedStruct" }>) => R;
+}): R {
+    return cases[value.type as AdvancedColors["type"]](value as never);
 }
 
-/** Enum comment */
-export type AdvancedColors = 
-    | { type: "Unit" }
-    /** This is a case comment */
-    | { type: "Str", content: string }
-    | { type: "Number", content: number }
-    | { type: "UnsignedNumber", content: number }
-    | { type: "NumberArray", content: number[] }
-    | { type: "TestWithAnonymousStruct", content: {
-    a: number;
-    b: number;
-}}
-    /** Comment on the last element */
-    | { type: "TestWithExplicitlyNamedStruct", content: ExplicitlyNamedStruct };
+export type AdvancedColors2 =
+    | { type: "str"; content: str }
+    | { type: "number"; content: int32 }
+    | { type: "number-array"; content: Seq<int32> }
+    | { type: "really-cool-type"; content: ExplicitlyNamedStruct };
 
-export type AdvancedColors2 = 
-    /** This is a case comment */
-    | { type: "str", content: string }
-    | { type: "number", content: number }
-    | { type: "number-array", content: number[] }
-    /** Comment on the last element */
-    | { type: "really-cool-type", content: ExplicitlyNamedStruct };
+export const advancedColors2Str = (value: str): AdvancedColors2 => ({ type: "str", content: value });
 
+export const advancedColors2Number = (value: int32): AdvancedColors2 => ({ type: "number", content: value });
+
+export const advancedColors2NumberArray = (value: Seq<int32>): AdvancedColors2 => ({ type: "number-array", content: value });
+
+export const advancedColors2ReallyCoolType = (value: ExplicitlyNamedStruct): AdvancedColors2 => ({ type: "really-cool-type", content: value });
+
+export function matchAdvancedColors2<R>(value: AdvancedColors2, cases: {
+    str: (v: Extract<AdvancedColors2, { type: "str" }>) => R;
+    number: (v: Extract<AdvancedColors2, { type: "number" }>) => R;
+    number-array: (v: Extract<AdvancedColors2, { type: "number-array" }>) => R;
+    really-cool-type: (v: Extract<AdvancedColors2, { type: "really-cool-type" }>) => R;
+}): R {
+    return cases[value.type as AdvancedColors2["type"]](value as never);
+}
+
+/// Struct comment
+export class ExplicitlyNamedStruct {
+    constructor (public a: uint32, public b: uint32) {
+    }
+}

--- a/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum/output.ts
@@ -56,8 +56,8 @@ export const advancedColors2ReallyCoolType = (value: ExplicitlyNamedStruct): Adv
 export function matchAdvancedColors2<R>(value: AdvancedColors2, cases: {
     str: (v: Extract<AdvancedColors2, { type: "str" }>) => R;
     number: (v: Extract<AdvancedColors2, { type: "number" }>) => R;
-    number-array: (v: Extract<AdvancedColors2, { type: "number-array" }>) => R;
-    really-cool-type: (v: Extract<AdvancedColors2, { type: "really-cool-type" }>) => R;
+    "number-array": (v: Extract<AdvancedColors2, { type: "number-array" }>) => R;
+    "really-cool-type": (v: Extract<AdvancedColors2, { type: "really-cool-type" }>) => R;
 }): R {
     return cases[value.type as AdvancedColors2["type"]](value as never);
 }

--- a/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum_with_skipped_variants/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum_with_skipped_variants/mod.rs
@@ -15,3 +15,7 @@ pub enum SomeEnum {
     #[facet(skip)]
     E,
 }
+
+crate::test! {
+    SomeEnum for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum_with_skipped_variants/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_adjacently_tagged_enum_with_skipped_variants/output.ts
@@ -1,4 +1,16 @@
-export type SomeEnum = 
-    | { type: "A" }
-    | { type: "C", content: number };
+type int32 = number;
 
+export type SomeEnum =
+    | { type: "A" }
+    | { type: "C"; content: int32 };
+
+export const someEnumA = (): SomeEnum => ({ type: "A" });
+
+export const someEnumC = (value: int32): SomeEnum => ({ type: "C", content: value });
+
+export function matchSomeEnum<R>(value: SomeEnum, cases: {
+    A: (v: Extract<SomeEnum, { type: "A" }>) => R;
+    C: (v: Extract<SomeEnum, { type: "C" }>) => R;
+}): R {
+    return cases[value.type as SomeEnum["type"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_bare_string_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_bare_string_enum/mod.rs
@@ -9,7 +9,7 @@ pub enum Colors {
     Green,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Colors for kotlin
+    Colors for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_bare_string_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_bare_string_enum/output.ts
@@ -1,7 +1,20 @@
-/** This is a comment. */
-export enum Colors {
-    Red = "Red",
-    Blue = "Blue",
-    Green = "Green",
-}
 
+/// This is a comment.
+export type Colors =
+    | { kind: "Red" }
+    | { kind: "Blue" }
+    | { kind: "Green" };
+
+export const colorsRed = (): Colors => ({ kind: "Red" });
+
+export const colorsBlue = (): Colors => ({ kind: "Blue" });
+
+export const colorsGreen = (): Colors => ({ kind: "Green" });
+
+export function matchColors<R>(value: Colors, cases: {
+    Red: (v: Extract<Colors, { kind: "Red" }>) => R;
+    Blue: (v: Extract<Colors, { kind: "Blue" }>) => R;
+    Green: (v: Extract<Colors, { kind: "Green" }>) => R;
+}): R {
+    return cases[value.kind as Colors["kind"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_adjacently_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_empty_adjacently_tagged_enum/mod.rs
@@ -13,3 +13,7 @@ pub enum Test {
     AnonymousEmptyStruct {},
     NoStruct,
 }
+
+crate::test! {
+    NamedEmptyStruct, Test for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_adjacently_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_empty_adjacently_tagged_enum/output.ts
@@ -1,9 +1,24 @@
-export interface NamedEmptyStruct {
+
+export class NamedEmptyStruct {
+    constructor () {
+    }
 }
 
-export type Test = 
-    | { type: "NamedEmptyStruct", content: NamedEmptyStruct }
-    | { type: "AnonymousEmptyStruct", content: {
-}}
+export type Test =
+    | { type: "NamedEmptyStruct"; content: NamedEmptyStruct }
+    | { type: "AnonymousEmptyStruct" }
     | { type: "NoStruct" };
 
+export const testNamedEmptyStruct = (value: NamedEmptyStruct): Test => ({ type: "NamedEmptyStruct", content: value });
+
+export const testAnonymousEmptyStruct = (): Test => ({ type: "AnonymousEmptyStruct" });
+
+export const testNoStruct = (): Test => ({ type: "NoStruct" });
+
+export function matchTest<R>(value: Test, cases: {
+    NamedEmptyStruct: (v: Extract<Test, { type: "NamedEmptyStruct" }>) => R;
+    AnonymousEmptyStruct: (v: Extract<Test, { type: "AnonymousEmptyStruct" }>) => R;
+    NoStruct: (v: Extract<Test, { type: "NoStruct" }>) => R;
+}): R {
+    return cases[value.type as Test["type"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_externally_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_empty_externally_tagged_enum/mod.rs
@@ -9,3 +9,7 @@ pub enum Test {
     NamedEmptyStruct(NamedEmptyStruct),
     AnonymousEmptyStruct {},
 }
+
+crate::test! {
+    NamedEmptyStruct, Test for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_externally_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_empty_externally_tagged_enum/output.ts
@@ -1,8 +1,20 @@
-export interface NamedEmptyStruct {
+
+export class NamedEmptyStruct {
+    constructor () {
+    }
 }
 
-export type Test = 
-    | { NamedEmptyStruct: NamedEmptyStruct }
-    | { AnonymousEmptyStruct: {
-}};
+export type Test =
+    | { kind: "NamedEmptyStruct"; value: NamedEmptyStruct }
+    | { kind: "AnonymousEmptyStruct" };
 
+export const testNamedEmptyStruct = (value: NamedEmptyStruct): Test => ({ kind: "NamedEmptyStruct", value });
+
+export const testAnonymousEmptyStruct = (): Test => ({ kind: "AnonymousEmptyStruct" });
+
+export function matchTest<R>(value: Test, cases: {
+    NamedEmptyStruct: (v: Extract<Test, { kind: "NamedEmptyStruct" }>) => R;
+    AnonymousEmptyStruct: (v: Extract<Test, { kind: "AnonymousEmptyStruct" }>) => R;
+}): R {
+    return cases[value.kind as Test["kind"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_internally_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_empty_internally_tagged_enum/mod.rs
@@ -7,3 +7,7 @@ pub enum Test {
     AnonymousEmptyStruct {},
     NoStruct,
 }
+
+crate::test! {
+    Test for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_empty_internally_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_empty_internally_tagged_enum/output.ts
@@ -1,5 +1,15 @@
-export type Test = 
-    | { type: "AnonymousEmptyStruct",
-}
+
+export type Test =
+    | { type: "AnonymousEmptyStruct" }
     | { type: "NoStruct" };
 
+export const testAnonymousEmptyStruct = (): Test => ({ type: "AnonymousEmptyStruct" });
+
+export const testNoStruct = (): Test => ({ type: "NoStruct" });
+
+export function matchTest<R>(value: Test, cases: {
+    AnonymousEmptyStruct: (v: Extract<Test, { type: "AnonymousEmptyStruct" }>) => R;
+    NoStruct: (v: Extract<Test, { type: "NoStruct" }>) => R;
+}): R {
+    return cases[value.type as Test["type"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_externally_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_externally_tagged_enum/mod.rs
@@ -25,3 +25,7 @@ pub enum SomeEnum {
     E(SomeNamedStruct),
     F(Option<SomeNamedStruct>),
 }
+
+crate::test! {
+    SomeResult, SomeNamedStruct, SomeEnum for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_externally_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_externally_tagged_enum/output.ts
@@ -1,24 +1,56 @@
-export interface SomeNamedStruct {
-    a_field: string;
-    another_field: number;
+type bool = boolean;
+type float32 = number;
+type Optional<T> = T | null;
+type str = string;
+type uint32 = number;
+
+export type SomeEnum =
+    | { kind: "A"; field1: str }
+    | { kind: "B"; field1: uint32; field2: float32 }
+    | { kind: "C"; field3: Optional<bool> }
+    | { kind: "D"; value: uint32 }
+    | { kind: "E"; value: SomeNamedStruct }
+    | { kind: "F"; value: Optional<SomeNamedStruct> };
+
+export const someEnumA = (field1: str): SomeEnum => ({ kind: "A", field1 });
+
+export const someEnumB = (field1: uint32, field2: float32): SomeEnum => ({ kind: "B", field1, field2 });
+
+export const someEnumC = (field3: Optional<bool>): SomeEnum => ({ kind: "C", field3 });
+
+export const someEnumD = (value: uint32): SomeEnum => ({ kind: "D", value });
+
+export const someEnumE = (value: SomeNamedStruct): SomeEnum => ({ kind: "E", value });
+
+export const someEnumF = (value: Optional<SomeNamedStruct>): SomeEnum => ({ kind: "F", value });
+
+export function matchSomeEnum<R>(value: SomeEnum, cases: {
+    A: (v: Extract<SomeEnum, { kind: "A" }>) => R;
+    B: (v: Extract<SomeEnum, { kind: "B" }>) => R;
+    C: (v: Extract<SomeEnum, { kind: "C" }>) => R;
+    D: (v: Extract<SomeEnum, { kind: "D" }>) => R;
+    E: (v: Extract<SomeEnum, { kind: "E" }>) => R;
+    F: (v: Extract<SomeEnum, { kind: "F" }>) => R;
+}): R {
+    return cases[value.kind as SomeEnum["kind"]](value as never);
 }
 
-export type SomeResult = 
-    | { Ok: number }
-    | { Error: string };
+export class SomeNamedStruct {
+    constructor (public a_field: str, public another_field: uint32) {
+    }
+}
 
-export type SomeEnum = 
-    | { A: {
-    field1: string;
-}}
-    | { B: {
-    field1: number;
-    field2: number;
-}}
-    | { C: {
-    field3?: boolean | null;
-}}
-    | { D: number }
-    | { E: SomeNamedStruct }
-    | { F: SomeNamedStruct | null };
+export type SomeResult =
+    | { kind: "Ok"; value: uint32 }
+    | { kind: "Error"; value: str };
 
+export const someResultOk = (value: uint32): SomeResult => ({ kind: "Ok", value });
+
+export const someResultError = (value: str): SomeResult => ({ kind: "Error", value });
+
+export function matchSomeResult<R>(value: SomeResult, cases: {
+    Ok: (v: Extract<SomeResult, { kind: "Ok" }>) => R;
+    Error: (v: Extract<SomeResult, { kind: "Error" }>) => R;
+}): R {
+    return cases[value.kind as SomeResult["kind"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_internally_tagged_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_internally_tagged_enum/mod.rs
@@ -18,3 +18,7 @@ pub enum SomeEnum {
     D { field3: Option<bool> },
     E(ExplicitlyNamedStruct),
 }
+
+crate::test! {
+    ExplicitlyNamedStruct, SomeEnum for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_internally_tagged_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_internally_tagged_enum/output.ts
@@ -1,19 +1,37 @@
-export interface ExplicitlyNamedStruct {
-    a_field: string;
-    another_field: number;
+type bool = boolean;
+type float32 = number;
+type Optional<T> = T | null;
+type str = string;
+type uint32 = number;
+
+export class ExplicitlyNamedStruct {
+    constructor (public a_field: str, public another_field: uint32) {
+    }
 }
 
-export type SomeEnum = 
+export type SomeEnum =
     | { type: "A" }
-    | { type: "B",
-    field1: string;
-}
-    | { type: "C",
-    field1: number;
-    field2: number;
-}
-    | { type: "D",
-    field3?: boolean | null;
-}
-    | { type: "E" } & (ExplicitlyNamedStruct);
+    | { type: "B"; field1: str }
+    | { type: "C"; field1: uint32; field2: float32 }
+    | { type: "D"; field3: Optional<bool> }
+    | { type: "E" } & ExplicitlyNamedStruct;
 
+export const someEnumA = (): SomeEnum => ({ type: "A" });
+
+export const someEnumB = (field1: str): SomeEnum => ({ type: "B", field1 });
+
+export const someEnumC = (field1: uint32, field2: float32): SomeEnum => ({ type: "C", field1, field2 });
+
+export const someEnumD = (field3: Optional<bool>): SomeEnum => ({ type: "D", field3 });
+
+export const someEnumE = (value: ExplicitlyNamedStruct): SomeEnum => ({ type: "E", ...value });
+
+export function matchSomeEnum<R>(value: SomeEnum, cases: {
+    A: (v: Extract<SomeEnum, { type: "A" }>) => R;
+    B: (v: Extract<SomeEnum, { type: "B" }>) => R;
+    C: (v: Extract<SomeEnum, { type: "C" }>) => R;
+    D: (v: Extract<SomeEnum, { type: "D" }>) => R;
+    E: (v: Extract<SomeEnum, { type: "E" }>) => R;
+}): R {
+    return cases[value.type as SomeEnum["type"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_readonly_fields/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_readonly_fields/mod.rs
@@ -8,3 +8,7 @@ pub struct SomeStruct {
     #[facet(fg::readonly)]
     field_b: Vec<String>,
 }
+
+crate::test! {
+    SomeStruct for typescript
+}

--- a/crates/facet_generate/src/tests/can_generate_readonly_fields/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_readonly_fields/output.ts
@@ -1,5 +1,8 @@
-export interface SomeStruct {
-    readonly field_a: number;
-    readonly field_b: string[];
-}
+type Seq<T> = T[];
+type str = string;
+type uint32 = number;
 
+export class SomeStruct {
+    constructor (public field_a: uint32, public field_b: Seq<str>) {
+    }
+}

--- a/crates/facet_generate/src/tests/can_generate_simple_struct_with_a_comment/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_simple_struct_with_a_comment/mod.rs
@@ -14,7 +14,7 @@ pub struct Person {
     pub location: Location,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Person for kotlin
+    Person for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_simple_struct_with_a_comment/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_simple_struct_with_a_comment/output.ts
@@ -1,13 +1,15 @@
-export interface Location {
+type Optional<T> = T | null;
+type Seq<T> = T[];
+type str = string;
+type uint8 = number;
+
+export class Location {
+    constructor () {
+    }
 }
 
-/** This is a comment. */
-export interface Person {
-    /** This is another comment */
-    name: string;
-    age: number;
-    info?: string | null;
-    emails: string[];
-    location: Location;
+/// This is a comment.
+export class Person {
+    constructor (public name: str, public age: uint8, public info: Optional<str>, public emails: Seq<str>, public location: Location) {
+    }
 }
-

--- a/crates/facet_generate/src/tests/can_generate_slice_of_user_type/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_slice_of_user_type/mod.rs
@@ -9,7 +9,7 @@ pub struct Video<'a> {
 #[derive(Facet, Serialize)]
 pub struct Tag;
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Video for kotlin
+    Video for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_slice_of_user_type/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_slice_of_user_type/output.ts
@@ -1,4 +1,11 @@
-export interface Video {
-    tags: Tag[];
+type Seq<T> = T[];
+
+export class Tag {
+    constructor () {
+    }
 }
 
+export class Video {
+    constructor (public tags: Seq<Tag>) {
+    }
+}

--- a/crates/facet_generate/src/tests/can_generate_struct_with_skipped_fields/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_struct_with_skipped_fields/mod.rs
@@ -11,7 +11,7 @@ pub struct MyStruct {
     d: i32,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    MyStruct for kotlin
+    MyStruct for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_struct_with_skipped_fields/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_struct_with_skipped_fields/output.ts
@@ -1,5 +1,6 @@
-export interface MyStruct {
-    a: number;
-    c: number;
-}
+type int32 = number;
 
+export class MyStruct {
+    constructor (public a: int32, public c: int32, public d: int32) {
+    }
+}

--- a/crates/facet_generate/src/tests/can_generate_unit_enum/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_unit_enum/mod.rs
@@ -11,7 +11,7 @@ pub enum Colors {
     Green = 2,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Colors for kotlin
+    Colors for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_unit_enum/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_unit_enum/output.ts
@@ -1,11 +1,21 @@
-/**
- * This is a comment.
- * Continued lovingly here
- */
-export enum Colors {
-    Red = "Red",
-    Blue = "Blue",
-    /** Green is a cool color */
-    Green = "Green",
-}
 
+/// This is a comment.
+/// Continued lovingly here
+export type Colors =
+    | { kind: "Red" }
+    | { kind: "Blue" }
+    | { kind: "Green" };
+
+export const colorsRed = (): Colors => ({ kind: "Red" });
+
+export const colorsBlue = (): Colors => ({ kind: "Blue" });
+
+export const colorsGreen = (): Colors => ({ kind: "Green" });
+
+export function matchColors<R>(value: Colors, cases: {
+    Red: (v: Extract<Colors, { kind: "Red" }>) => R;
+    Blue: (v: Extract<Colors, { kind: "Blue" }>) => R;
+    Green: (v: Extract<Colors, { kind: "Green" }>) => R;
+}): R {
+    return cases[value.kind as Colors["kind"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_generate_unit_structs/mod.rs
+++ b/crates/facet_generate/src/tests/can_generate_unit_structs/mod.rs
@@ -5,7 +5,7 @@ use facet::Facet;
 #[derive(Facet)]
 struct UnitStruct;
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    UnitStruct for kotlin
+    UnitStruct for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_generate_unit_structs/output.ts
+++ b/crates/facet_generate/src/tests/can_generate_unit_structs/output.ts
@@ -1,3 +1,5 @@
-export interface UnitStruct {
-}
 
+export class UnitStruct {
+    constructor () {
+    }
+}

--- a/crates/facet_generate/src/tests/can_handle_anonymous_struct/mod.rs
+++ b/crates/facet_generate/src/tests/can_handle_anonymous_struct/mod.rs
@@ -33,3 +33,7 @@ pub enum EnumWithManyVariants {
     AnotherUnitVariant,
     AnotherAnonVariant { uuid: String, thing: i32 },
 }
+
+crate::test! {
+    AutofilledBy, EnumWithManyVariants for typescript
+}

--- a/crates/facet_generate/src/tests/can_handle_anonymous_struct/output.ts
+++ b/crates/facet_generate/src/tests/can_handle_anonymous_struct/output.ts
@@ -1,29 +1,50 @@
-/** Enum keeping track of who autofilled a field */
-export type AutofilledBy = 
-    /** This field was autofilled by us */
-    | { type: "Us", content: {
-    /** The UUID for the fill */
-    uuid: string;
-}}
-    /** Something else autofilled this field */
-    | { type: "SomethingElse", content: {
-    /** The UUID for the fill */
-    uuid: string;
-    /** Some other thing */
-    thing: number;
-}};
+type int32 = number;
+type str = string;
 
-/** This is a comment (yareek sameek wuz here) */
-export type EnumWithManyVariants = 
+/// Enum keeping track of who autofilled a field
+export type AutofilledBy =
+    | { type: "Us"; content: { uuid: str; } }
+    | { type: "SomethingElse"; content: { uuid: str; thing: int32; } };
+
+export const autofilledByUs = (uuid: str): AutofilledBy => ({ type: "Us", content: { uuid } });
+
+export const autofilledBySomethingElse = (uuid: str, thing: int32): AutofilledBy => ({ type: "SomethingElse", content: { uuid, thing } });
+
+export function matchAutofilledBy<R>(value: AutofilledBy, cases: {
+    Us: (v: Extract<AutofilledBy, { type: "Us" }>) => R;
+    SomethingElse: (v: Extract<AutofilledBy, { type: "SomethingElse" }>) => R;
+}): R {
+    return cases[value.type as AutofilledBy["type"]](value as never);
+}
+
+/// This is a comment (yareek sameek wuz here)
+export type EnumWithManyVariants =
     | { type: "UnitVariant" }
-    | { type: "TupleVariantString", content: string }
-    | { type: "AnonVariant", content: {
-    uuid: string;
-}}
-    | { type: "TupleVariantInt", content: number }
+    | { type: "TupleVariantString"; content: str }
+    | { type: "AnonVariant"; content: { uuid: str; } }
+    | { type: "TupleVariantInt"; content: int32 }
     | { type: "AnotherUnitVariant" }
-    | { type: "AnotherAnonVariant", content: {
-    uuid: string;
-    thing: number;
-}};
+    | { type: "AnotherAnonVariant"; content: { uuid: str; thing: int32; } };
 
+export const enumWithManyVariantsUnitVariant = (): EnumWithManyVariants => ({ type: "UnitVariant" });
+
+export const enumWithManyVariantsTupleVariantString = (value: str): EnumWithManyVariants => ({ type: "TupleVariantString", content: value });
+
+export const enumWithManyVariantsAnonVariant = (uuid: str): EnumWithManyVariants => ({ type: "AnonVariant", content: { uuid } });
+
+export const enumWithManyVariantsTupleVariantInt = (value: int32): EnumWithManyVariants => ({ type: "TupleVariantInt", content: value });
+
+export const enumWithManyVariantsAnotherUnitVariant = (): EnumWithManyVariants => ({ type: "AnotherUnitVariant" });
+
+export const enumWithManyVariantsAnotherAnonVariant = (uuid: str, thing: int32): EnumWithManyVariants => ({ type: "AnotherAnonVariant", content: { uuid, thing } });
+
+export function matchEnumWithManyVariants<R>(value: EnumWithManyVariants, cases: {
+    UnitVariant: (v: Extract<EnumWithManyVariants, { type: "UnitVariant" }>) => R;
+    TupleVariantString: (v: Extract<EnumWithManyVariants, { type: "TupleVariantString" }>) => R;
+    AnonVariant: (v: Extract<EnumWithManyVariants, { type: "AnonVariant" }>) => R;
+    TupleVariantInt: (v: Extract<EnumWithManyVariants, { type: "TupleVariantInt" }>) => R;
+    AnotherUnitVariant: (v: Extract<EnumWithManyVariants, { type: "AnotherUnitVariant" }>) => R;
+    AnotherAnonVariant: (v: Extract<EnumWithManyVariants, { type: "AnotherAnonVariant" }>) => R;
+}): R {
+    return cases[value.type as EnumWithManyVariants["type"]](value as never);
+}

--- a/crates/facet_generate/src/tests/can_recognize_types_inside_modules/mod.rs
+++ b/crates/facet_generate/src/tests/can_recognize_types_inside_modules/mod.rs
@@ -39,7 +39,7 @@ pub struct OutsideOfModules {
     field: u32,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    A, AB, ABC, OutsideOfModules for kotlin
+    A, AB, ABC, OutsideOfModules for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/can_recognize_types_inside_modules/output.ts
+++ b/crates/facet_generate/src/tests/can_recognize_types_inside_modules/output.ts
@@ -1,16 +1,21 @@
-export interface A {
-    field: number;
+type uint32 = number;
+
+export class A {
+    constructor (public field: uint32) {
+    }
 }
 
-export interface ABC {
-    field: number;
+export class AB {
+    constructor (public field: uint32) {
+    }
 }
 
-export interface AB {
-    field: number;
+export class ABC {
+    constructor (public field: uint32) {
+    }
 }
 
-export interface OutsideOfModules {
-    field: number;
+export class OutsideOfModules {
+    constructor (public field: uint32) {
+    }
 }
-

--- a/crates/facet_generate/src/tests/deprecation_notice/mod.rs
+++ b/crates/facet_generate/src/tests/deprecation_notice/mod.rs
@@ -58,3 +58,7 @@ pub enum MyExternallyTaggedEnum {
     #[deprecated(note = "Use `VariantB` instead")]
     LegacyVariant(bool),
 }
+
+crate::test! {
+    MyLegacyStruct, MyLegacyAlias, MyLegacyEnum, MyUnitEnum, MyInternallyTaggedEnum, MyExternallyTaggedEnum for typescript
+}

--- a/crates/facet_generate/src/tests/deprecation_notice/output.ts
+++ b/crates/facet_generate/src/tests/deprecation_notice/output.ts
@@ -1,38 +1,89 @@
-/** @deprecated Use `MySuperAwesomeAlias` instead */
-export type MyLegacyAlias = number;
+type bool = boolean;
+type str = string;
+type uint32 = number;
 
-/** @deprecated Use `MySuperAwesomeStruct` instead */
-export interface MyLegacyStruct {
-    field: string;
+export type MyExternallyTaggedEnum =
+    | { kind: "VariantA"; value: str }
+    | { kind: "VariantB"; value: uint32 }
+    | { kind: "LegacyVariant"; value: bool };
+
+export const myExternallyTaggedEnumVariantA = (value: str): MyExternallyTaggedEnum => ({ kind: "VariantA", value });
+
+export const myExternallyTaggedEnumVariantB = (value: uint32): MyExternallyTaggedEnum => ({ kind: "VariantB", value });
+
+export const myExternallyTaggedEnumLegacyVariant = (value: bool): MyExternallyTaggedEnum => ({ kind: "LegacyVariant", value });
+
+export function matchMyExternallyTaggedEnum<R>(value: MyExternallyTaggedEnum, cases: {
+    VariantA: (v: Extract<MyExternallyTaggedEnum, { kind: "VariantA" }>) => R;
+    VariantB: (v: Extract<MyExternallyTaggedEnum, { kind: "VariantB" }>) => R;
+    LegacyVariant: (v: Extract<MyExternallyTaggedEnum, { kind: "LegacyVariant" }>) => R;
+}): R {
+    return cases[value.kind as MyExternallyTaggedEnum["kind"]](value as never);
 }
 
-/** @deprecated Use `MySuperAwesomeEnum` instead */
-export enum MyLegacyEnum {
-    VariantA = "VariantA",
-    VariantB = "VariantB",
-    VariantC = "VariantC",
+export type MyInternallyTaggedEnum =
+    | { type: "VariantA"; field: str }
+    | { type: "VariantB"; field: uint32 }
+    | { type: "LegacyVariant"; field: bool };
+
+export const myInternallyTaggedEnumVariantA = (field: str): MyInternallyTaggedEnum => ({ type: "VariantA", field });
+
+export const myInternallyTaggedEnumVariantB = (field: uint32): MyInternallyTaggedEnum => ({ type: "VariantB", field });
+
+export const myInternallyTaggedEnumLegacyVariant = (field: bool): MyInternallyTaggedEnum => ({ type: "LegacyVariant", field });
+
+export function matchMyInternallyTaggedEnum<R>(value: MyInternallyTaggedEnum, cases: {
+    VariantA: (v: Extract<MyInternallyTaggedEnum, { type: "VariantA" }>) => R;
+    VariantB: (v: Extract<MyInternallyTaggedEnum, { type: "VariantB" }>) => R;
+    LegacyVariant: (v: Extract<MyInternallyTaggedEnum, { type: "LegacyVariant" }>) => R;
+}): R {
+    return cases[value.type as MyInternallyTaggedEnum["type"]](value as never);
 }
 
-export enum MyUnitEnum {
-    VariantA = "VariantA",
-    VariantB = "VariantB",
-    /** @deprecated Use `VariantB` instead */
-    LegacyVariant = "LegacyVariant",
+export class MyLegacyAlias {
+    constructor (public value: uint32) {
+    }
 }
 
-export type MyInternallyTaggedEnum = 
-    | { type: "VariantA",
-    field: string;
-}
-    | { type: "VariantB",
-    field: number;
-}
-    | /** @deprecated Use `VariantA` instead */ { type: "LegacyVariant",
-    field: boolean;
-};
+export type MyLegacyEnum =
+    | { kind: "VariantA" }
+    | { kind: "VariantB" }
+    | { kind: "VariantC" };
 
-export type MyExternallyTaggedEnum = 
-    | { VariantA: string }
-    | { VariantB: number }
-    | /** @deprecated Use `VariantB` instead */ { LegacyVariant: boolean };
+export const myLegacyEnumVariantA = (): MyLegacyEnum => ({ kind: "VariantA" });
 
+export const myLegacyEnumVariantB = (): MyLegacyEnum => ({ kind: "VariantB" });
+
+export const myLegacyEnumVariantC = (): MyLegacyEnum => ({ kind: "VariantC" });
+
+export function matchMyLegacyEnum<R>(value: MyLegacyEnum, cases: {
+    VariantA: (v: Extract<MyLegacyEnum, { kind: "VariantA" }>) => R;
+    VariantB: (v: Extract<MyLegacyEnum, { kind: "VariantB" }>) => R;
+    VariantC: (v: Extract<MyLegacyEnum, { kind: "VariantC" }>) => R;
+}): R {
+    return cases[value.kind as MyLegacyEnum["kind"]](value as never);
+}
+
+export class MyLegacyStruct {
+    constructor (public field: str) {
+    }
+}
+
+export type MyUnitEnum =
+    | { kind: "VariantA" }
+    | { kind: "VariantB" }
+    | { kind: "LegacyVariant" };
+
+export const myUnitEnumVariantA = (): MyUnitEnum => ({ kind: "VariantA" });
+
+export const myUnitEnumVariantB = (): MyUnitEnum => ({ kind: "VariantB" });
+
+export const myUnitEnumLegacyVariant = (): MyUnitEnum => ({ kind: "LegacyVariant" });
+
+export function matchMyUnitEnum<R>(value: MyUnitEnum, cases: {
+    VariantA: (v: Extract<MyUnitEnum, { kind: "VariantA" }>) => R;
+    VariantB: (v: Extract<MyUnitEnum, { kind: "VariantB" }>) => R;
+    LegacyVariant: (v: Extract<MyUnitEnum, { kind: "LegacyVariant" }>) => R;
+}): R {
+    return cases[value.kind as MyUnitEnum["kind"]](value as never);
+}

--- a/crates/facet_generate/src/tests/generate_types/mod.rs
+++ b/crates/facet_generate/src/tests/generate_types/mod.rs
@@ -19,7 +19,7 @@ pub struct Types {
     pub custom_type: CustomType,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Types for kotlin
+    Types for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/generate_types/output.ts
+++ b/crates/facet_generate/src/tests/generate_types/output.ts
@@ -1,16 +1,18 @@
-export interface CustomType {
+type float32 = number;
+type float64 = number;
+type int32 = number;
+type int8 = number;
+type ListTuple<T extends any[]> = Tuple<T>[];
+type Optional<T> = T | null;
+type Seq<T> = T[];
+type str = string;
+
+export class CustomType {
+    constructor () {
+    }
 }
 
-export interface Types {
-    s: string;
-    static_s: string;
-    int8: number;
-    float: number;
-    double: number;
-    array: string[];
-    fixed_length_array: [string, string, string, string];
-    dictionary: Record<string, number>;
-    optional_dictionary?: Record<string, number> | null;
-    custom_type: CustomType;
+export class Types {
+    constructor (public s: str, public static_s: str, public int8: int8, public float: float32, public double: float64, public array: Seq<str>, public fixed_length_array: ListTuple<[str]>, public dictionary: Map<str,int32>, public optional_dictionary: Optional<Map<str,int32>>, public custom_type: CustomType) {
+    }
 }
-

--- a/crates/facet_generate/src/tests/generates_empty_structs_and_initializers/mod.rs
+++ b/crates/facet_generate/src/tests/generates_empty_structs_and_initializers/mod.rs
@@ -3,7 +3,7 @@ use facet::Facet;
 #[derive(Facet)]
 pub struct MyEmptyStruct {}
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    MyEmptyStruct for kotlin
+    MyEmptyStruct for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/generates_empty_structs_and_initializers/output.ts
+++ b/crates/facet_generate/src/tests/generates_empty_structs_and_initializers/output.ts
@@ -1,3 +1,5 @@
-export interface MyEmptyStruct {
-}
 
+export class MyEmptyStruct {
+    constructor () {
+    }
+}

--- a/crates/facet_generate/src/tests/use_correct_decoded_variable_name/mod.rs
+++ b/crates/facet_generate/src/tests/use_correct_decoded_variable_name/mod.rs
@@ -3,7 +3,7 @@ use facet::Facet;
 #[derive(Facet)]
 pub struct MyEmptyStruct {}
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    MyEmptyStruct for kotlin
+    MyEmptyStruct for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/use_correct_decoded_variable_name/output.ts
+++ b/crates/facet_generate/src/tests/use_correct_decoded_variable_name/output.ts
@@ -1,3 +1,5 @@
-export interface MyEmptyStruct {
-}
 
+export class MyEmptyStruct {
+    constructor () {
+    }
+}

--- a/crates/facet_generate/src/tests/use_correct_integer_types/mod.rs
+++ b/crates/facet_generate/src/tests/use_correct_integer_types/mod.rs
@@ -11,7 +11,7 @@ pub struct Foo {
     pub g: u32,
 }
 
-// TODO: enable swift, typescript (expect files need updating for no-encoding output)
+// TODO: enable swift
 crate::test! {
-    Foo for kotlin
+    Foo for kotlin, typescript
 }

--- a/crates/facet_generate/src/tests/use_correct_integer_types/output.ts
+++ b/crates/facet_generate/src/tests/use_correct_integer_types/output.ts
@@ -1,10 +1,12 @@
-/** This is a comment. */
-export interface Foo {
-    a: number;
-    b: number;
-    c: number;
-    e: number;
-    f: number;
-    g: number;
-}
+type int16 = number;
+type int32 = number;
+type int8 = number;
+type uint16 = number;
+type uint32 = number;
+type uint8 = number;
 
+/// This is a comment.
+export class Foo {
+    constructor (public a: int8, public b: int16, public c: int32, public e: uint8, public f: uint16, public g: uint32) {
+    }
+}

--- a/crates/facet_generate/tests/common_tests.rs
+++ b/crates/facet_generate/tests/common_tests.rs
@@ -42,6 +42,7 @@ fn test_get_simple_registry() {
                       - U8
                       - []
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: Test
@@ -91,6 +92,7 @@ fn test_get_registry() {
             E:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: List
@@ -109,6 +111,7 @@ fn test_get_registry() {
                       namespace: ROOT
                       name: List
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: NewTypeStruct
@@ -325,6 +328,7 @@ fn test_get_registry() {
             EmptyStructVariant:
               - UNIT
               - []
+        - EXTERNAL
         - []
     ? namespace: ROOT
       name: SimpleList

--- a/crates/facet_generate/tests/readme.rs
+++ b/crates/facet_generate/tests/readme.rs
@@ -1,11 +1,10 @@
 //! Keeps the generated-code examples in the top-level `README.md` in sync with
 //! what the generators actually produce.
 //!
-//! For Swift, Kotlin, and C# we reflect `Point` (a representative struct) and
-//! extract just its declaration. For TypeScript we show the full generated
-//! module (struct + enum), because TypeScript enums now produce a discriminated
-//! union type rather than a class and the declaration-extraction logic does not
-//! handle that format.
+//! For each language we reflect both `Point` (a struct) and `Shape` (an enum)
+//! and emit the full generated module, stripping only language-level preamble
+//! (import/package/using declarations). The result is embedded in the README
+//! inside collapsible `<details>` blocks.
 //!
 //! Each language's output is compared against the fenced code block embedded in
 //! the README between marker comments such as:
@@ -69,7 +68,7 @@ struct Block {
     marker: &'static str,
     /// Language tag for the ```` ```lang ```` fence.
     fence: &'static str,
-    /// The generated source for the `HttpHeader` declaration.
+    /// The generated source code.
     code: String,
 }
 
@@ -142,7 +141,8 @@ fn generate_swift(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "Point")
+    let source = find_source_with_token(dir.path(), "Point").expect("Swift module not found");
+    strip_preamble(&source)
 }
 
 fn generate_kotlin(registry: &Registry) -> String {
@@ -151,27 +151,18 @@ fn generate_kotlin(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "Point")
+    let source = find_source_with_token(dir.path(), "Point").expect("Kotlin module not found");
+    strip_preamble(&source)
 }
 
-/// For TypeScript we show the full generated module (minus import statements)
-/// because enums now produce discriminated union types rather than classes, and
-/// the brace-balanced `extract_declaration` helper cannot handle that format.
 fn generate_typescript(registry: &Registry) -> String {
     let dir = tempfile::tempdir().unwrap();
     typescript::Installer::new("example", dir.path())
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    let source = find_source_with_declaration(dir.path(), "Point")
-        .expect("generated TypeScript module not found");
-    source
-        .lines()
-        .skip_while(|line| line.starts_with("import "))
-        .collect::<Vec<_>>()
-        .join("\n")
-        .trim_start()
-        .to_string()
+    let source = find_source_with_token(dir.path(), "Point").expect("TypeScript module not found");
+    strip_preamble(&source)
 }
 
 fn generate_csharp(registry: &Registry) -> String {
@@ -180,23 +171,31 @@ fn generate_csharp(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "Point")
+    let source = find_source_with_token(dir.path(), "Point").expect("C# module not found");
+    strip_preamble(&source)
 }
 
-/// Walks `dir`, finds the generated module file that declares `type_name`, and
-/// returns the dedented source for just that declaration (including any
-/// immediately-preceding attribute/doc-comment lines).
-fn extract_declaration(dir: &Path, type_name: &str) -> String {
-    let source = find_source_with_declaration(dir, type_name).unwrap_or_else(|| {
-        panic!(
-            "no generated file declares `{type_name}` under {}",
-            dir.display()
-        )
-    });
-    extract_block(&source, type_name)
+/// Strips language preamble (import / package / using lines and blank lines
+/// between them) from the start of a generated source file.
+fn strip_preamble(source: &str) -> String {
+    source
+        .lines()
+        .skip_while(|line| {
+            let t = line.trim();
+            t.is_empty()
+                || t.starts_with("import ")
+                || t.starts_with("package ")
+                || t.starts_with("using ")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_start()
+        .to_string()
 }
 
-fn find_source_with_declaration(dir: &Path, type_name: &str) -> Option<String> {
+/// Walks `dir` and returns the contents of the first source file that contains
+/// `token` as a word.
+fn find_source_with_token(dir: &Path, token: &str) -> Option<String> {
     let mut stack = vec![dir.to_path_buf()];
     while let Some(path) = stack.pop() {
         let entries = fs::read_dir(&path).ok()?;
@@ -205,87 +204,13 @@ fn find_source_with_declaration(dir: &Path, type_name: &str) -> Option<String> {
             if path.is_dir() {
                 stack.push(path);
             } else if let Ok(contents) = fs::read_to_string(&path)
-                && declares_type(&contents, type_name)
+                && contents.contains(token)
             {
                 return Some(contents);
             }
         }
     }
     None
-}
-
-fn declares_type(source: &str, type_name: &str) -> bool {
-    source.lines().any(|line| is_declaration(line, type_name))
-}
-
-fn is_declaration(line: &str, type_name: &str) -> bool {
-    const KEYWORDS: [&str; 4] = ["struct ", "class ", "interface ", "enum "];
-    KEYWORDS.iter().any(|kw| line.contains(kw)) && line.contains(type_name)
-}
-
-/// Extracts the brace-balanced block declaring `type_name`, including any
-/// directly preceding attribute (`[...]`) or doc-comment (`///`) lines, then
-/// removes common leading indentation.
-fn extract_block(source: &str, type_name: &str) -> String {
-    let lines: Vec<&str> = source.lines().collect();
-    let decl = lines
-        .iter()
-        .position(|line| is_declaration(line, type_name))
-        .expect("declaration line not found");
-
-    // Include directly-preceding attribute / doc-comment lines.
-    let mut start = decl;
-    while start > 0 {
-        let prev = lines[start - 1].trim_start();
-        if prev.starts_with("///") || prev.starts_with('[') {
-            start -= 1;
-        } else {
-            break;
-        }
-    }
-
-    let mut depth = 0i32;
-    let mut seen_brace = false;
-    let mut end = decl;
-    for (offset, line) in lines[decl..].iter().enumerate() {
-        for ch in line.chars() {
-            match ch {
-                '{' => {
-                    depth += 1;
-                    seen_brace = true;
-                }
-                '}' => depth -= 1,
-                _ => {}
-            }
-        }
-        if seen_brace && depth == 0 {
-            end = decl + offset;
-            break;
-        }
-    }
-
-    dedent(&lines[start..=end])
-}
-
-fn dedent(lines: &[&str]) -> String {
-    let indent = lines
-        .iter()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| line.len() - line.trim_start().len())
-        .min()
-        .unwrap_or(0);
-
-    lines
-        .iter()
-        .map(|line| {
-            if line.len() >= indent {
-                &line[indent..]
-            } else {
-                line.trim_start()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 // --- README rewriting -------------------------------------------------------

--- a/crates/facet_generate/tests/readme.rs
+++ b/crates/facet_generate/tests/readme.rs
@@ -1,10 +1,14 @@
 //! Keeps the generated-code examples in the top-level `README.md` in sync with
 //! what the generators actually produce.
 //!
-//! For each target language we reflect the `HttpHeader` type used in the README,
-//! generate the bincode-enabled output, extract just the `HttpHeader`
-//! declaration, and compare it against the fenced code block embedded in the
-//! README between marker comments such as:
+//! For Swift, Kotlin, and C# we reflect `Point` (a representative struct) and
+//! extract just its declaration. For TypeScript we show the full generated
+//! module (struct + enum), because TypeScript enums now produce a discriminated
+//! union type rather than a class and the declaration-extraction logic does not
+//! handle that format.
+//!
+//! Each language's output is compared against the fenced code block embedded in
+//! the README between marker comments such as:
 //!
 //! ```text
 //! <!-- generated:swift:start -->
@@ -34,13 +38,28 @@ use facet::Facet;
 use facet_generate::{
     Registry,
     generation::{bincode::BincodePlugin, csharp, kotlin, swift, typescript},
-    reflect,
+    reflection::RegistryBuilder,
 };
 
 #[derive(Facet)]
-struct HttpHeader {
-    name: String,
-    value: String,
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Facet)]
+#[repr(C)]
+#[allow(dead_code)]
+enum Shape {
+    Circle {
+        centre: Point,
+        radius: f64,
+    },
+    Rectangle {
+        position: Point,
+        width: f64,
+        height: f64,
+    },
 }
 
 /// The README block we keep in sync, identified by the marker name and the
@@ -56,7 +75,11 @@ struct Block {
 
 #[test]
 fn readme_examples_are_up_to_date() {
-    let registry = reflect!(HttpHeader).unwrap();
+    let registry = RegistryBuilder::new()
+        .add_type::<Shape>()
+        .unwrap()
+        .build()
+        .unwrap();
 
     let blocks = vec![
         Block {
@@ -119,7 +142,7 @@ fn generate_swift(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "HttpHeader")
+    extract_declaration(dir.path(), "Point")
 }
 
 fn generate_kotlin(registry: &Registry) -> String {
@@ -128,16 +151,27 @@ fn generate_kotlin(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "HttpHeader")
+    extract_declaration(dir.path(), "Point")
 }
 
+/// For TypeScript we show the full generated module (minus import statements)
+/// because enums now produce discriminated union types rather than classes, and
+/// the brace-balanced `extract_declaration` helper cannot handle that format.
 fn generate_typescript(registry: &Registry) -> String {
     let dir = tempfile::tempdir().unwrap();
     typescript::Installer::new("example", dir.path())
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "HttpHeader")
+    let source = find_source_with_declaration(dir.path(), "Point")
+        .expect("generated TypeScript module not found");
+    source
+        .lines()
+        .skip_while(|line| line.starts_with("import "))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_start()
+        .to_string()
 }
 
 fn generate_csharp(registry: &Registry) -> String {
@@ -146,7 +180,7 @@ fn generate_csharp(registry: &Registry) -> String {
         .plugin(BincodePlugin)
         .generate(registry)
         .unwrap();
-    extract_declaration(dir.path(), "HttpHeader")
+    extract_declaration(dir.path(), "Point")
 }
 
 /// Walks `dir`, finds the generated module file that declares `type_name`, and

--- a/crates/facet_generate/tests/typescript_runtime.rs
+++ b/crates/facet_generate/tests/typescript_runtime.rs
@@ -119,10 +119,11 @@ Deno.test("bincode serialization matches deserialization", () => {{
   const deserializer = new BincodeDeserializer(expectedBytes);
   const deserializedInstance: Test = Test.deserialize(deserializer);
 
+  const expectedChoice: Choice = choiceC(7);
   const expectedInstance: Test = new Test(
     [4, 6],
     [BigInt(-3), BigInt(5)],
-    new ChoiceVariantC(7),
+    expectedChoice,
   );
 
   assertEquals(deserializedInstance, expectedInstance, "Object instances should match");


### PR DESCRIPTION
closes: #83 

## Summary

- Replace abstract class hierarchies with TypeScript discriminated union types for enums
- Add constructor arrow functions (`fooBar(...)`) and per-enum `matchFoo<R>(...)` helpers
- Update bincode and JSON plugins to emit standalone `serializeX` / `deserializeX` functions for enum types, branching `Format::TypeName` serialization based on whether the type is an enum
- Add `EnumTagging` to the format AST (`External` / `Internal { tag }` / `Adjacent { tag, content }`) and extract it from `#[facet(tag = ..., content = ...)]` attributes
- Add `enum_type_names: BTreeSet<String>` to `CodeGeneratorConfig`, populated by `update_from`
- Fix clippy pedantic warnings in the TypeScript emitter
- Wire up TypeScript expect tests for 21 previously-untested or disabled test cases
- Fix: quote non-identifier property keys (e.g. kebab-case) in generated `matchX` function case types

## Usage examples

Given this Rust enum:

```rust
#[derive(Facet)]
#[repr(C)]
pub enum Shape {
    Circle { radius: f64 },
    Rectangle { width: f64, height: f64 },
    Point,
}
```

The generated TypeScript is:

```typescript
export type Shape =
    | { kind: "Circle"; radius: float64 }
    | { kind: "Rectangle"; width: float64; height: float64 }
    | { kind: "Point" };

export const shapeCircle = (radius: float64): Shape => ({ kind: "Circle", radius });
export const shapeRectangle = (width: float64, height: float64): Shape => ({ kind: "Rectangle", width, height });
export const shapePoint = (): Shape => ({ kind: "Point" });

export function matchShape<R>(value: Shape, cases: {
    Circle: (v: Extract<Shape, { kind: "Circle" }>) => R;
    Rectangle: (v: Extract<Shape, { kind: "Rectangle" }>) => R;
    Point: (v: Extract<Shape, { kind: "Point" }>) => R;
}): R {
    return cases[value.kind as Shape["kind"]](value as never);
}
```

**Constructing values:**

```typescript
const circle = shapeCircle(3.14);
const rect = shapeRectangle(10, 20);
const point = shapePoint();
```

**Exhaustive pattern matching:**

```typescript
const area = matchShape(shape, {
    Circle: ({ radius }) => Math.PI * radius ** 2,
    Rectangle: ({ width, height }) => width * height,
    Point: () => 0,
});
```

**Type narrowing without `matchShape`** — TypeScript's built-in narrowing works directly on the `kind` field:

```typescript
if (shape.kind === "Circle") {
    console.log(shape.radius); // TypeScript knows this is a Circle
}
```

**Internally tagged enums** (`#[facet(tag = "type")]`) inline the tag alongside the payload fields:

```rust
#[facet(tag = "type")]
pub enum Event {
    Click { x: i32, y: i32 },
    KeyPress { key: String },
}
```

```typescript
export type Event =
    | { type: "Click"; x: int32; y: int32 }
    | { type: "KeyPress"; key: str };
```

**Adjacently tagged enums** (`#[facet(tag = "type", content = "data")]`) wrap the payload under a content field:

```rust
#[facet(tag = "type", content = "data")]
pub enum Message {
    Text(String),
    Image { url: String, alt: String },
}
```

```typescript
export type Message =
    | { type: "Text"; data: str }
    | { type: "Image"; data: { url: str; alt: str; } };
```

## Test plan

- [x] `cargo test -p facet_generate` passes clean (784 lib tests + all integration tests)
- [x] Bincode runtime roundtrip test passes with Deno (`test_typescript_runtime_bincode_serialization`)
- [x] Snapshot and expect files reviewed for correctness across external, internal, and adjacent tagging modes
- [x] Kebab-case variant names correctly quoted in match function case types