### PR TITLE
chore(deps)!: facet 0.46.5, releasing facet_generate 0.19.0 and facet-generate-attrs 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.19.0] - 2026-08-06
+
+A dependency-only release: `facet` moves from `=0.44` to `=0.46.5`. No generation
+behaviour changes — output is byte-for-byte identical to 0.18.0.
+
+`facet-generate-attrs` is released alongside as **0.18.0** for the same reason.
+
+### 💥 Breaking Changes
+
+- **Requires `facet` 0.46.5** (was 0.44). `facet` is a public dependency of both crates
+  — `facet_generate` takes `Shape`, `Field` and `Variant` in its API, and
+  `facet-generate-attrs` builds its attribute grammar with `facet::define_attr_grammar!`
+  — so a consumer pinning `facet =0.44` cannot use this version, and vice versa. Both
+  crates need to move together with whatever pins `facet` downstream.
+
+### ⚙️ Miscellaneous Tasks
+
+- No source changes were required for the upgrade. The facet 0.44 → 0.46 delta is
+  additive and confined to parts of facet this crate does not use: `facet-core` gained
+  list `pop`/`swap` operations, `char` and `()` now advertise `Clone` in their
+  `TypeOps`, `Result`'s hand-written drop glue moved, and `facet-reflect` grew its
+  `poke` module (map, set, option, result, tuple, pointer, ndarray, list_like,
+  dynamic_value). `facet-macros` and `facet-macro-parse` are byte-identical, so there
+  are no new derive attributes. The `Shape`/`Field`/`Variant` surface this crate reads
+  is unchanged, which is why no snapshots or expect-files moved.
+
 ## [0.18.0] - 2026-08-03
 
 TypeScript enums are now generated as **discriminated union types** instead of abstract class hierarchies. This is a breaking change for any code that was constructing or matching TypeScript enum values, but the new output is far more idiomatic and integrates naturally with TypeScript's type narrowing.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.44.5"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c78066af2cc259674a54fef24323f6081ae54a5f3a3fb53b995af7a867041c81"
+checksum = "df488bcda61dde160301ee6bce43d42397db599ffc689381a1873b5f035135f9"
 dependencies = [
  "autocfg",
  "facet-core",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04625a816bc27bb757b5f62ec17a228b90c08631f579ee0b36eccd6c426df207"
+checksum = "c33cf9d80307e9a29f93e5a65ddb65b227b5fa082d649c65d4083345f5d398d0"
 dependencies = [
  "autocfg",
  "bytes",
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-parse"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a288cd230608b4d7e89b307f85be2029f265e27dcdc565a2ae5358d0c4e53f57"
+checksum = "c5ab349bd1823fbfa129e595a826ef7fb4d1b9c7215428b28de18044d009dbc1"
 dependencies = [
  "facet-macro-types",
  "proc-macro2",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macro-types"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c805b7f1ad4bba14e1dba5c67ef810bf9eef2373364fe3916af1d08a5411296"
+checksum = "79622a74665b47d1744998dd0d15b73eb0eecdfeb16630b436c5f03365b02e55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -384,18 +384,18 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cc46a94a2725e82f2c0095bac16665057c24d7f4f11169a7a879dbcba81d8f"
+checksum = "a6656fc7457975f5e1c86791b7a810c40ba53993823ae655f7c331e808c4b5ff"
 dependencies = [
  "facet-macros-impl",
 ]
 
 [[package]]
 name = "facet-macros-impl"
-version = "0.44.4"
+version = "0.46.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af13fd5dfa728cc48418cf33cbcfc0d5cfdbaaf22a3d0f5229da4b1e5669fa5"
+checksum = "f462bad2b5a574b2c94e9ad54162704ceacf3200741b4f0fb88020936b9003ec"
 dependencies = [
  "facet-macro-parse",
  "facet-macro-types",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
 ]
@@ -640,15 +640,14 @@ dependencies = [
 
 [[package]]
 name = "iddqd"
-version = "0.3.18"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616230c7d641ef971a3a5bfcc654c6b7524ab9c9fb665693c6a397dba9a14aca"
+checksum = "8450e1521a7518a32addf0b805ffcfbc8f9c558d2ad5769f068f2aeef5a81126"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
  "hashbrown",
- "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "facet",
 ]
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ rust-version = "1.90"
 [workspace.dependencies]
 anyhow = "1.0.102"
 expect-test = "1.5.1"
-facet = "=0.44"
+facet = "=0.46.5"
 facet-generate-attrs = { path = "crates/facet-generate-attrs", version = "0.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ rust-version = "1.90"
 anyhow = "1.0.102"
 expect-test = "1.5.1"
 facet = "=0.46.5"
-facet-generate-attrs = { path = "crates/facet-generate-attrs", version = "0.17" }
+facet-generate-attrs = { path = "crates/facet-generate-attrs", version = "0.18" }

--- a/crates/facet-generate-attrs/Cargo.toml
+++ b/crates/facet-generate-attrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "facet-generate-attrs"
 description = "Extension attributes for facet-generate code generation"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/crates/facet_generate/Cargo.toml
+++ b/crates/facet_generate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "facet_generate"
 description = "Generate Swift, Kotlin, TypeScript, and C# from types annotated with `#[derive(Facet)]`"
-version = "0.18.0"
+version = "0.19.0"
 authors.workspace = true
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
Moves `facet` from `=0.44` to `=0.46.5`, and releases both crates for it. **No source
changes were needed, and generation output is byte-for-byte identical.**

Two commits: the dependency bump, then the version bump + changelog.

### What changed in facet between 0.44 and 0.46

Smaller than two minors suggests. Only **7 files** differ in `facet-core`, and
`facet-macros` / `facet-macro-parse` are **byte-identical** — so there are no new derive
attributes:

- **`facet-core`** — list `pop` and `swap` operations added (`ListPopFn`, `ListSwapFn`,
  new `ListDef::pop()`), with impls for `Vec`, `SmallVec` and `bytes::Bytes`; `char` and
  `()` now advertise `Clone` in their `TypeOps` (they're `Copy`, so the op is registered
  where it wasn't); `Result`'s hand-written `result_drop` removed in favour of drop glue
  handled elsewhere.
- **`facet-reflect`** — substantial growth in the `poke` module: nine new files covering
  `map`, `set`, `option`, `result`, `tuple`, `pointer`, `ndarray`, `list_like` and
  `dynamic_value`.

All of it is on the *construct and mutate* side of facet. This crate only ever reads
static descriptions — `Shape`, `Field`, `Variant`, `Facet` — and that surface is
unchanged. Hence no code changes and no snapshot or expect-file churn.

### Why both crates get a minor bump

`facet` is a **public dependency** of both:

- `facet_generate` takes `Shape`, `Field` and `Variant` in its API.
- `facet-generate-attrs` builds its attribute grammar with `facet::define_attr_grammar!`.

So a consumer pinning `facet =0.44` cannot use these versions, and vice versa — the
crates have to move in step with whatever pins `facet` downstream. `facet_generate`'s
requirement on `facet-generate-attrs` also goes to `^0.18`.

| Crate | From | To |
| --- | --- | --- |
| `facet_generate` | 0.18.0 | **0.19.0** |
| `facet-generate-attrs` | 0.17.0 | **0.18.0** |

### Verification

- `just ci` green: **829 Rust tests passed** (1 skipped) plus the Swift suites, with no
  expect-file or snapshot changes.
- Verified downstream in **crux** against these crates as path dependencies: its root
  `just ci` passes, and generated Swift, Kotlin, C# and TypeScript for the counter
  example — **75 files** — are byte-for-byte identical to the facet 0.44 output.

### Downstream note

crux pins `facet` in **8 places** (its workspace, all six example `shared` crates, and
the book), and bumping only some of them produces
`RenderOperation: Facet<'_> is not satisfied` with two `facet_core` versions in the
graph. They all have to move together with this release.
