### PR TITLE
chore(typescript): consistent 64-bit integer access in serde runtime, plus i64 review follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,17 @@ TypeScript enums are now generated as **discriminated union types** instead of a
 ### 🐛 Bug Fixes
 
 - **fix(typescript): quote non-identifier property keys in match function** — variant names that are not valid JavaScript identifiers (e.g. `"number-array"` from `rename_all = "kebab-case"`) are now correctly quoted as string keys in the `matchX` cases object type [#106](https://github.com/redbadger/facet-generate/pull/106)
-- fix(typescript): Correct `deserializeI64` / `deserializeI128` when the low limb has its high bit set. The previous BigInt `|` of signed halves dropped the upper limb (e.g. epoch-millis timestamps).
+- **fix(typescript): correct `i64`/`i128` deserialization when the low limb has its high bit set** — the previous BigInt `|` of signed halves sign-extended the low limb and dropped the upper one, so any `i64` at or above `2^31` (including every current epoch-millis timestamp) decoded incorrectly [#110](https://github.com/redbadger/facet-generate/pull/110)
+- **fix(csharp): escape reserved C# identifiers in bincode output** — generated local variable names that collide with C# keywords (e.g. a field named `event` or `string`) are now prefixed with `@`, so the emitted bincode serializers compile [#109](https://github.com/redbadger/facet-generate/pull/109)
 
 ### 🧪 Tests
 
 - Enabled TypeScript output for 21 previously-disabled or untested expect-file test cases covering structs, unit enums, externally/internally/adjacently tagged enums, skipped variants, readonly fields, deprecation notices, and anonymous struct variants [#106](https://github.com/redbadger/facet-generate/pull/106)
+- Added edge-case round-trip coverage for every multi-limb integer in the TypeScript runtime (`i64`, `u64`, `i128`, `u128` at zero, ±1, the type extremes, and the 32-/64-bit limb boundaries), checked against bincode's encoding rather than against the runtime itself
+
+### ⚙️ Miscellaneous Tasks
+
+- chore(typescript): The `serde` runtime now reads and writes 64-bit integers with the native `DataView` `BigInt64`/`BigUint64` accessors instead of splitting them into 32-bit limbs, making `U64`/`U128` consistent with the `I64`/`I128` fix and retiring the now-unused `BIG_32` constants
 
 ---
 

--- a/crates/facet_generate/runtime/typescript-node/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/runtime/typescript-node/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/runtime/typescript-node/serde/binarySerializer.ts
+++ b/crates/facet_generate/runtime/typescript-node/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization/snapshots/typescript/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_namespaces_as_external/snapshots/typescript/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_external/snapshots/typescript/serde/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_serialization_and_serde_internal/snapshots/typescript/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_bincode/typescript/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binaryDeserializer.ts
@@ -6,7 +6,6 @@
 import { Deserializer } from "./deserializer";
 
 export abstract class BinaryDeserializer implements Deserializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
   private static readonly textDecoder = new TextDecoder();
   public buffer: ArrayBuffer;
@@ -69,25 +68,14 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeU64(): bigint {
-    const low = this.deserializeU32();
-    const high = this.deserializeU32();
-
-    // combine the two 32-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-        BigInt(low.toString()),
-    );
+    return new DataView(this.read(8)).getBigUint64(0, true);
   }
 
   public deserializeU128(): bigint {
+    // both limbs are unsigned, so they combine without sign extension
     const low = this.deserializeU64();
     const high = this.deserializeU64();
-
-    // combine the two 64-bit values and return (little endian)
-    return BigInt(
-      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-        BigInt(low.toString()),
-    );
+    return low | (high << BinaryDeserializer.BIG_64);
   }
 
   public deserializeI8(): number {

--- a/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binarySerializer.ts
+++ b/crates/facet_generate/src/generation/tests/with_uuid/snapshots_json/typescript/serde/binarySerializer.ts
@@ -6,10 +6,8 @@
 import { Serializer } from "./serializer";
 
 export abstract class BinarySerializer implements Serializer {
-  private static readonly BIG_32: bigint = BigInt(32);
   private static readonly BIG_64: bigint = BigInt(64);
 
-  private static readonly BIG_32Fs: bigint = BigInt("4294967295");
   private static readonly BIG_64Fs: bigint = BigInt("18446744073709551615");
 
   private static readonly textEncoder = new TextEncoder();
@@ -72,6 +70,17 @@ export abstract class BinarySerializer implements Serializer {
     this.offset += bytesLength;
   }
 
+  private serializeBigWithFunction(
+    fn: (byteOffset: number, value: bigint, littleEndian: boolean) => void,
+    bytesLength: number,
+    value: bigint,
+  ) {
+    this.ensureBufferWillHandleSize(bytesLength);
+    const dv = new DataView(this.buffer, this.offset);
+    fn.apply(dv, [0, value, true]);
+    this.offset += bytesLength;
+  }
+
   public serializeU8(value: number): void {
     this.serialize(new Uint8Array([value]));
   }
@@ -85,21 +94,19 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeU64(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeU32(Number(low));
-    this.serializeU32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigUint64,
+      8,
+      BigInt(value.toString()),
+    );
   }
 
   public serializeU128(value: BigInt | number): void {
-    const low = BigInt(value.toString()) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value.toString()) >> BinarySerializer.BIG_64;
+    const unsigned = BigInt(value.toString());
 
     // write little endian number
-    this.serializeU64(low);
-    this.serializeU64(high);
+    this.serializeU64(unsigned & BinarySerializer.BIG_64Fs);
+    this.serializeU64(unsigned >> BinarySerializer.BIG_64);
   }
 
   public serializeI8(value: number): void {
@@ -124,21 +131,20 @@ export abstract class BinarySerializer implements Serializer {
   }
 
   public serializeI64(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_32Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_32;
-
-    // write little endian number
-    this.serializeI32(Number(low));
-    this.serializeI32(Number(high));
+    this.serializeBigWithFunction(
+      DataView.prototype.setBigInt64,
+      8,
+      BigInt(value),
+    );
   }
 
   public serializeI128(value: bigint | number): void {
-    const low = BigInt(value) & BinarySerializer.BIG_64Fs;
-    const high = BigInt(value) >> BinarySerializer.BIG_64;
+    const signed = BigInt(value);
 
-    // write little endian number
-    this.serializeI64(low);
-    this.serializeI64(high);
+    // write little endian number; the low limb is unsigned, and setBigInt64
+    // reinterprets it as the same 64-bit pattern
+    this.serializeI64(signed & BinarySerializer.BIG_64Fs);
+    this.serializeI64(signed >> BinarySerializer.BIG_64);
   }
 
   public serializeOptionTag(value: boolean): void {

--- a/crates/facet_generate/tests/typescript_runtime.rs
+++ b/crates/facet_generate/tests/typescript_runtime.rs
@@ -4,43 +4,134 @@
 pub mod common;
 
 use common::{Choice, Test};
-use facet_generate::generation::{CodeGeneratorConfig, bincode::BincodePlugin, typescript};
-use std::{fs::File, io::Write, process::Command, sync::Arc};
-use tempfile::tempdir;
+use facet_generate::{
+    Registry,
+    generation::{CodeGeneratorConfig, bincode::BincodePlugin, typescript},
+};
+use std::{fs::File, io::Write, path::PathBuf, process::Command, sync::Arc};
+use tempfile::{TempDir, tempdir};
+
+/// A throwaway TypeScript project with the serde and bincode runtimes
+/// installed, and a `test.ts` primed with the imports plus the types generated
+/// from `registry`.
+///
+/// Append `Deno.test` blocks with [`TsProject::write_test`], then execute them
+/// with [`TsProject::run`].
+struct TsProject {
+    dir: TempDir,
+    source_path: PathBuf,
+    source: File,
+}
+
+impl TsProject {
+    fn new(registry: &Registry) -> Self {
+        let dir = tempdir().unwrap();
+
+        let mut installer = typescript::Installer::new("main", dir.path());
+        installer.install_serde_runtime().unwrap();
+        installer.install_bincode_runtime().unwrap();
+
+        let source_path = dir.path().join("test.ts");
+        let mut source = File::create(&source_path).unwrap();
+
+        writeln!(
+            source,
+            r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
+import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
+"#
+        )
+        .unwrap();
+
+        let config = CodeGeneratorConfig::new("main".to_string());
+        let generator = typescript::TypeScriptCodeGenerator::new(&config)
+            .with_plugins(vec![Arc::new(BincodePlugin)]);
+        generator.output(&mut source, registry).unwrap();
+
+        Self {
+            dir,
+            source_path,
+            source,
+        }
+    }
+
+    fn write_test(&mut self, body: &str) {
+        writeln!(self.source, "{body}").unwrap();
+    }
+
+    fn run(self) {
+        drop(self.source);
+
+        let status = Command::new("deno")
+            .current_dir(self.dir.path())
+            .arg("test")
+            .arg("--sloppy-imports")
+            .arg(&self.source_path)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+}
+
+/// Pairs each value with its bincode encoding, for [`scalar_roundtrip_test`].
+macro_rules! wire_cases {
+    ($($value:expr),* $(,)?) => {
+        vec![$((($value).to_string(), bincode::serialize(&$value).unwrap())),*]
+    };
+}
+
+/// Builds a Deno test that round-trips every `(value, bytes)` pair through the
+/// runtime's `deserialize{method}` and `serialize{method}`.
+///
+/// The expected bytes come from bincode on the Rust side, so the TypeScript
+/// runtime is checked against the wire format rather than against itself.
+fn scalar_roundtrip_test(test_name: &str, method: &str, cases: &[(String, Vec<u8>)]) -> String {
+    let rows = cases
+        .iter()
+        .map(|(value, bytes)| {
+            let bytes = bytes
+                .iter()
+                .map(u8::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("    {{ value: BigInt(\"{value}\"), bytes: new Uint8Array([{bytes}]) }},")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"
+Deno.test("{test_name}", () => {{
+  const cases = [
+{rows}
+  ];
+
+  for (const {{ value, bytes }} of cases) {{
+    const deserializer = new BincodeDeserializer(bytes);
+    assertEquals(
+      deserializer.deserialize{method}(),
+      value,
+      `deserialize{method}(${{value}})`,
+    );
+
+    const serializer = new BincodeSerializer();
+    serializer.serialize{method}(value);
+    assertEquals(
+      serializer.getBytes(),
+      bytes,
+      `serialize{method}(${{value}})`,
+    );
+  }}
+}});"#
+    )
+}
 
 #[test]
 fn test_typescript_runtime_bincode_uuid_roundtrip() {
-    let registry = common::get_uuid_registry();
-    let dir = tempdir().unwrap();
-    let dir_path = dir.path();
-    std::fs::create_dir_all(dir_path).unwrap();
-
-    let mut installer = typescript::Installer::new("main", dir_path);
-    installer.install_serde_runtime().unwrap();
-    installer.install_bincode_runtime().unwrap();
-
-    let source_path = dir_path.join("test.ts");
-    let mut source = File::create(&source_path).unwrap();
-
-    writeln!(
-        source,
-        r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
-import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
-"#
-    )
-    .unwrap();
-
-    let config = CodeGeneratorConfig::new("main".to_string());
-    let generator = typescript::TypeScriptCodeGenerator::new(&config)
-        .with_plugins(vec![Arc::new(BincodePlugin)]);
-    generator.output(&mut source, &registry).unwrap();
+    let mut project = TsProject::new(&common::get_uuid_registry());
 
     let reference = common::get_uuid_reference_bytes();
-    let id_str = common::UUID_ID.to_string();
-    let parent_id_str = common::UUID_PARENT_ID.to_string();
 
-    writeln!(
-        source,
+    project.write_test(&format!(
         r#"
 Deno.test("UUID bincode roundtrip", () => {{
   const expectedBytes = new Uint8Array([{bytes}]);
@@ -59,50 +150,19 @@ Deno.test("UUID bincode roundtrip", () => {{
 "#,
         bytes = reference
             .iter()
-            .map(|x| format!("{x}"))
+            .map(u8::to_string)
             .collect::<Vec<_>>()
             .join(", "),
-        id = id_str,
-        parent_id = parent_id_str,
-    )
-    .unwrap();
+        id = common::UUID_ID,
+        parent_id = common::UUID_PARENT_ID,
+    ));
 
-    let status = Command::new("deno")
-        .current_dir(dir_path)
-        .arg("test")
-        .arg("--sloppy-imports")
-        .arg(&source_path)
-        .status()
-        .unwrap();
-    assert!(status.success());
+    project.run();
 }
 
 #[test]
 fn test_typescript_runtime_bincode_serialization() {
-    let registry = common::get_simple_registry();
-    let dir = tempdir().unwrap();
-    let dir_path = dir.path();
-    std::fs::create_dir_all(dir_path).unwrap();
-
-    let mut installer = typescript::Installer::new("main", dir_path);
-    installer.install_serde_runtime().unwrap();
-    installer.install_bincode_runtime().unwrap();
-
-    let source_path = dir_path.join("test.ts");
-    let mut source = File::create(&source_path).unwrap();
-
-    writeln!(
-        source,
-        r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
-import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
-"#
-    )
-    .unwrap();
-
-    let config = CodeGeneratorConfig::new("main".to_string());
-    let generator = typescript::TypeScriptCodeGenerator::new(&config)
-        .with_plugins(vec![Arc::new(BincodePlugin)]);
-    generator.output(&mut source, &registry).unwrap();
+    let mut project = TsProject::new(&common::get_simple_registry());
 
     let reference = bincode::serialize(&Test {
         a: vec![4, 6],
@@ -111,11 +171,10 @@ import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
     })
     .unwrap();
 
-    writeln!(
-        source,
+    project.write_test(&format!(
         r#"
 Deno.test("bincode serialization matches deserialization", () => {{
-  const expectedBytes = new Uint8Array([{0}]);
+  const expectedBytes = new Uint8Array([{bytes}]);
   const deserializer = new BincodeDeserializer(expectedBytes);
   const deserializedInstance: Test = Test.deserialize(deserializer);
 
@@ -135,22 +194,14 @@ Deno.test("bincode serialization matches deserialization", () => {{
   assertEquals(serializedBytes, expectedBytes, "bincode bytes should match");
 }});
 "#,
-        reference
+        bytes = reference
             .iter()
-            .map(|x| format!("{x}"))
+            .map(u8::to_string)
             .collect::<Vec<_>>()
             .join(", "),
-    )
-    .unwrap();
+    ));
 
-    let status = Command::new("deno")
-        .current_dir(dir_path)
-        .arg("test")
-        .arg("--sloppy-imports")
-        .arg(&source_path)
-        .status()
-        .unwrap();
-    assert!(status.success());
+    project.run();
 }
 
 #[test]
@@ -161,30 +212,7 @@ fn test_typescript_runtime_i64_i128_low_limb_high_bit_roundtrip() {
     const LARGE_I128: i128 = (1 << 64) | 0xF8C4_E09E_F8C4_E09E_u64 as i128;
     const NEGATIVE_I128: i128 = i128::MIN + 5;
 
-    let registry = common::get_simple_registry();
-    let dir = tempdir().unwrap();
-    let dir_path = dir.path();
-    std::fs::create_dir_all(dir_path).unwrap();
-
-    let mut installer = typescript::Installer::new("main", dir_path);
-    installer.install_serde_runtime().unwrap();
-    installer.install_bincode_runtime().unwrap();
-
-    let source_path = dir_path.join("test.ts");
-    let mut source = File::create(&source_path).unwrap();
-
-    writeln!(
-        source,
-        r#"import {{ assertEquals }} from "https://deno.land/std@0.110.0/testing/asserts.ts";
-import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
-"#
-    )
-    .unwrap();
-
-    let config = CodeGeneratorConfig::new("main".to_string());
-    let generator = typescript::TypeScriptCodeGenerator::new(&config)
-        .with_plugins(vec![Arc::new(BincodePlugin)]);
-    generator.output(&mut source, &registry).unwrap();
+    let mut project = TsProject::new(&common::get_simple_registry());
 
     let reference = bincode::serialize(&Test {
         a: vec![1],
@@ -193,8 +221,7 @@ import {{ BincodeDeserializer, BincodeSerializer }} from "./bincode/index.ts";
     })
     .unwrap();
 
-    writeln!(
-        source,
+    project.write_test(&format!(
         r#"
 Deno.test("i64 with low-half bit 31 set round-trips", () => {{
   const expectedBytes = new Uint8Array([{bytes}]);
@@ -211,17 +238,15 @@ Deno.test("i64 with low-half bit 31 set round-trips", () => {{
 "#,
         bytes = reference
             .iter()
-            .map(|x| format!("{x}"))
+            .map(u8::to_string)
             .collect::<Vec<_>>()
             .join(", "),
         large = LARGE_I64,
-    )
-    .unwrap();
+    ));
 
     let i128_reference = bincode::serialize(&(LARGE_I128, NEGATIVE_I128)).unwrap();
 
-    writeln!(
-        source,
+    project.write_test(&format!(
         r#"
 Deno.test("i128 with low-limb bit 63 set round-trips", () => {{
   const expectedBytes = new Uint8Array([{bytes}]);
@@ -240,20 +265,85 @@ Deno.test("i128 with low-limb bit 63 set round-trips", () => {{
 "#,
         bytes = i128_reference
             .iter()
-            .map(|x| format!("{x}"))
+            .map(u8::to_string)
             .collect::<Vec<_>>()
             .join(", "),
         large = LARGE_I128,
         negative = NEGATIVE_I128,
-    )
-    .unwrap();
+    ));
 
-    let status = Command::new("deno")
-        .current_dir(dir_path)
-        .arg("test")
-        .arg("--sloppy-imports")
-        .arg(&source_path)
-        .status()
-        .unwrap();
-    assert!(status.success());
+    project.run();
+}
+
+/// Exercises the boundaries of every multi-limb integer the TypeScript runtime
+/// handles: zero, ±1, the type extremes, and values that straddle the 32- and
+/// 64-bit limb boundaries where sign extension used to corrupt the result.
+#[test]
+fn test_typescript_runtime_integer_edge_cases_roundtrip() {
+    let mut project = TsProject::new(&common::get_simple_registry());
+
+    let i64_cases = wire_cases![
+        0_i64,
+        1_i64,
+        -1_i64,
+        i64::MIN,
+        i64::MAX,
+        1_i64 << 31,
+        -(1_i64 << 31),
+        1_785_688_513_662_i64,
+        -1_785_688_513_662_i64,
+    ];
+    project.write_test(&scalar_roundtrip_test(
+        "i64 edge cases round-trip",
+        "I64",
+        &i64_cases,
+    ));
+
+    let u64_cases = wire_cases![
+        0_u64,
+        1_u64,
+        u64::MAX,
+        1_u64 << 31,
+        (1_u64 << 32) - 1,
+        1_u64 << 32,
+        0xFFFF_FFFF_8000_0000_u64,
+    ];
+    project.write_test(&scalar_roundtrip_test(
+        "u64 edge cases round-trip",
+        "U64",
+        &u64_cases,
+    ));
+
+    let i128_cases = wire_cases![
+        0_i128,
+        1_i128,
+        -1_i128,
+        i128::MIN,
+        i128::MAX,
+        i128::MIN + 5,
+        1_i128 << 63,
+        -(1_i128 << 64),
+    ];
+    project.write_test(&scalar_roundtrip_test(
+        "i128 edge cases round-trip",
+        "I128",
+        &i128_cases,
+    ));
+
+    let u128_cases = wire_cases![
+        0_u128,
+        1_u128,
+        u128::MAX,
+        1_u128 << 63,
+        1_u128 << 64,
+        u128::from(u64::MAX),
+        (1_u128 << 64) | 0xF8C4_E09E_F8C4_E09E_u128,
+    ];
+    project.write_test(&scalar_roundtrip_test(
+        "u128 edge cases round-trip",
+        "U128",
+        &u128_cases,
+    ));
+
+    project.run();
 }


### PR DESCRIPTION
## Summary

Follow-ups from the review of #110, plus the changelog entries #109 and #110 were missing.

## 1. Consistent 64-bit integer access in the `serde` runtime

#110 fixed `deserializeI64`/`deserializeI128`, where OR-ing two **signed** 32-bit limbs as BigInts sign-extended the low limb and dropped the high one. That left `U64`/`U128` still splitting values into 32-bit limbs — *correct*, because unsigned limbs cannot sign-extend, but it kept the idiom that caused the bug sitting right next to the fix.

Both directions now use the native accessors:

| | before | after |
|---|---|---|
| `deserializeU64` | two `getUint32` + shift/OR | `getBigUint64(0, true)` |
| `serializeU64` | mask/shift + two `setUint32` | `setBigUint64` |
| `serializeI64` | mask/shift + two `setInt32` | `setBigInt64` |

The 128-bit methods still combine two 64-bit limbs, which is unavoidable, but they lose the `BigInt(x.toString())` round-trips. `BIG_32` and `BIG_32Fs` had no remaining references and are gone.

**No behaviour change**, including for out-of-range input: `setBigUint64`/`setBigInt64` apply the same modulo-2^64 wrapping the old `setUint32`/`setInt32` truncation did.

## 2. Integer edge-case coverage

The #110 regression test only checked positive values. Added a test that round-trips `i64`, `u64`, `i128` and `u128` at zero, ±1, the type extremes, and the 32-/64-bit limb boundaries where sign extension used to corrupt the result. Expected bytes come from `bincode` on the Rust side, so the TypeScript runtime is checked against the wire format rather than against itself.

The coverage was mutation-tested rather than just observed green: swapping `getBigUint64` for `getBigInt64` fails the `u64` cases.

## 3. Shared test scaffolding

The three Deno runtime tests each repeated ~40 lines of tempdir / installer / import-preamble / generator setup. That now lives in a `TsProject` helper, so the new test adds cases rather than another copy of the boilerplate.

## 4. Changelog

- #109 landed with no entry at all — added one under `0.18.0`.
- The #110 entry was missing its PR link, and understated the blast radius: *every* `i64` at or above `2^31` decoded incorrectly, not just epoch-millis timestamps.

## Test plan

- [x] `cargo nextest run --all-features` — 828 passed, 1 skipped
- [x] `just check` (fmt + `clippy -Dclippy::pedantic -Dwarnings`)
- [x] `just docs`, `just build`
- [x] Snapshots regenerated with `UPDATE_EXPECT=1`; all 7 copies of each runtime file verified byte-identical
- [x] Mutation check: `getBigUint64` → `getBigInt64` fails the new `u64` cases

## Not included

`read()` still returns a short `ArrayBuffer.slice` past the end of the buffer, so truncated input surfaces as a `RangeError` from `DataView` rather than a clear deserialization error. It is pre-existing and affects every method, so it is going in a separate PR.
