### PR TITLE
fix: escape reserved C# identifiers in bincode output

### DIFF
--- a/crates/facet_generate/src/generation/bincode/csharp.rs
+++ b/crates/facet_generate/src/generation/bincode/csharp.rs
@@ -20,6 +20,7 @@
 //! | `type_body` | `Serialize`/`Deserialize`/`BincodeSerialize`/`BincodeDeserialize` methods |
 //! | `after_type` | `{EnumName}Bincode` static helper class for all-unit enums |
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
@@ -239,6 +240,100 @@ fn is_all_unit_enum(format: &ContainerFormat) -> bool {
     }
 }
 
+/// Escapes an identifier when it is a reserved C# keyword.
+///
+/// C# verbatim identifiers preserve the identifier's spelling while allowing a
+/// keyword to be used in declaration and reference positions. Contextual
+/// keywords are intentionally omitted because the generated identifiers are
+/// method locals, where those words are valid without escaping.
+fn escape_identifier(identifier: &str) -> Cow<'_, str> {
+    const RESERVED_KEYWORDS: &[&str] = &[
+        "abstract",
+        "as",
+        "base",
+        "bool",
+        "break",
+        "byte",
+        "case",
+        "catch",
+        "char",
+        "checked",
+        "class",
+        "const",
+        "continue",
+        "decimal",
+        "default",
+        "delegate",
+        "do",
+        "double",
+        "else",
+        "enum",
+        "event",
+        "explicit",
+        "extern",
+        "false",
+        "finally",
+        "fixed",
+        "float",
+        "for",
+        "foreach",
+        "goto",
+        "if",
+        "implicit",
+        "in",
+        "int",
+        "interface",
+        "internal",
+        "is",
+        "lock",
+        "long",
+        "namespace",
+        "new",
+        "null",
+        "object",
+        "operator",
+        "out",
+        "override",
+        "params",
+        "private",
+        "protected",
+        "public",
+        "readonly",
+        "ref",
+        "return",
+        "sbyte",
+        "sealed",
+        "short",
+        "sizeof",
+        "stackalloc",
+        "static",
+        "string",
+        "struct",
+        "switch",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typeof",
+        "uint",
+        "ulong",
+        "unchecked",
+        "unsafe",
+        "ushort",
+        "using",
+        "virtual",
+        "void",
+        "volatile",
+        "while",
+    ];
+
+    if RESERVED_KEYWORDS.contains(&identifier) {
+        Cow::Owned(format!("@{identifier}"))
+    } else {
+        Cow::Borrowed(identifier)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Main code-generation functions
 // ---------------------------------------------------------------------------
@@ -270,7 +365,8 @@ fn write_class_bincode_methods(
     with_block(w, Newlines::BOTH, |w| {
         writeln!(w, "deserializer.IncreaseContainerDepth();")?;
         for field in fields {
-            let local_name = field.name.to_lower_camel_case();
+            let lower_camel_name = field.name.to_lower_camel_case();
+            let local_name = escape_identifier(&lower_camel_name);
             write_deserialize_binding(w, &local_name, &field.value, c_style_enums)?;
         }
         writeln!(w, "deserializer.DecreaseContainerDepth();")?;
@@ -281,7 +377,8 @@ fn write_class_bincode_methods(
             with_block(w, Newlines::OPEN, |w| {
                 for field in fields {
                     let prop_name = field.name.to_upper_camel_case();
-                    let local_name = field.name.to_lower_camel_case();
+                    let lower_camel_name = field.name.to_lower_camel_case();
+                    let local_name = escape_identifier(&lower_camel_name);
                     writeln!(w, "{prop_name} = {local_name},")?;
                 }
                 Ok(())
@@ -613,16 +710,13 @@ fn deserializer_variant_body(
         }
         VariantFormat::Struct(fields) => {
             for field in fields {
-                write_deserialize_binding(
-                    w,
-                    &field.name.to_lower_camel_case(),
-                    &field.value,
-                    c_style_enums,
-                )?;
+                let lower_camel_name = field.name.to_lower_camel_case();
+                let local_name = escape_identifier(&lower_camel_name);
+                write_deserialize_binding(w, &local_name, &field.value, c_style_enums)?;
             }
             let args = fields
                 .iter()
-                .map(|field| field.name.to_lower_camel_case())
+                .map(|field| escape_identifier(&field.name.to_lower_camel_case()).into_owned())
                 .collect::<Vec<_>>()
                 .join(", ");
             writeln!(

--- a/crates/facet_generate/src/generation/csharp/emitter/tests_bincode/enums.rs
+++ b/crates/facet_generate/src/generation/csharp/emitter/tests_bincode/enums.rs
@@ -10,6 +10,31 @@ use super::super::*;
 use crate::{emit, generation::bincode::BincodePlugin};
 
 #[test]
+fn struct_variant_with_csharp_keyword_fields_escapes_deserialize_locals() {
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum KeywordVariant {
+        Values { event: bool, lock: bool },
+    }
+
+    let actual = emit!(KeywordVariant as CSharp with BincodePlugin).unwrap();
+
+    assert!(
+        actual.contains("var @event = deserializer.DeserializeBool();"),
+        "{actual}"
+    );
+    assert!(
+        actual.contains("var @lock = deserializer.DeserializeBool();"),
+        "{actual}"
+    );
+    assert!(
+        actual.contains("return new Values(@event, @lock);"),
+        "{actual}"
+    );
+}
+
+#[test]
 fn enum_with_unit_variants() {
     #[derive(Facet)]
     #[repr(C)]

--- a/crates/facet_generate/src/generation/csharp/emitter/tests_bincode/structs.rs
+++ b/crates/facet_generate/src/generation/csharp/emitter/tests_bincode/structs.rs
@@ -9,6 +9,36 @@ use super::super::*;
 use crate::{self as fg, emit, generation::bincode::BincodePlugin};
 
 #[test]
+fn struct_with_csharp_keyword_fields_escapes_deserialize_locals() {
+    #[derive(Facet)]
+    #[allow(clippy::struct_excessive_bools)]
+    struct KeywordFields {
+        event: bool,
+        lock: bool,
+        class: bool,
+        namespace: bool,
+    }
+
+    let actual = emit!(KeywordFields as CSharp with BincodePlugin).unwrap();
+
+    for (keyword, property) in [
+        ("event", "Event"),
+        ("lock", "Lock"),
+        ("class", "Class"),
+        ("namespace", "Namespace"),
+    ] {
+        assert!(
+            actual.contains(&format!("var @{keyword} = deserializer.DeserializeBool();")),
+            "missing escaped declaration for {keyword}:\n{actual}"
+        );
+        assert!(
+            actual.contains(&format!("{property} = @{keyword},")),
+            "missing escaped reference for {keyword}:\n{actual}"
+        );
+    }
+}
+
+#[test]
 fn unit_struct() {
     /// line 1
     #[derive(Facet)]
@@ -258,7 +288,7 @@ fn struct_with_fields_of_primitive_types() {
         {
             deserializer.IncreaseContainerDepth();
             var unit = deserializer.DeserializeUnit();
-            var bool = deserializer.DeserializeBool();
+            var @bool = deserializer.DeserializeBool();
             var i8 = deserializer.DeserializeI8();
             var i16 = deserializer.DeserializeI16();
             var i32 = deserializer.DeserializeI32();
@@ -271,12 +301,12 @@ fn struct_with_fields_of_primitive_types() {
             var u128 = deserializer.DeserializeU128();
             var f32 = deserializer.DeserializeF32();
             var f64 = deserializer.DeserializeF64();
-            var char = deserializer.DeserializeChar();
-            var string = deserializer.DeserializeStr();
+            var @char = deserializer.DeserializeChar();
+            var @string = deserializer.DeserializeStr();
             deserializer.DecreaseContainerDepth();
             return new StructWithFields {
                 Unit = unit,
-                Bool = bool,
+                Bool = @bool,
                 I8 = i8,
                 I16 = i16,
                 I32 = i32,
@@ -289,8 +319,8 @@ fn struct_with_fields_of_primitive_types() {
                 U128 = u128,
                 F32 = f32,
                 F64 = f64,
-                Char = char,
-                String = string,
+                Char = @char,
+                String = @string,
             };
         }
 

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -281,7 +281,7 @@ impl Emitter<TypeScript> for Format {
 
 impl Emitter<TypeScript> for Named<Format> {
     fn write<W: IndentWrite>(&self, w: &mut W, lang: &TypeScript) -> Result<()> {
-        write!(w, "public {}: ", &self.name)?;
+        write!(w, "public {}: ", self.name)?;
         self.value.write(w, lang)
     }
 }
@@ -319,7 +319,7 @@ fn output_struct_or_variant<W: IndentWrite>(
         .iter()
         .map(|f| {
             let type_str = quote_type(&f.value, lang);
-            format!("public {}: {}", &f.name, type_str)
+            format!("public {}: {}", f.name, type_str)
         })
         .collect();
     let args = args.join(", ");

--- a/crates/facet_generate/tests/csharp_generation.rs
+++ b/crates/facet_generate/tests/csharp_generation.rs
@@ -39,6 +39,35 @@ fn test_that_csharp_code_compiles_with_bincode() {
 }
 
 #[test]
+fn test_that_csharp_code_with_keyword_fields_compiles_with_bincode() {
+    #[derive(Facet)]
+    #[allow(clippy::struct_excessive_bools)]
+    struct KeywordFields {
+        event: bool,
+        lock: bool,
+        class: bool,
+        namespace: bool,
+    }
+
+    #[derive(Facet)]
+    #[repr(C)]
+    #[allow(unused)]
+    enum KeywordVariant {
+        Values { event: bool, lock: bool },
+    }
+
+    let registry = reflect!(KeywordFields, KeywordVariant).unwrap();
+    let dir = tempdir().unwrap();
+
+    csharp::Installer::new("Example.Testing", &dir)
+        .plugin(BincodePlugin)
+        .generate(&registry)
+        .unwrap();
+
+    dotnet_build(&dir);
+}
+
+#[test]
 fn test_that_csharp_code_compiles_with_json() {
     let registry = common::get_registry();
     let dir = tempdir().unwrap();

--- a/crates/facet_generate/tests/csharp_runtime.rs
+++ b/crates/facet_generate/tests/csharp_runtime.rs
@@ -7,7 +7,12 @@
 
 use std::{fs, io::Write as _, process::Command};
 
-use facet_generate::generation::{bincode::BincodePlugin, csharp};
+use facet::Facet;
+use facet_generate::{
+    generation::{bincode::BincodePlugin, csharp},
+    reflect,
+};
+use serde::Serialize;
 use tempfile::tempdir;
 
 pub mod common;
@@ -51,6 +56,58 @@ fn quote_bytes(bytes: &[u8]) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     )
+}
+
+#[test]
+fn test_csharp_bincode_runtime_with_keyword_fields() {
+    #[derive(Facet, Serialize)]
+    #[allow(clippy::struct_excessive_bools)]
+    struct KeywordFields {
+        event: bool,
+        lock: bool,
+        class: bool,
+        namespace: bool,
+    }
+
+    let registry = reflect!(KeywordFields).unwrap();
+    let dir = tempdir().unwrap();
+    let dir = dir.path().to_path_buf().join("testing");
+
+    csharp::Installer::new("Example.Testing", &dir)
+        .plugin(BincodePlugin)
+        .generate(&registry)
+        .unwrap();
+
+    let reference = bincode::serialize(&KeywordFields {
+        event: true,
+        lock: false,
+        class: true,
+        namespace: false,
+    })
+    .unwrap();
+
+    make_executable(&dir, "Example.Testing");
+    fs::write(
+        dir.join("Program.cs"),
+        format!(
+            r#"using System;
+using System.Linq;
+using Example.Testing;
+
+byte[] input = {bytes};
+var value = KeywordFields.BincodeDeserialize(input);
+
+if (!value.Event || value.Lock || !value.Class || value.Namespace)
+    throw new Exception("Keyword field values did not deserialize correctly");
+if (!input.SequenceEqual(value.BincodeSerialize()))
+    throw new Exception("Keyword field roundtrip failed");
+"#,
+            bytes = quote_bytes(&reference),
+        ),
+    )
+    .unwrap();
+
+    dotnet_run(&dir);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- escape reserved C# keywords in generated bincode deserialization locals
- use the escaped identifiers consistently in declarations and references
- cover regular structs and struct-style enum variants
- add generated-code compilation and bincode round-trip regressions

## Root cause

The C# bincode generator converted reflected field names to lower camel case and emitted them directly as local identifiers. Fields such as `event`, `lock`, `class`, and `namespace` therefore produced invalid C#.

The generator now prefixes reserved keywords with `@`, preserving field names and wire compatibility.

## Validation

- `cargo test -p facet_generate --lib`
- generated C# project containing reserved field names builds successfully
- generated C# bincode round-trip with reserved field names passes
- `git diff --check`

Closes #108
