### PR TITLE
chore(justfile): split tagging out of the publish recipes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -72,18 +72,42 @@ update-rust-deps:
     cargo upgrade --incompatible allow
     cargo update
 
+# Release flow:
+#
+#   1. bump the version in the crate's Cargo.toml, and date the CHANGELOG
+#      section (`## [x.y.z] - unreleased` -> `## [x.y.z] - <date>`)
+#   2. `just ci`, then commit the bump and push it to `main`
+#   3. create the GitHub release, which creates the tag for you:
+#        gh release create "facet-generate-v<version>" --target <commit> \
+#          --notes-file <the CHANGELOG section>
+#      or, when releasing without a GitHub release, `just tag`
+#   4. `just publish`
+#
+# Tagging is deliberately not part of `publish`: `gh release create` already
+# creates the tag, so doing it in `publish` too fails the whole recipe after
+# the irreversible upload has already happened. Keeping them separate means
+# `publish` behaves the same whichever order you release in.
+
+# publish the main crate to crates.io
+# Note: run `cargo login` first if you haven't already
+publish:
+    @echo '{{ style("command") }}publish v{{ version }}:{{ NORMAL }}'
+    cargo publish -p facet_generate
+
 # publish the attribute macro crate independently (only needed when it changes)
 # Note: run `cargo login` first if you haven't already
 publish-attrs:
     @echo '{{ style("command") }}publish facet-generate-attrs v{{ attrs-version }}:{{ NORMAL }}'
     cargo publish -p facet-generate-attrs
-    git tag -a "facet-generate-attrs-v{{ attrs-version }}" -m "Release facet-generate-attrs v{{ attrs-version }}"
-    git push origin "facet-generate-attrs-v{{ attrs-version }}"
 
-# publish the main crate to crates.io, then tag and push
-# Note: run `cargo login` first if you haven't already
-publish:
-    @echo '{{ style("command") }}publish v{{ version }}:{{ NORMAL }}'
-    cargo publish -p facet_generate
+# tag git HEAD and push the tag (unnecessary if a GitHub release made it; HEAD is `@-` under jj)
+tag:
+    @echo '{{ style("command") }}tag facet-generate-v{{ version }}:{{ NORMAL }}'
     git tag -a "facet-generate-v{{ version }}" -m "Release facet-generate v{{ version }}"
     git push origin "facet-generate-v{{ version }}"
+
+# as `tag`, for the independently versioned attribute macro crate
+tag-attrs:
+    @echo '{{ style("command") }}tag facet-generate-attrs-v{{ attrs-version }}:{{ NORMAL }}'
+    git tag -a "facet-generate-attrs-v{{ attrs-version }}" -m "Release facet-generate-attrs v{{ attrs-version }}"
+    git push origin "facet-generate-attrs-v{{ attrs-version }}"


### PR DESCRIPTION
## Summary

`publish` tagged the release immediately after the upload:

```just
publish:
    cargo publish -p facet_generate
    git tag -a "facet-generate-v{{ version }}" -m "..."
    git push origin "facet-generate-v{{ version }}"
```

Releasing through a GitHub release creates the tag as a side effect, so by the time `just publish` reached `git tag` the tag already existed and the recipe failed — *after* the irreversible `cargo publish` had succeeded. This came up for real while releasing 0.18.0: the tag was created by `gh release create`, so the publish had to be run as a bare `cargo publish -p facet_generate` instead.

There was no ordering that worked cleanly:

| order | outcome |
|---|---|
| GitHub release first, then `just publish` | fails at `git tag` (tag exists), after uploading |
| `just publish` first, then GitHub release | works, but the release must then reuse the existing tag |

## Change

Tagging is now a separate recipe per crate, so `publish` does one thing and behaves identically whichever order you release in:

- `publish` / `publish-attrs` — just `cargo publish`
- `tag` / `tag-attrs` — create and push the annotated tag

`tag-attrs` is new; `publish-attrs` previously had tagging inlined the same way. Worth noting no `facet-generate-attrs-v*` tag exists in the repo today, so that path had never actually produced one.

The release sequence is now written down above the recipes (bump → `just ci` → commit and push → GitHub release or `just tag` → `just publish`), along with why tagging is deliberately not part of `publish`.

The `tag` doc comment also records that `git tag` tags git `HEAD`, which in this colocated jj repo is `@-` rather than `@` — verified, and an easy way to tag the wrong commit otherwise.

## Test plan

- [x] `just --list` parses and shows all four recipes with useful descriptions
- [x] `just --dry-run publish` / `tag` / `tag-attrs` expand to the expected commands
- [x] Version interpolation resolves correctly: `facet-generate-v0.18.0` and `facet-generate-attrs-v0.17.0`

No behaviour change to any build, test, or lint recipe.

## Possible follow-up, not done here

`cargo publish --locked` would pin the release to the committed `Cargo.lock` rather than whatever resolves at publish time. Left out because it turns a stale lockfile into a release-time failure, which is a judgement call about how you'd rather find out.
