### PR TITLE
fix(typescript): correct i64/i128 deserialization when low limb has high bit set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### 🐛 Bug Fixes
+
+- fix(typescript): Correct `deserializeI64` / `deserializeI128` when the low limb has its high bit set. The previous BigInt `|` of signed halves dropped the upper limb (e.g. epoch-millis timestamps).
+
 ## [0.17.2] - 2026-06-25
 
 ### 🐛 Bug Fixes

--- a/crates/facet_generate/runtime/typescript-node/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/runtime/typescript-node/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
@@ -103,25 +103,13 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeI64(): bigint {
-    const low = this.deserializeI32();
-    const high = this.deserializeI32();
-
-    // combine the two 32-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString())
-    );
+    return new DataView(this.read(8)).getBigInt64(0, true);
   }
 
   public deserializeI128(): bigint {
-    const low = this.deserializeI64();
-    const high = this.deserializeI64();
-
-    // combine the two 64-bit values and return (little endian)
-    return (
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString())
-    );
+    const low = BigInt.asUintN(64, this.deserializeI64());
+    const high = BigInt.asUintN(64, this.deserializeI64());
+    return BigInt.asIntN(128, low | (high << BinaryDeserializer.BIG_64));
   }
 
   public deserializeOptionTag(): boolean {

--- a/crates/facet_generate/src/generation/typescript/emitter/mod.rs
+++ b/crates/facet_generate/src/generation/typescript/emitter/mod.rs
@@ -281,7 +281,7 @@ impl Emitter<TypeScript> for Format {
 
 impl Emitter<TypeScript> for Named<Format> {
     fn write<W: IndentWrite>(&self, w: &mut W, lang: &TypeScript) -> Result<()> {
-        write!(w, "public {}: ", &self.name)?;
+        write!(w, "public {}: ", self.name)?;
         self.value.write(w, lang)
     }
 }
@@ -319,7 +319,7 @@ fn output_struct_or_variant<W: IndentWrite>(
         .iter()
         .map(|f| {
             let type_str = quote_type(&f.value, lang);
-            format!("public {}: {}", &f.name, type_str)
+            format!("public {}: {}", f.name, type_str)
         })
         .collect();
     let args = args.join(", ");

--- a/crates/facet_generate/tests/typescript_runtime.rs
+++ b/crates/facet_generate/tests/typescript_runtime.rs
@@ -151,3 +151,107 @@ Deno.test("bincode serialization matches deserialization", () => {{
         .unwrap();
     assert!(status.success());
 }
+
+#[test]
+fn test_typescript_runtime_i64_i128_low_limb_high_bit_roundtrip() {
+    let registry = common::get_simple_registry();
+    let dir = tempdir().unwrap();
+    let dir_path = dir.path();
+    std::fs::create_dir_all(dir_path).unwrap();
+
+    let mut installer = typescript::Installer::new("main", dir_path);
+    installer.install_serde_runtime().unwrap();
+    installer.install_bincode_runtime().unwrap();
+
+    let source_path = dir_path.join("test.ts");
+    let mut source = File::create(&source_path).unwrap();
+
+    writeln!(
+        source,
+        r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
+import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
+"#
+    )
+    .unwrap();
+
+    let config = CodeGeneratorConfig::new("main".to_string());
+    let generator = typescript::TypeScriptCodeGenerator::new(&config)
+        .with_plugins(vec![Arc::new(BincodePlugin)]);
+    generator.output(&mut source, &registry).unwrap();
+
+    const LARGE_I64: i64 = 1_785_688_513_662;
+    let reference = bincode::serialize(&Test {
+        a: vec![1],
+        b: (LARGE_I64, 9),
+        c: Choice::A,
+    })
+    .unwrap();
+
+    writeln!(
+        source,
+        r#"
+Deno.test("i64 with low-half bit 31 set round-trips", () => {{
+  const expectedBytes = new Uint8Array([{bytes}]);
+  const deserializer = new BincodeDeserializer(expectedBytes);
+  const value: Test = Test.deserialize(deserializer);
+
+  assertEquals(value.b[0], BigInt("{large}"), "i64 must keep high limb");
+  assertEquals(value.b[1], BigInt(9));
+
+  const serializer = new BincodeSerializer();
+  value.serialize(serializer);
+  assertEquals(serializer.getBytes(), expectedBytes, "bytes must round-trip");
+}});
+"#,
+        bytes = reference
+            .iter()
+            .map(|x| format!("{x}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        large = LARGE_I64,
+    )
+    .unwrap();
+
+    // Low limb (bits 0-63) has bit 63 set; the old signed-OR combine dropped
+    // the high limb the same way it did for i64.
+    const LARGE_I128: i128 = (1 << 64) | 0xF8C4_E09E_F8C4_E09E_u64 as i128;
+    const NEGATIVE_I128: i128 = i128::MIN + 5;
+    let i128_reference = bincode::serialize(&(LARGE_I128, NEGATIVE_I128)).unwrap();
+
+    writeln!(
+        source,
+        r#"
+Deno.test("i128 with low-limb bit 63 set round-trips", () => {{
+  const expectedBytes = new Uint8Array([{bytes}]);
+  const deserializer = new BincodeDeserializer(expectedBytes);
+  const large = deserializer.deserializeI128();
+  const negative = deserializer.deserializeI128();
+
+  assertEquals(large, BigInt("{large}"), "i128 must keep high limb");
+  assertEquals(negative, BigInt("{negative}"), "negative i128 must round-trip");
+
+  const serializer = new BincodeSerializer();
+  serializer.serializeI128(large);
+  serializer.serializeI128(negative);
+  assertEquals(serializer.getBytes(), expectedBytes, "bytes must round-trip");
+}});
+"#,
+        bytes = i128_reference
+            .iter()
+            .map(|x| format!("{x}"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        large = LARGE_I128,
+        negative = NEGATIVE_I128,
+    )
+    .unwrap();
+
+    let status = Command::new("deno")
+        .current_dir(dir_path)
+        .arg("test")
+        .arg("--sloppy-imports")
+        .arg(&source_path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}

--- a/crates/facet_generate/tests/typescript_runtime.rs
+++ b/crates/facet_generate/tests/typescript_runtime.rs
@@ -154,6 +154,12 @@ Deno.test("bincode serialization matches deserialization", () => {{
 
 #[test]
 fn test_typescript_runtime_i64_i128_low_limb_high_bit_roundtrip() {
+    const LARGE_I64: i64 = 1_785_688_513_662;
+    // Low limb (bits 0-63) has bit 63 set; the old signed-OR combine dropped
+    // the high limb the same way it did for i64.
+    const LARGE_I128: i128 = (1 << 64) | 0xF8C4_E09E_F8C4_E09E_u64 as i128;
+    const NEGATIVE_I128: i128 = i128::MIN + 5;
+
     let registry = common::get_simple_registry();
     let dir = tempdir().unwrap();
     let dir_path = dir.path();
@@ -179,7 +185,6 @@ import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
         .with_plugins(vec![Arc::new(BincodePlugin)]);
     generator.output(&mut source, &registry).unwrap();
 
-    const LARGE_I64: i64 = 1_785_688_513_662;
     let reference = bincode::serialize(&Test {
         a: vec![1],
         b: (LARGE_I64, 9),
@@ -212,10 +217,6 @@ Deno.test("i64 with low-half bit 31 set round-trips", () => {{
     )
     .unwrap();
 
-    // Low limb (bits 0-63) has bit 63 set; the old signed-OR combine dropped
-    // the high limb the same way it did for i64.
-    const LARGE_I128: i128 = (1 << 64) | 0xF8C4_E09E_F8C4_E09E_u64 as i128;
-    const NEGATIVE_I128: i128 = i128::MIN + 5;
     let i128_reference = bincode::serialize(&(LARGE_I128, NEGATIVE_I128)).unwrap();
 
     writeln!(


### PR DESCRIPTION
## Summary

TypeScript `deserializeI64` combined two **signed** i32 halves with BigInt `|`. When the low half has bit 31 set, JS sign-extends the negative BigInt and drops the high limb. Same pattern broke `deserializeI128` across its low limb.

## Before / after

Epoch-millis value `1785688513662` (`0x19F_C3545C7E` — low u32 `0xC3545C7E`, bit 31 set):

| | value |
|---|---|
| **wire / Rust** | `1785688513662` |
| **before (TS)** | `-1017881474` → `Date` ≈ 1969-12-20 |
| **after (TS)** | `1785688513662` |

```ts
// before
const low = this.deserializeI32();  // -1017881474
const high = this.deserializeI32(); // 415
return (BigInt(high) << 32n) | BigInt(low); // => -1017881474n  ❌

// after
return new DataView(this.read(8)).getBigInt64(0, true); // => 1785688513662n  ✅
```

Small i64 values (e.g. counter `21`) were unaffected; anything whose low 32 bits have bit 31 set was wrong — including every current epoch-millis timestamp and any `i64 >= 2^31`.

`deserializeI128` gets the analogous fix: combine the two 64-bit limbs as unsigned (`BigInt.asUintN`) before reinterpreting the 128-bit pattern as signed (`BigInt.asIntN`).

## Test plan

- [x] Deno round-trip regression for i64 with `1785688513662` (fails against the old deserializer, passes with the fix)
- [x] Deno round-trip regression for i128 with low limb bit 63 set (`(1 << 64) | 0xF8C4E09EF8C4E09E`) and `i128::MIN + 5`
- [x] `cargo nextest run -p facet_generate --features typescript test_typescript_runtime_i64`

Made with [Cursor](https://cursor.com)
