### PR TITLE
ci: allow the build to be triggered manually

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
   pull_request:
+  # Lets a build be re-run by hand from the Actions tab or `gh workflow run ci
+  # --ref main`. Without this there is no supported way to ask for a fresh run
+  # on main: `push` only fires on a new commit, so a run that never starts
+  # leaves main with no build and nothing to retry. That happened after #117 —
+  # the run sat queued for 12 hours having acquired no jobs, and GitHub refused
+  # both `rerun` ("already running") and `cancel` ("has not yet queued"), so it
+  # could only be waited out.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Adds `workflow_dispatch` to the `ci` workflow, so a build can be re-run by hand from the
Actions tab or with `gh workflow run ci --ref main`.

### Why

The workflow only triggered on `push` to main and `pull_request`. `push` fires only on a
new commit, so there was no supported way to ask for a fresh run on main — and a run
that never starts leaves main with no build and nothing to retry.

That is exactly what happened to the #117 merge. Its run sat **queued for over 12 hours
having acquired no jobs**, and GitHub refused every route out:

| Attempt | Response |
| --- | --- |
| `rerun` | 403 — "This workflow is already running" |
| `cancel` | 409 — "Cannot cancel a workflow re-run that has not yet queued" |
| `force-cancel` | 409 — same |

The API reported `status: queued`, `conclusion: null`, `run_attempt: 1` with `updated_at`
frozen — simultaneously believing the run was in progress and that it had never started.
With no `workflow_dispatch` trigger the only remedies were to wait for GitHub's 24-hour
queue timeout, or push another commit to main purely to displace it.

### What this does and does not change

- Does **not** change what runs on `push` or on a `pull_request`.
- The `concurrency` group already keys on `github.event.pull_request.number || github.ref`,
  so a manual run on main shares a group with push runs for main, exactly as before.
- No inputs are defined — this is a plain "run it again" button.

Verified that the workflow YAML still parses with all three triggers
(`push`, `pull_request`, `workflow_dispatch`) and the `build` job intact.

### Note

This does not rescue the stuck #117 run, which can only be waited out. It means we are
never in that position again. Nothing was actually unvalidated by that run failing to
start: the pre-merge run on `deps/facet-0-46-5` passed in 19m50s against identical
content, and `facet_generate` 0.19.0 / `facet-generate-attrs` 0.18.0 are published and
verified on crates.io.
