### PR TITLE
ci: bump actions/cache and sccache-action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Install just
         uses: taiki-e/install-action@just
@@ -52,7 +52,7 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('src/generation/csharp/installer/mod.rs') }}


### PR DESCRIPTION
## Summary

Every build currently carries this annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`, `mozilla-actions/sccache-action@v0.0.9`.

Both are pinned to versions that predate the Node 24 migration, so the runner is silently overriding their declared runtime. This bumps them to versions that target Node 24 natively.

| action | before | after | Node 24 landed in |
|---|---|---|---|
| `actions/cache` | `v4` | `v6` | `v5.0.0` — v6.0.0 additionally migrates the action to ESM |
| `mozilla-actions/sccache-action` | `v0.0.9` | `v0.0.11` | `v0.0.10` ("Bump to `node24`") |

Version choices follow how the rest of the workflow already pins: a moving major tag where the action publishes one (`actions/checkout@v6`, `actions/setup-dotnet@v5`, `actions/setup-java@v5`, `denoland/setup-deno@v2`), and an exact tag for the 0.x action.

`actions/cache@v5` would equally clear the warning if you'd rather take the smaller step — v6 is the current major line and only differs from v5 by the ESM packaging change. Note also that v5+ requires Actions Runner ≥ 2.327.1, which matters only for self-hosted runners; this workflow uses GitHub-hosted `ubuntu-latest` / `windows-latest`.

## Test plan

- [x] CI on this PR is the test — it exercises both actions on Linux and Windows, and the annotation should be gone from the run summary

No changelog entry: this is workflow-only and invisible to consumers of the crate.

## Unrelated observation

`SwiftyLab/setup-swift@latest` is pinned to a floating `@latest` tag, which makes builds non-reproducible and is a supply-chain footgun. Left alone here since pinning it needs its own validation against the Swift runtime tests.
